### PR TITLE
feat(review-queue): backlog 상한과 TTL 제어

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ http://localhost:9001/graph
 | `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | 기억 리뷰 후보 최소 importance (0~1) |
 | `MEMORY_REVIEW_STALE_DAYS` | `14` | 기억 리뷰 후보 최소 stale 일수 (정수 ≥ 1) |
 | `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | 기억 리뷰 후보 최대 개수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_MAX_BACKLOG` | `500` | pending 후보가 이 수 이상이면 신규 선정을 건너뜀 (`0`: 비활성화) |
+| `MEMORY_REVIEW_CANDIDATE_TTL_DAYS` | `30` | 이 일수보다 오래된 pending 후보를 배치 실행 전에 만료 (`0`: 비활성화) |
 | `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` | 배치 스케줄 간격(ms), 최소 `60000` |
 | `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | 배치가 `due_at`에 더하는 일 수 (1~366) |
 

--- a/docs/api/en/api-reference.md
+++ b/docs/api/en/api-reference.md
@@ -904,6 +904,8 @@ Content-Type: application/json
 | `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | Minimum importance for candidacy (0–1; invalid values fall back to default) |
 | `MEMORY_REVIEW_STALE_DAYS` | `14` | Minimum stale age in days (integer ≥ 1) |
 | `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | Max candidates from selection / upsert path (integer ≥ 1) |
+| `MEMORY_REVIEW_MAX_BACKLOG` | `500` | Skip new selection when pending candidates reach this count (`0`: disabled) |
+| `MEMORY_REVIEW_CANDIDATE_TTL_DAYS` | `30` | Expire pending candidates older than this many days before each batch (`0`: disabled) |
 | `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` (24h) | Scheduler interval for `memory_review_candidates` in ms (minimum `60000`) |
 | `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | Days added to “now” when the batch computes each row’s `due_at` (1–366) |
 

--- a/docs/api/ko/api-reference.md
+++ b/docs/api/ko/api-reference.md
@@ -1024,10 +1024,12 @@ Content-Type: application/json
 | `MEMORY_REVIEW_IMPORTANCE_THRESHOLD` | `0.7` | 후보로 고려할 최소 importance (0~1; 잘못된 값은 기본값으로 대체) |
 | `MEMORY_REVIEW_STALE_DAYS` | `14` | 최소 stale 일수 (정수 ≥ 1) |
 | `MEMORY_REVIEW_MAX_CANDIDATES` | `50` | 선정 단계에서 반환·큐에 반영할 최대 후보 수 (정수 ≥ 1) |
+| `MEMORY_REVIEW_MAX_BACKLOG` | `500` | pending 후보가 이 수 이상이면 신규 선정을 건너뜀 (`0`: 비활성화) |
+| `MEMORY_REVIEW_CANDIDATE_TTL_DAYS` | `30` | 이 일수보다 오래된 pending 후보를 배치 실행 전에 만료 (`0`: 비활성화) |
 | `MEMORY_REVIEW_CANDIDATES_INTERVAL_MS` | `86400000` (24h) | 배치 `memory_review_candidates` 스케줄 간격(ms). 최소 `60000` |
 | `MEMORY_REVIEW_CANDIDATE_DUE_DAYS` | `14` | 배치가 `due_at`을 계산할 때 기준 시각에 더하는 일 수 (1~366) |
 
-운영 시 **후보 선정 민감도**는 위 표의 앞 세 변수로, **스케줄 간격·마감 시각**은 마지막 두 변수로 조정합니다.
+운영 시 **후보 선정 민감도**는 앞 세 변수로, **큐 누적 제어**는 backlog·TTL 변수로, **스케줄 간격·마감 시각**은 마지막 두 변수로 조정합니다.
 
 대시보드 **Review Queue** 탭의 백그라운드 폴링은 HTTP 서버가 `GET /dashboard` HTML에 `window.__MEMENTO_REVIEW_QUEUE__`를 인라인으로 주입해 적용합니다(GitHub #274).
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-06-14)
 
 ## Corpus Check
-- 1134 files · ~1,501,080 words
+- 1135 files · ~1,502,248 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5659 nodes · 6976 edges · 1126 communities detected
+- 5665 nodes · 6982 edges · 1127 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1136,6 +1136,7 @@
 - [[_COMMUNITY_Community 1123|Community 1123]]
 - [[_COMMUNITY_Community 1124|Community 1124]]
 - [[_COMMUNITY_Community 1125|Community 1125]]
+- [[_COMMUNITY_Community 1126|Community 1126]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -1789,151 +1790,151 @@ Nodes (1): RememberTool
 
 ### Community 156 - "Community 156"
 Cohesion: 0.22
-Nodes (1): ConsolidationRepository
+Nodes (2): getMemoryReviewCandidateById(), mapRow()
 
 ### Community 157 - "Community 157"
+Cohesion: 0.22
+Nodes (1): ConsolidationRepository
+
+### Community 158 - "Community 158"
 Cohesion: 0.29
 Nodes (1): PredicateCanonicalizer
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.24
 Nodes (2): scopeSearchFilters(), SqliteHybridAgentContextSource
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (2): escapeHtml(), QualityReporter
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.31
 Nodes (6): countMagicNumbers(), findMagicNumbers(), getAllTsFiles(), isCoreModule(), isExcluded(), main()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.36
 Nodes (9): checkSqlInjection(), findFiles(), findSqlInjectionPatterns(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.36
 Nodes (9): countAnyTypes(), findAnyTypes(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.36
 Nodes (8): cursorKey(), findLastNewlineBefore(), readDockerLogs(), readIncrementalJsonlLines(), readJsonlFiles(), readStreamLines(), resolveDockerLogsRef(), runDocker()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.22
 Nodes (1): MementoAssistant
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.39
 Nodes (8): findSubcommandWithIndex(), main(), parseCli(), parseGlobalFlags(), stripGlobalArgvForAgentDetection(), subcommandArgvFrom(), writeStderr(), writeStdout()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.28
 Nodes (4): registerHandlers(), runHeavyInit(), Semaphore, startServer()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.44
 Nodes (8): applySizePolicy(), buildBatch(), cloneEvent(), reducibleText(), removeOptionalFields(), truncateToFit(), utf8Size(), validateBatch()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.47
 Nodes (6): hasOnlyKeys(), isRecord(), validateAgentEvent(), validatePayload(), validIdentifier(), validJsonValue()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.44
 Nodes (7): defaultGit(), detectClaudeCodeScope(), detectCodexScope(), explicit(), normalizeRemote(), processFromBranch(), value()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.36
 Nodes (1): TripleExtractionLogger
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.31
 Nodes (1): MigrationRunner
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (1): BackupManager
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.33
 Nodes (1): AnchorTableMigration
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.36
 Nodes (1): FactMetadataFieldsMigration
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (1): MemoryItemIsConsolidatedMigration
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.39
 Nodes (1): TripleExtractionFieldsMigration
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.42
 Nodes (1): FeedbackEventAttributionMigration
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (1): ProceduralVersionIndexesMigration
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.36
 Nodes (1): MemoryItemAttributionMigration
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.36
 Nodes (1): KgTripleTableMigration
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.39
 Nodes (1): SoftDeleteFieldsMigration
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.36
 Nodes (1): MemoryItemOwnerIdMigration
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.25
 Nodes (1): RetryManager
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.36
 Nodes (1): FileLogger
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.28
 Nodes (3): convertMemoryRowToItem(), isMemoryType(), isPrivacyScope()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.31
 Nodes (1): LoggingRateLimiter
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.31
 Nodes (4): buildLogMessage(), formatTime(), logToStderr(), safeStringify()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.36
 Nodes (7): canonicalizeHttpBindHostForListen(), formatHttpBindHostForUrl(), getMementoHttpSecurityStartupViolationMessage(), isHttpBindHostRemotelyReachable(), isIpv4Loopback127Block(), isIpv4MappedLoopback(), MementoHttpSecurityStartupError
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.22
 Nodes (2): DefaultSearchLogger, HybridSearchFactory
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.36
 Nodes (1): LlmProceduralExtractor
-
-### Community 192 - "Community 192"
-Cohesion: 0.25
-Nodes (2): getMemoryReviewCandidateById(), mapRow()
 
 ### Community 193 - "Community 193"
 Cohesion: 0.44
@@ -2417,111 +2418,111 @@ Nodes (1): VectorPerformanceRepositoryImpl
 
 ### Community 313 - "Community 313"
 Cohesion: 0.53
-Nodes (1): SummarizationService
+Nodes (5): parseImportanceThreshold(), parseMemoryReviewQueueControlEnv(), parseMemoryReviewSelectionEnv(), parseNonNegativeInt(), parsePositiveInt()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.47
-Nodes (3): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner()
+Cohesion: 0.53
+Nodes (1): SummarizationService
 
 ### Community 315 - "Community 315"
 Cohesion: 0.47
-Nodes (3): chunkSucceeded(), failureMessageFromResult(), TriplePipelineOrchestrator
+Nodes (3): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner()
 
 ### Community 316 - "Community 316"
+Cohesion: 0.47
+Nodes (3): chunkSucceeded(), failureMessageFromResult(), TriplePipelineOrchestrator
+
+### Community 317 - "Community 317"
 Cohesion: 0.6
 Nodes (5): executePerformanceAlerts(), handleList(), handleResolve(), handleSearch(), handleStats()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.47
 Nodes (1): RuntimeDiagnosticsLogger
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.47
 Nodes (1): MigrateEmbeddingsTool
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.6
 Nodes (5): compositeScore(), generateCandidate(), main(), mulberry32(), parseTuneArgs()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.6
 Nodes (5): findThrows(), isTestFile(), main(), scanDirectory(), shouldExcludeDir()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.4
 Nodes (2): emptyState(), loadState()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.6
 Nodes (5): recordJsonlSkip(), recordMonitorError(), runMonitorCycle(), syncFingerprint(), withFingerprint()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.8
 Nodes (5): buildRequestOptions(), getDashboardAuth(), mementoAdminFetch(), performFetch(), waitForSession()
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.53
 Nodes (4): loadSessions(), loadTimeline(), selectSession(), value()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.6
 Nodes (5): invalidateDryRun(), readTranscriptFile(), renderImportResult(), submitTranscript(), transcriptValue()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.6
 Nodes (3): broadcastReviewCandidatesChanged(), buildReviewCandidatesChangedEnvelope(), parseReviewCandidatesChangedRelayUrls()
-
-### Community 327 - "Community 327"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 328 - "Community 328"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 329 - "Community 329"
-Cohesion: 0.6
-Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.6
-Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+Nodes (3): attachReviewCandidatesSse(), notifyReviewCandidatesChanged(), writeSafe()
 
 ### Community 331 - "Community 331"
+Cohesion: 0.6
+Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
+
+### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 332 - "Community 332"
-Cohesion: 0.4
-Nodes (1): SseServer
-
 ### Community 333 - "Community 333"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): SseServer
 
 ### Community 334 - "Community 334"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 335 - "Community 335"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 336 - "Community 336"
 Cohesion: 0.6
 Nodes (3): createClaudeCodeHttpTransport(), readStream(), runClaudeCodeHookCommand()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (2): seedTwoProjectMemories(), stopBatchSchedulerSingleton()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.6
 Nodes (3): createCodexHttpTransport(), readStream(), runCodexHookCommand()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.6
 Nodes (3): parseOptions(), readSettings(), runClaudeCodeConnect()
-
-### Community 339 - "Community 339"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.4
@@ -2548,28 +2549,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 346 - "Community 346"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 347 - "Community 347"
 Cohesion: 0.5
 Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (2): normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (2): getStopWords(), isStopWord()
 
 ### Community 351 - "Community 351"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getStopWords(), isStopWord()
 
 ### Community 352 - "Community 352"
 Cohesion: 0.4
@@ -2580,132 +2581,132 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 356 - "Community 356"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 357 - "Community 357"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (1): EvolutionDemoNotFoundError
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.7
 Nodes (4): makeConsolidationQuality(), makeContext(), makeMemoryQuality(), makeSearchQuality()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 366 - "Community 366"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 367 - "Community 367"
 Cohesion: 0.4
-Nodes (1): RecallTool
+Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (1): RecallTool
 
 ### Community 369 - "Community 369"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 370 - "Community 370"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): IntrospectionScanCache
 
 ### Community 371 - "Community 371"
 Cohesion: 0.4
-Nodes (1): TokenBucketRateLimiter
+Nodes (1): FailingRepo
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): TokenBucketRateLimiter
 
 ### Community 373 - "Community 373"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 374 - "Community 374"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.6
 Nodes (4): buildComparisonHintMarkup(), renderPointSegment(), syncSegmentSelection(), updateComparisonHint()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.7
 Nodes (4): renderConsolidationPanel(), renderEpisodicSources(), renderSearchComparison(), renderSemanticResult()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.7
 Nodes (4): activateTab(), dispatchGraphIframeResize(), getTabButtons(), setRovingTabindex()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
@@ -2721,35 +2722,35 @@ Nodes (0):
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.83
-Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
+Cohesion: 0.5
+Nodes (1): BraveSearchProvider
 
 ### Community 391 - "Community 391"
 Cohesion: 0.83
-Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
 
 ### Community 392 - "Community 392"
+Cohesion: 0.83
+Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (2): fixture(), fixtureUrl()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (1): DatabaseOptimizeTool
-
 ### Community 396 - "Community 396"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): DatabaseOptimizeTool
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
@@ -2772,144 +2773,144 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
-Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
-Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
+Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
 
 ### Community 404 - "Community 404"
-Cohesion: 0.5
-Nodes (1): QualityMeasurementBatchJob
+Cohesion: 0.67
+Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.5
-Nodes (1): SleepConsolidationBatchJob
+Nodes (1): QualityMeasurementBatchJob
 
 ### Community 406 - "Community 406"
 Cohesion: 0.5
-Nodes (1): TelemetryCleanupBatchJob
+Nodes (1): SleepConsolidationBatchJob
 
 ### Community 407 - "Community 407"
+Cohesion: 0.5
+Nodes (1): TelemetryCleanupBatchJob
+
+### Community 408 - "Community 408"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 409 - "Community 409"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 410 - "Community 410"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 412 - "Community 412"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 413 - "Community 413"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 414 - "Community 414"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 415 - "Community 415"
+Cohesion: 0.5
+Nodes (1): RestoreAnchorsTool
+
+### Community 416 - "Community 416"
 Cohesion: 0.83
 Nodes (3): buildSnapshotsFromFixture(), getFixtureSnapshot(), key()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.5
 Nodes (1): SearchResultCombiner
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.67
 Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.67
 Nodes (2): computeProcessAttributeFit(), toSet()
 
-### Community 419 - "Community 419"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 420 - "Community 420"
 Cohesion: 0.5
-Nodes (1): ForgettingStatsTool
+Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.5
-Nodes (1): GetTelemetrySummaryTool
+Nodes (1): ForgettingStatsTool
 
 ### Community 422 - "Community 422"
+Cohesion: 0.5
+Nodes (1): GetTelemetrySummaryTool
+
+### Community 423 - "Community 423"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (1): PersonalAgentLlmError
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.5
 Nodes (1): OpenAiChatLlmAdapter
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.5
 Nodes (1): OllamaChatLlmAdapter
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.5
 Nodes (1): GeminiChatLlmAdapter
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (1): MemoryInjectionPrompt
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.5
 Nodes (1): GetMemoryNeighborsTool
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (1): ProceduralRollbackTool
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.5
 Nodes (1): CleanupMemoryTool
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (1): ProceduralDiffTool
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (1): GetIntrospectionSummaryTool
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (1): RememberProcedureTool
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 435 - "Community 435"
-Cohesion: 0.83
-Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
-
 ### Community 436 - "Community 436"
 Cohesion: 0.83
-Nodes (3): parseImportanceThreshold(), parseMemoryReviewSelectionEnv(), parsePositiveInt()
+Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.5
@@ -3181,7 +3182,7 @@ Nodes (0):
 
 ### Community 504 - "Community 504"
 Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readInsertedUpdated()
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
@@ -3200,16 +3201,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 509 - "Community 509"
-Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 510 - "Community 510"
 Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 511 - "Community 511"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
@@ -3220,28 +3221,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 514 - "Community 514"
-Cohesion: 1.0
-Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
-
-### Community 515 - "Community 515"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 515 - "Community 515"
+Cohesion: 1.0
+Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 517 - "Community 517"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 518 - "Community 518"
 Cohesion: 1.0
 Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
-### Community 518 - "Community 518"
-Cohesion: 0.67
-Nodes (1): FeedbackRepository
-
 ### Community 519 - "Community 519"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FeedbackRepository
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
@@ -3252,12 +3253,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 1.0
-Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
-
-### Community 523 - "Community 523"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 523 - "Community 523"
+Cohesion: 1.0
+Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
@@ -3265,19 +3266,19 @@ Nodes (0):
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 527 - "Community 527"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 528 - "Community 528"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
@@ -3304,24 +3305,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 537 - "Community 537"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
-Nodes (1): AgentIntegrationError
+Nodes (0):
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AgentIntegrationError
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
@@ -3332,16 +3333,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 544 - "Community 544"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
@@ -3352,36 +3353,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 547 - "Community 547"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
-
-### Community 548 - "Community 548"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 549 - "Community 549"
+### Community 548 - "Community 548"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
+
+### Community 549 - "Community 549"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 551 - "Community 551"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 552 - "Community 552"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 553 - "Community 553"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 554 - "Community 554"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 555 - "Community 555"
 Cohesion: 1.0
@@ -5667,1152 +5668,1156 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1126 - "Community 1126"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `TimeoutError`, `FeedbackRepository`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 554`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 555`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 556`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 557`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 558`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 559`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 560`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 561`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 562`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 563`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `readReviewCandidatesPanelSources()`, `dashboard-review-candidates-panel.spec.ts`
+- **Thin community `Community 564`** (2 nodes): `readReviewCandidatesPanelSources()`, `dashboard-review-candidates-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 565`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 566`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 567`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 568`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 569`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 570`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 571`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 572`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 573`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 574`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 575`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
+- **Thin community `Community 576`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 577`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 578`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 579`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 580`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
+- **Thin community `Community 581`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 582`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 583`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 584`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 585`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 586`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
+- **Thin community `Community 587`** (2 nodes): `registerAdminRelationRoutes()`, `admin-relations.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 588`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 589`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 590`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 591`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
+- **Thin community `Community 592`** (2 nodes): `runCli()`, `cli-ac5-ac6.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
+- **Thin community `Community 593`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `event()`, `codex-hook.spec.ts`
+- **Thin community `Community 594`** (2 nodes): `event()`, `codex-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 595`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 596`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 597`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 598`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 599`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 600`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 601`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 602`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 603`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 604`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 605`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 606`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 607`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
+- **Thin community `Community 608`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
+- **Thin community `Community 609`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
+- **Thin community `Community 610`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `runner.ts`, `runCodexHook()`
+- **Thin community `Community 611`** (2 nodes): `runner.ts`, `runCodexHook()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 612`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 613`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 614`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 615`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 616`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 617`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 618`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 619`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 620`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 621`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 622`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 623`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 624`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 625`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 626`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 627`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 628`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 629`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 630`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 631`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 632`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 633`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 634`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 635`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 636`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 637`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 638`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 639`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 640`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 641`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 642`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
+- **Thin community `Community 643`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 644`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 645`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 646`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 647`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
+- **Thin community `Community 648`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 649`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 650`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 651`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 652`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 653`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 654`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 655`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 656`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 657`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 658`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 659`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 660`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 661`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 662`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 663`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 664`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 665`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 666`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 667`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 668`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 669`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 670`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 671`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 672`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 673`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 674`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 675`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 676`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 677`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 678`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 679`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 680`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
+- **Thin community `Community 681`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
+- **Thin community `Community 682`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 683`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 684`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 685`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 686`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 687`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 688`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 689`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 690`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 691`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 692`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 693`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 694`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 695`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 696`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 697`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 698`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 699`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 700`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 701`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 702`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 703`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 704`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 705`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 706`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 707`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 708`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 709`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 710`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 711`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
+- **Thin community `Community 712`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
+- **Thin community `Community 713`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 714`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 715`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 716`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 717`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 718`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 719`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 720`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 721`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 722`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 723`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 724`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 725`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 726`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 727`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 728`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 729`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 730`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 731`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 732`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 733`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 734`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 735`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 736`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 737`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 738`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 739`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 740`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 741`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 742`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 743`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 744`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 745`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 746`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 747`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 748`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 749`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 750`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 751`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 752`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 753`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 754`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 755`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 756`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 757`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 758`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 759`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 760`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 761`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 762`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 763`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 764`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 765`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 766`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 767`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 768`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 769`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 770`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 771`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 772`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 773`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `types.ts`
+- **Thin community `Community 774`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 775`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (1 nodes): `index.ts`
+- **Thin community `Community 776`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 777`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 779`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `transport.ts`
+- **Thin community `Community 783`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `index.ts`
+- **Thin community `Community 784`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 785`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 786`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 787`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 790`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 792`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 797`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 800`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 809`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 810`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 811`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 812`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `context.ts`
+- **Thin community `Community 813`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 814`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `mcp-tool-call-error.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 816`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `index.ts`
+- **Thin community `Community 819`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 822`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `types.ts`
+- **Thin community `Community 824`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 825`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 827`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 828`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 829`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 830`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 831`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 832`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 834`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 835`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 837`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `types.ts`
+- **Thin community `Community 838`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `index.ts`
+- **Thin community `Community 840`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 841`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `types.ts`
+- **Thin community `Community 843`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 846`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `types.ts`
+- **Thin community `Community 847`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 849`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `index.ts`
+- **Thin community `Community 850`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 852`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 853`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `types.ts`
+- **Thin community `Community 861`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 864`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 871`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 872`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 874`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 875`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 883`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 886`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `pii-masker-api-key.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 902`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 903`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 904`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 905`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 906`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 907`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 908`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 909`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 910`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 911`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 912`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `error-types.ts`
+- **Thin community `Community 913`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 914`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 915`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `search.types.ts`
+- **Thin community `Community 916`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 917`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 918`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `constants.ts`
+- **Thin community `Community 919`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 920`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 921`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 922`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 923`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 928`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 929`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 931`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 932`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 933`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 934`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 935`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 936`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 937`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 938`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 939`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 940`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 941`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 942`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 943`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 956`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 957`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `index.ts`
+- **Thin community `Community 959`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 960`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `database-types.ts`
+- **Thin community `Community 961`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 962`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 964`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `types.ts`
+- **Thin community `Community 965`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `index.ts`
+- **Thin community `Community 966`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `spec.ts`
+- **Thin community `Community 967`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 968`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 969`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 970`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 971`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 972`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `vector-search.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 983`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 984`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 985`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 986`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `index.ts`
+- **Thin community `Community 987`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 988`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 989`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `index.ts`
+- **Thin community `Community 990`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 991`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 992`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 993`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 994`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 995`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `context-port.ts`
+- **Thin community `Community 996`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 997`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 998`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 999`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1000`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1001`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1002`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 1003`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 1004`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 1005`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 1006`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 1007`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 1008`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 1009`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 1010`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 1011`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 1012`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 1013`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 1014`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 1015`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 1016`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 1017`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 1018`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 1019`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 1020`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 1021`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1027`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1028`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1029`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1031`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1032`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1033`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1035`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1036`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1037`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1038`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `index.ts`
+- **Thin community `Community 1039`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1041`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1042`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1043`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1044`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1045`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1046`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1047`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1048`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1049`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1050`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1051`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1052`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1053`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1054`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1055`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1056`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1057`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1058`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 1059`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `triple-parser.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `types.ts`
+- **Thin community `Community 1060`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1061`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1062`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1063`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1064`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1065`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1066`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1067`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1068`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 1069`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1070`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1071`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1072`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1073`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1074`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1075`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1076`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1077`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1078`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1079`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `types.ts`
+- **Thin community `Community 1080`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1081`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1082`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1083`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1084`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1085`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1086`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1087`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1088`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1089`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1090`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1091`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1092`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `agent-sessions.e2e.ts`
+- **Thin community `Community 1093`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1094`** (1 nodes): `agent-sessions.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1095`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1096`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1097`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1098`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `longmemeval-validation.spec.ts`
+- **Thin community `Community 1099`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `acquire-longmemeval.spec.ts`
+- **Thin community `Community 1100`** (1 nodes): `longmemeval-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1101`** (1 nodes): `acquire-longmemeval.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1102`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1103`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1104`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1105`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1106`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1107`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1108`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1109`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1110`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `types.ts`
+- **Thin community `Community 1111`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1112`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1113`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1114`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1115`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1116`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1117`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1118`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1119`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1120`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1121`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1122`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1123`** (1 nodes): `entrypoint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1124`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1125`** (1 nodes): `memory-evolution-demo-shell-render.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1126`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "playwright.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "vitest.config.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "assistant.spec.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "types.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "types.spec.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "assistant.ts",
@@ -57,7 +57,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_ts",
-      "community": 164
+      "community": 165
     },
     {
       "label": "MementoAssistant",
@@ -65,7 +65,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L21",
       "id": "assistant_mementoassistant",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".constructor()",
@@ -73,7 +73,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L34",
       "id": "assistant_mementoassistant_constructor",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".fromEnv()",
@@ -81,7 +81,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L46",
       "id": "assistant_mementoassistant_fromenv",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".beforeUserTurn()",
@@ -89,7 +89,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L61",
       "id": "assistant_mementoassistant_beforeuserturn",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".afterAssistantTurn()",
@@ -97,7 +97,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L67",
       "id": "assistant_mementoassistant_afterassistantturn",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".recall()",
@@ -105,7 +105,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L75",
       "id": "assistant_mementoassistant_recall",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".remember()",
@@ -113,7 +113,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L78",
       "id": "assistant_mementoassistant_remember",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".close()",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L81",
       "id": "assistant_mementoassistant_close",
-      "community": 164
+      "community": 165
     },
     {
       "label": "index.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "after-assistant-turn.ts",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 554
+      "community": 555
     },
     {
       "label": "before-user-turn.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 555
+      "community": 556
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "auto-remember-policy.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 556
+      "community": 557
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "channel-scope.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "http-transport.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "mock-transport.spec.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "transport.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "index.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "http-transport.spec.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "factory.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "createTransportFromEnv()",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 557
+      "community": 558
     },
     {
       "label": "stdio-transport.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "mock-transport.ts",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 382
+      "community": 383
     },
     {
       "label": "createRateLimitedLogger()",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 382
+      "community": 383
     },
     {
       "label": "levelFromEnv()",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 382
+      "community": 383
     },
     {
       "label": "consoleSink()",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 382
+      "community": 383
     },
     {
       "label": "logger.spec.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "retry-queue.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "retry-queue.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "http.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "start-http-server.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 383
+      "community": 384
     },
     {
       "label": "startTestHttpServer()",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 383
+      "community": 384
     },
     {
       "label": "findFreePort()",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 383
+      "community": 384
     },
     {
       "label": "waitForHealth()",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 383
+      "community": 384
     },
     {
       "label": "http-server-runner.js",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 796
+      "community": 797
     },
     {
       "label": "test-integration.js",
@@ -913,7 +913,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 558
+      "community": 559
     },
     {
       "label": "testBasicFunctionality()",
@@ -921,7 +921,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 558
+      "community": 559
     },
     {
       "label": "performance-optimizer.js",
@@ -1097,7 +1097,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "basicUsageExample()",
@@ -1105,7 +1105,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 559
+      "community": 560
     },
     {
       "label": "performance-examples.ts",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "advancedUsageExample()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 560
+      "community": 561
     },
     {
       "label": "migration-guide.ts",
@@ -1505,7 +1505,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "makeNullRunner()",
@@ -1513,7 +1513,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 561
+      "community": 562
     },
     {
       "label": "telemetry-cli.ts",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_ts",
-      "community": 165
+      "community": 166
     },
     {
       "label": "writeStdout()",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L7",
       "id": "cli_writestdout",
-      "community": 165
+      "community": 166
     },
     {
       "label": "writeStderr()",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L19",
       "id": "cli_writestderr",
-      "community": 165
+      "community": 166
     },
     {
       "label": "stripGlobalArgvForAgentDetection()",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L45",
       "id": "cli_stripglobalargvforagentdetection",
-      "community": 165
+      "community": 166
     },
     {
       "label": "parseGlobalFlags()",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L59",
       "id": "cli_parseglobalflags",
-      "community": 165
+      "community": 166
     },
     {
       "label": "findSubcommandWithIndex()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L75",
       "id": "cli_findsubcommandwithindex",
-      "community": 165
+      "community": 166
     },
     {
       "label": "subcommandArgvFrom()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L91",
       "id": "cli_subcommandargvfrom",
-      "community": 165
+      "community": 166
     },
     {
       "label": "parseCli()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L106",
       "id": "cli_parsecli",
-      "community": 165
+      "community": 166
     },
     {
       "label": "main()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L150",
       "id": "cli_main",
-      "community": 165
+      "community": 166
     },
     {
       "label": "check-migration-status.ts",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1921,7 +1921,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "readShellSources()",
@@ -1929,7 +1929,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L22",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 562
+      "community": 563
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 384
+      "community": 385
     },
     {
       "label": "getRepoRoot()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 384
+      "community": 385
     },
     {
       "label": "collectEnvKeys()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 384
+      "community": 385
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 384
+      "community": 385
     },
     {
       "label": "server-info.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "readReviewCandidatesPanelSources()",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L20",
       "id": "dashboard_review_candidates_panel_spec_readreviewcandidatespanelsources",
-      "community": 563
+      "community": 564
     },
     {
       "label": "index-factory.spec.ts",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "context.spec.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "server-factory.ts",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "createServerFactory()",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 564
+      "community": 565
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_ts",
-      "community": 326
+      "community": 327
     },
     {
       "label": "parseReviewCandidatesChangedRelayUrls()",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L38",
       "id": "review_candidates_changed_fanout_parsereviewcandidateschangedrelayurls",
-      "community": 326
+      "community": 327
     },
     {
       "label": "buildReviewCandidatesChangedEnvelope()",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L49",
       "id": "review_candidates_changed_fanout_buildreviewcandidateschangedenvelope",
-      "community": 326
+      "community": 327
     },
     {
       "label": "relayPost()",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L72",
       "id": "review_candidates_changed_fanout_relaypost",
-      "community": 326
+      "community": 327
     },
     {
       "label": "broadcastReviewCandidatesChanged()",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.ts",
       "source_location": "L110",
       "id": "review_candidates_changed_fanout_broadcastreviewcandidateschanged",
-      "community": 326
+      "community": 327
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "startStdioServer()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 565
+      "community": 566
     },
     {
       "label": "server-factory.spec.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "server-state.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_integration_spec_ts",
-      "community": 327
+      "community": 328
     },
     {
       "label": "postJson()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L11",
       "id": "auth_session_integration_spec_postjson",
-      "community": 327
+      "community": 328
     },
     {
       "label": "getJson()",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L52",
       "id": "auth_session_integration_spec_getjson",
-      "community": 327
+      "community": 328
     },
     {
       "label": "deleteRequest()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L87",
       "id": "auth_session_integration_spec_deleterequest",
-      "community": 327
+      "community": 328
     },
     {
       "label": "startRealHttpServer()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/auth-session.integration.spec.ts",
       "source_location": "L126",
       "id": "auth_session_integration_spec_startrealhttpserver",
-      "community": 327
+      "community": 328
     },
     {
       "label": "mcp.routes.streamable-http.spec.ts",
@@ -2385,7 +2385,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_streamable_http_spec_ts",
-      "community": 328
+      "community": 329
     },
     {
       "label": "listenWithMcpRouter()",
@@ -2393,7 +2393,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L8",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouter",
-      "community": 328
+      "community": 329
     },
     {
       "label": "postJsonRpc()",
@@ -2401,7 +2401,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L31",
       "id": "mcp_routes_streamable_http_spec_postjsonrpc",
-      "community": 328
+      "community": 329
     },
     {
       "label": "openSse()",
@@ -2409,7 +2409,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L70",
       "id": "mcp_routes_streamable_http_spec_opensse",
-      "community": 328
+      "community": 329
     },
     {
       "label": "listenWithMcpRouterAndMocks()",
@@ -2417,7 +2417,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.streamable-http.spec.ts",
       "source_location": "L112",
       "id": "mcp_routes_streamable_http_spec_listenwithmcprouterandmocks",
-      "community": 328
+      "community": 329
     },
     {
       "label": "index.ts",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_ts",
-      "community": 166
+      "community": 167
     },
     {
       "label": "Semaphore",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L52",
       "id": "index_semaphore",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".constructor()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L55",
       "id": "index_semaphore_constructor",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".acquire()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L56",
       "id": "index_semaphore_acquire",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".release()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L60",
       "id": "index_semaphore_release",
-      "community": 166
+      "community": 167
     },
     {
       "label": "runHeavyInit()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L87",
       "id": "index_runheavyinit",
-      "community": 166
+      "community": 167
     },
     {
       "label": "registerHandlers()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L106",
       "id": "index_registerhandlers",
-      "community": 166
+      "community": 167
     },
     {
       "label": "startServer()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L135",
       "id": "index_startserver",
-      "community": 166
+      "community": 167
     },
     {
       "label": "cleanup()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L173",
       "id": "index_cleanup",
-      "community": 166
+      "community": 167
     },
     {
       "label": "server-info.spec.ts",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2505,7 +2505,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2513,7 +2513,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 566
+      "community": 567
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "bootstrap.ts",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_sse_hub_ts",
-      "community": 329
+      "community": 330
     },
     {
       "label": "resetReviewCandidatesSseHubForTests()",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L12",
       "id": "review_candidates_sse_hub_resetreviewcandidatesssehubfortests",
-      "community": 329
+      "community": 330
     },
     {
       "label": "writeSafe()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L23",
       "id": "review_candidates_sse_hub_writesafe",
-      "community": 329
+      "community": 330
     },
     {
       "label": "attachReviewCandidatesSse()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L39",
       "id": "review_candidates_sse_hub_attachreviewcandidatessse",
-      "community": 329
+      "community": 330
     },
     {
       "label": "notifyReviewCandidatesChanged()",
@@ -2721,7 +2721,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-sse-hub.ts",
       "source_location": "L69",
       "id": "review_candidates_sse_hub_notifyreviewcandidateschanged",
-      "community": 329
+      "community": 330
     },
     {
       "label": "index.spec.ts",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "sse-server-impl.ts",
@@ -2737,7 +2737,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 385
+      "community": 386
     },
     {
       "label": "startSseServer()",
@@ -2745,7 +2745,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 385
+      "community": 386
     },
     {
       "label": "stopSseServer()",
@@ -2753,7 +2753,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 385
+      "community": 386
     },
     {
       "label": "cleanupSseServer()",
@@ -2761,7 +2761,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 385
+      "community": 386
     },
     {
       "label": "http-server.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "batch-run-history.ts",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_instance_lock_ts",
-      "community": 330
+      "community": 331
     },
     {
       "label": "isProcessAlive()",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L21",
       "id": "instance_lock_isprocessalive",
-      "community": 330
+      "community": 331
     },
     {
       "label": "getLockFilePath()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L33",
       "id": "instance_lock_getlockfilepath",
-      "community": 330
+      "community": 331
     },
     {
       "label": "tryAcquireLock()",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L45",
       "id": "instance_lock_tryacquirelock",
-      "community": 330
+      "community": 331
     },
     {
       "label": "releaseLock()",
@@ -3033,7 +3033,7 @@
       "source_file": "packages/memento-server/src/server/utils/instance-lock.ts",
       "source_location": "L70",
       "id": "instance_lock_releaselock",
-      "community": 330
+      "community": 331
     },
     {
       "label": "cors-policy.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "mcp-tool-call-error.spec.ts",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "mcp-tool-call-error.ts",
@@ -3081,7 +3081,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3089,7 +3089,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 567
+      "community": 568
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3145,7 +3145,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3153,7 +3153,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3161,7 +3161,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3169,7 +3169,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "makeMocks()",
@@ -3177,7 +3177,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 568
+      "community": 569
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 569
+      "community": 570
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createMockResponse()",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 570
+      "community": 571
     },
     {
       "label": "index.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 386
+      "community": 387
     },
     {
       "label": "readCookie()",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 386
+      "community": 387
     },
     {
       "label": "writeUnauthorized()",
@@ -3337,7 +3337,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 386
+      "community": 387
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3345,7 +3345,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 386
+      "community": 387
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3353,7 +3353,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createServiceInjector()",
@@ -3361,7 +3361,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 571
+      "community": 572
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3369,7 +3369,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3377,7 +3377,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L14",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 572
+      "community": 573
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3385,7 +3385,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "createMockResponse()",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L6",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 573
+      "community": 574
     },
     {
       "label": "session-store.spec.ts",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "session-store.ts",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "createSessionStore()",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 574
+      "community": 575
     },
     {
       "label": "stdio-server.ts",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 331
+      "community": 332
     },
     {
       "label": "StdioServer",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 331
+      "community": 332
     },
     {
       "label": ".start()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 331
+      "community": 332
     },
     {
       "label": ".stop()",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 331
+      "community": 332
     },
     {
       "label": ".cleanup()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 331
+      "community": 332
     },
     {
       "label": "sse-server.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 332
+      "community": 333
     },
     {
       "label": "SseServer",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 332
+      "community": 333
     },
     {
       "label": ".start()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 332
+      "community": 333
     },
     {
       "label": ".stop()",
@@ -3489,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 332
+      "community": 333
     },
     {
       "label": ".cleanup()",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 332
+      "community": 333
     },
     {
       "label": "test-database.ts",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "agent.routes.spec.ts",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_transcript_import_spec_ts",
-      "community": 333
+      "community": 334
     },
     {
       "label": "rawEvent()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L15",
       "id": "agent_transcript_import_spec_rawevent",
-      "community": 333
+      "community": 334
     },
     {
       "label": "preparedEvent()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L26",
       "id": "agent_transcript_import_spec_preparedevent",
-      "community": 333
+      "community": 334
     },
     {
       "label": "jsonl()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L52",
       "id": "agent_transcript_import_spec_jsonl",
-      "community": 333
+      "community": 334
     },
     {
       "label": "importer()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L76",
       "id": "agent_transcript_import_spec_importer",
-      "community": 333
+      "community": 334
     },
     {
       "label": "agent.routes.events.ts",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_events_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "prepareEvent()",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L14",
       "id": "agent_routes_events_prepareevent",
-      "community": 575
+      "community": 576
     },
     {
       "label": "admin.routes.ts",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createAdminRouter()",
@@ -3857,7 +3857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L27",
       "id": "admin_routes_createadminrouter",
-      "community": 576
+      "community": 577
     },
     {
       "label": "auth.routes.ts",
@@ -3865,7 +3865,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 334
+      "community": 335
     },
     {
       "label": "readBearerToken()",
@@ -3873,7 +3873,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 334
+      "community": 335
     },
     {
       "label": "readApiKeyHeader()",
@@ -3881,7 +3881,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 334
+      "community": 335
     },
     {
       "label": "readCookie()",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 334
+      "community": 335
     },
     {
       "label": "createAuthRouter()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 334
+      "community": 335
     },
     {
       "label": "mcp.routes.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "createToolsRouter()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L18",
       "id": "tools_routes_createtoolsrouter",
-      "community": 577
+      "community": 578
     },
     {
       "label": "agent.routes.injection.ts",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_injection_ts",
-      "community": 387
+      "community": 388
     },
     {
       "label": "initialInjectionQuery()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L5",
       "id": "agent_routes_injection_initialinjectionquery",
-      "community": 387
+      "community": 388
     },
     {
       "label": "injectionScope()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L16",
       "id": "agent_routes_injection_injectionscope",
-      "community": 387
+      "community": 388
     },
     {
       "label": "buildInjectionDetails()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L25",
       "id": "agent_routes_injection_buildinjectiondetails",
-      "community": 387
+      "community": 388
     },
     {
       "label": "api.routes.ts",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "createApiRouter()",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L16",
       "id": "api_routes_createapirouter",
-      "community": 578
+      "community": 579
     },
     {
       "label": "agent.routes.utils.ts",
@@ -4297,7 +4297,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "createQualityRouter()",
@@ -4305,7 +4305,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 579
+      "community": 580
     },
     {
       "label": "agent.routes.dto.ts",
@@ -4369,7 +4369,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "registerAdminEvolutionDemoRoutes()",
@@ -4377,7 +4377,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L13",
       "id": "admin_evolution_demo_routes_registeradminevolutiondemoroutes",
-      "community": 580
+      "community": 581
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -4385,7 +4385,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 388
+      "community": 389
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -4393,7 +4393,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L33",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 388
+      "community": 389
     },
     {
       "label": "parseBulkSelector()",
@@ -4401,7 +4401,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L45",
       "id": "admin_memory_review_routes_parsebulkselector",
-      "community": 388
+      "community": 389
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -4409,7 +4409,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L83",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 388
+      "community": 389
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 581
+      "community": 582
     },
     {
       "label": "admin-graph-response.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "buildGraphResponse()",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L67",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 582
+      "community": 583
     },
     {
       "label": "admin-tools.routes.ts",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -4553,7 +4553,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 583
+      "community": 584
     },
     {
       "label": "admin-batch.routes.ts",
@@ -4561,7 +4561,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -4569,7 +4569,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 584
+      "community": 585
     },
     {
       "label": "admin-graph.routes.ts",
@@ -4577,7 +4577,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -4585,7 +4585,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 585
+      "community": 586
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -4617,7 +4617,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_relations_routes_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "registerAdminRelationRoutes()",
@@ -4625,7 +4625,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-relations.routes.ts",
       "source_location": "L17",
       "id": "admin_relations_routes_registeradminrelationroutes",
-      "community": 586
+      "community": 587
     },
     {
       "label": "admin-runtime-performance.routes.ts",
@@ -4633,7 +4633,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -4641,7 +4641,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 587
+      "community": 588
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -4649,7 +4649,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -4657,7 +4657,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 588
+      "community": 589
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -4665,7 +4665,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 589
+      "community": 590
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -4769,7 +4769,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_ts",
-      "community": 335
+      "community": 336
     },
     {
       "label": "route()",
@@ -4777,7 +4777,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L48",
       "id": "claude_code_hook_route",
-      "community": 335
+      "community": 336
     },
     {
       "label": "createClaudeCodeHttpTransport()",
@@ -4785,7 +4785,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L73",
       "id": "claude_code_hook_createclaudecodehttptransport",
-      "community": 335
+      "community": 336
     },
     {
       "label": "readStream()",
@@ -4793,7 +4793,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L109",
       "id": "claude_code_hook_readstream",
-      "community": 335
+      "community": 336
     },
     {
       "label": "runClaudeCodeHookCommand()",
@@ -4801,7 +4801,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L115",
       "id": "claude_code_hook_runclaudecodehookcommand",
-      "community": 335
+      "community": 336
     },
     {
       "label": "agent-ask.spec.ts",
@@ -4809,7 +4809,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "argv()",
@@ -4817,7 +4817,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 590
+      "community": 591
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -4825,7 +4825,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
-      "community": 336
+      "community": 337
     },
     {
       "label": "stopBatchSchedulerSingleton()",
@@ -4833,7 +4833,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L22",
       "id": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
-      "community": 336
+      "community": 337
     },
     {
       "label": "argvAgentAsk()",
@@ -4841,7 +4841,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L30",
       "id": "agent_ask_issue237_e2e_spec_argvagentask",
-      "community": 336
+      "community": 337
     },
     {
       "label": "captureStdoutWrite()",
@@ -4849,7 +4849,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L38",
       "id": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
-      "community": 336
+      "community": 337
     },
     {
       "label": "seedTwoProjectMemories()",
@@ -4857,7 +4857,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L52",
       "id": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
-      "community": 336
+      "community": 337
     },
     {
       "label": "claude-code-connect.spec.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "env-loader.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "codex-hook.ts",
@@ -4905,7 +4905,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_ts",
-      "community": 337
+      "community": 338
     },
     {
       "label": "route()",
@@ -4913,7 +4913,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L48",
       "id": "codex_hook_route",
-      "community": 337
+      "community": 338
     },
     {
       "label": "createCodexHttpTransport()",
@@ -4921,7 +4921,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L67",
       "id": "codex_hook_createcodexhttptransport",
-      "community": 337
+      "community": 338
     },
     {
       "label": "readStream()",
@@ -4929,7 +4929,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L101",
       "id": "codex_hook_readstream",
-      "community": 337
+      "community": 338
     },
     {
       "label": "runCodexHookCommand()",
@@ -4937,7 +4937,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L107",
       "id": "codex_hook_runcodexhookcommand",
-      "community": 337
+      "community": 338
     },
     {
       "label": "cli-ac5-ac6.spec.ts",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "runCli()",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L67",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 591
+      "community": 592
     },
     {
       "label": "agent-ask.ts",
@@ -5097,7 +5097,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_ts",
-      "community": 338
+      "community": 339
     },
     {
       "label": "defaultProbe()",
@@ -5105,7 +5105,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L29",
       "id": "claude_code_connect_defaultprobe",
-      "community": 338
+      "community": 339
     },
     {
       "label": "parseOptions()",
@@ -5113,7 +5113,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L46",
       "id": "claude_code_connect_parseoptions",
-      "community": 338
+      "community": 339
     },
     {
       "label": "readSettings()",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L68",
       "id": "claude_code_connect_readsettings",
-      "community": 338
+      "community": 339
     },
     {
       "label": "runClaudeCodeConnect()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L78",
       "id": "claude_code_connect_runclaudecodeconnect",
-      "community": 338
+      "community": 339
     },
     {
       "label": "option-map.ts",
@@ -5185,7 +5185,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "event()",
@@ -5193,7 +5193,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L7",
       "id": "claude_code_hook_spec_event",
-      "community": 592
+      "community": 593
     },
     {
       "label": "agent-ops.ts",
@@ -5353,7 +5353,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "event()",
@@ -5361,7 +5361,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L7",
       "id": "codex_hook_spec_event",
-      "community": 593
+      "community": 594
     },
     {
       "label": "codex-connect.ts",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "testSimpleAlerts()",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "testBasicFunctionality()",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 595
+      "community": 596
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -5481,7 +5481,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -5489,7 +5489,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 596
+      "community": 597
     },
     {
       "label": "test-server-synchronization.ts",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "testErrorLogging()",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 597
+      "community": 598
     },
     {
       "label": "debug-http-v2.ts",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "testFetch()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 598
+      "community": 599
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "initializeTestDatabase()",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 599
+      "community": 600
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -5577,7 +5577,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -5585,7 +5585,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "testReflexionE2E()",
@@ -5593,7 +5593,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 600
+      "community": 601
     },
     {
       "label": "test-alerts-direct.ts",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "testAlertsDirect()",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 601
+      "community": 602
     },
     {
       "label": "test-client.ts",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "test-http-server-v2.ts",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "testPerformanceAlerts()",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "testPathTraversalE2E()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 603
+      "community": 604
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 604
+      "community": 605
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "brave-search-provider.ts",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 389
+      "community": 390
     },
     {
       "label": "BraveSearchProvider",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".constructor()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 389
+      "community": 390
     },
     {
       "label": ".search()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 389
+      "community": 390
     },
     {
       "label": "noop-search-provider.ts",
@@ -5889,7 +5889,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "createSearchProvider()",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 605
+      "community": 606
     },
     {
       "label": "search-provider.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "llm-provider.ts",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "claude-provider.spec.ts",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "types.ts",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "loadAgentConfig()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 606
+      "community": 607
     },
     {
       "label": "system-prompt.ts",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "vitest.config.ts",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "injection-contract.spec.ts",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_queue_runtime_spec_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "transport()",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L179",
       "id": "queue_runtime_spec_transport",
-      "community": 607
+      "community": 608
     },
     {
       "label": "redaction-size.spec.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "injection-contract.ts",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "runtime.ts",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_test_fixtures_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "eventFixture()",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L15",
       "id": "test_fixtures_eventfixture",
-      "community": 608
+      "community": 609
     },
     {
       "label": "schema-normalize.spec.ts",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "normalize.ts",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_normalize_ts",
-      "community": 390
+      "community": 391
     },
     {
       "label": "normalizeJson()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L4",
       "id": "normalize_normalizejson",
-      "community": 390
+      "community": 391
     },
     {
       "label": "canonicalize()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L33",
       "id": "normalize_canonicalize",
-      "community": 390
+      "community": 391
     },
     {
       "label": "normalizeAgentEvent()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L47",
       "id": "normalize_normalizeagentevent",
-      "community": 390
+      "community": 391
     },
     {
       "label": "index.ts",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "priority-queue.ts",
@@ -6329,7 +6329,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_size_policy_ts",
-      "community": 167
+      "community": 168
     },
     {
       "label": "utf8Size()",
@@ -6337,7 +6337,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L12",
       "id": "size_policy_utf8size",
-      "community": 167
+      "community": 168
     },
     {
       "label": "cloneEvent()",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L16",
       "id": "size_policy_cloneevent",
-      "community": 167
+      "community": 168
     },
     {
       "label": "removeOptionalFields()",
@@ -6353,7 +6353,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L20",
       "id": "size_policy_removeoptionalfields",
-      "community": 167
+      "community": 168
     },
     {
       "label": "reducibleText()",
@@ -6361,7 +6361,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L49",
       "id": "size_policy_reducibletext",
-      "community": 167
+      "community": 168
     },
     {
       "label": "truncateToFit()",
@@ -6369,7 +6369,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L89",
       "id": "size_policy_truncatetofit",
-      "community": 167
+      "community": 168
     },
     {
       "label": "applySizePolicy()",
@@ -6377,7 +6377,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L110",
       "id": "size_policy_applysizepolicy",
-      "community": 167
+      "community": 168
     },
     {
       "label": "buildBatch()",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L128",
       "id": "size_policy_buildbatch",
-      "community": 167
+      "community": 168
     },
     {
       "label": "validateBatch()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L150",
       "id": "size_policy_validatebatch",
-      "community": 167
+      "community": 168
     },
     {
       "label": "schema.ts",
@@ -6401,7 +6401,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_ts",
-      "community": 168
+      "community": 169
     },
     {
       "label": "isRecord()",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L50",
       "id": "schema_isrecord",
-      "community": 168
+      "community": 169
     },
     {
       "label": "hasOnlyKeys()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L54",
       "id": "schema_hasonlykeys",
-      "community": 168
+      "community": 169
     },
     {
       "label": "validIdentifier()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L58",
       "id": "schema_valididentifier",
-      "community": 168
+      "community": 169
     },
     {
       "label": "validJsonValue()",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L68",
       "id": "schema_validjsonvalue",
-      "community": 168
+      "community": 169
     },
     {
       "label": "validatePayload()",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L94",
       "id": "schema_validatepayload",
-      "community": 168
+      "community": 169
     },
     {
       "label": "validateAgentEvent()",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L125",
       "id": "schema_validateagentevent",
-      "community": 168
+      "community": 169
     },
     {
       "label": "eventSchema()",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L177",
       "id": "schema_eventschema",
-      "community": 168
+      "community": 169
     },
     {
       "label": "asAgentEvent()",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L277",
       "id": "schema_asagentevent",
-      "community": 168
+      "community": 169
     },
     {
       "label": "scope.spec.ts",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "adapter.ts",
@@ -6585,7 +6585,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "types.ts",
@@ -6593,7 +6593,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "scope.ts",
@@ -6601,7 +6601,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_ts",
-      "community": 169
+      "community": 170
     },
     {
       "label": "value()",
@@ -6609,7 +6609,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L7",
       "id": "scope_value",
-      "community": 169
+      "community": 170
     },
     {
       "label": "defaultGit()",
@@ -6617,7 +6617,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L12",
       "id": "scope_defaultgit",
-      "community": 169
+      "community": 170
     },
     {
       "label": "normalizeRemote()",
@@ -6625,7 +6625,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L25",
       "id": "scope_normalizeremote",
-      "community": 169
+      "community": 170
     },
     {
       "label": "processFromBranch()",
@@ -6633,7 +6633,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L38",
       "id": "scope_processfrombranch",
-      "community": 169
+      "community": 170
     },
     {
       "label": "detectCodexScope()",
@@ -6641,7 +6641,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L44",
       "id": "scope_detectcodexscope",
-      "community": 169
+      "community": 170
     },
     {
       "label": "diagnostics.spec.ts",
@@ -6649,7 +6649,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "diagnostics.ts",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "diagnoseCodex()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L21",
       "id": "diagnostics_diagnosecodex",
-      "community": 609
+      "community": 610
     },
     {
       "label": "settings.ts",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "runCodexHook()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L6",
       "id": "runner_runcodexhook",
-      "community": 610
+      "community": 611
     },
     {
       "label": "adapter.spec.ts",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_adapter_spec_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "fixture()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L12",
       "id": "adapter_spec_fixture",
-      "community": 392
+      "community": 393
     },
     {
       "label": "scope.spec.ts",
@@ -6753,7 +6753,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "adapter.ts",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "types.ts",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "scope.ts",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_ts",
-      "community": 169
+      "community": 170
     },
     {
       "label": "explicit()",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L7",
       "id": "scope_explicit",
-      "community": 169
+      "community": 170
     },
     {
       "label": "detectClaudeCodeScope()",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L44",
       "id": "scope_detectclaudecodescope",
-      "community": 169
+      "community": 170
     },
     {
       "label": "diagnostics.spec.ts",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "diagnostics.ts",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_ts",
-      "community": 391
+      "community": 392
     },
     {
       "label": "parseVersion()",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L19",
       "id": "diagnostics_parseversion",
-      "community": 391
+      "community": 392
     },
     {
       "label": "versionAtLeast()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L31",
       "id": "diagnostics_versionatleast",
-      "community": 391
+      "community": 392
     },
     {
       "label": "diagnoseClaudeCode()",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L42",
       "id": "diagnostics_diagnoseclaudecode",
-      "community": 391
+      "community": 392
     },
     {
       "label": "settings.ts",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_adapter_spec_ts",
-      "community": 392
+      "community": 393
     },
     {
       "label": "fixtureUrl()",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L9",
       "id": "adapter_spec_fixtureurl",
-      "community": 392
+      "community": 393
     },
     {
       "label": "vitest.config.ts",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "utils.spec.ts",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 611
+      "community": 612
     },
     {
       "label": "buildMemory()",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 611
+      "community": 612
     },
     {
       "label": "context-injector.ts",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "agent-api.spec.ts",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "logger.ts",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 393
+      "community": 394
     },
     {
       "label": "constructor()",
@@ -7969,7 +7969,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L233",
       "id": "bootstrap_spec_constructor",
-      "community": 393
+      "community": 394
     },
     {
       "label": "loadBootstrap()",
@@ -7977,7 +7977,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L256",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 393
+      "community": 394
     },
     {
       "label": "installTimeoutSpy()",
@@ -7985,7 +7985,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L260",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 393
+      "community": 394
     },
     {
       "label": "index.ts",
@@ -8017,7 +8017,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 612
+      "community": 613
     },
     {
       "label": "initializeServices()",
@@ -8025,7 +8025,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 612
+      "community": 613
     },
     {
       "label": "context.ts",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 394
+      "community": 395
     },
     {
       "label": "createServerContext()",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L15",
       "id": "context_createservercontext",
-      "community": 394
+      "community": 395
     },
     {
       "label": "createToolContext()",
@@ -8049,7 +8049,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L24",
       "id": "context_createtoolcontext",
-      "community": 394
+      "community": 395
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L37",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 394
+      "community": 395
     },
     {
       "label": "write-and-meta.ts",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 613
+      "community": 614
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 613
+      "community": 614
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 614
+      "community": 615
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L13",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 614
+      "community": 615
     },
     {
       "label": "anchor-stack.ts",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 615
+      "community": 616
     },
     {
       "label": "createAnchorStack()",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 615
+      "community": 616
     },
     {
       "label": "failure-reflexion.ts",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "startFailureAndReflexion()",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 616
+      "community": 617
     },
     {
       "label": "search-and-embedding.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 617
+      "community": 618
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -8145,7 +8145,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -8153,7 +8153,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 618
+      "community": 619
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 619
+      "community": 620
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -8977,7 +8977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "createInput()",
@@ -8985,7 +8985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 620
+      "community": 621
     },
     {
       "label": "reflexion-worker.spec.ts",
@@ -8993,7 +8993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 339
+      "community": 340
     },
     {
       "label": "extract()",
@@ -9001,7 +9001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 339
+      "community": 340
     },
     {
       "label": "waitForEventProcessing()",
@@ -9009,7 +9009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createProceduralMemory()",
@@ -9017,7 +9017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 339
+      "community": 340
     },
     {
       "label": "createFailureEvent()",
@@ -9025,7 +9025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 339
+      "community": 340
     },
     {
       "label": "relation-graph-factory.ts",
@@ -9033,7 +9033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "createRelationGraph()",
@@ -9041,7 +9041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 621
+      "community": 622
     },
     {
       "label": "consolidation-score-service.ts",
@@ -9129,7 +9129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -9137,7 +9137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_ts",
-      "community": 170
+      "community": 171
     },
     {
       "label": "TripleExtractionLogger",
@@ -9145,7 +9145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L61",
       "id": "triple_extraction_logger_tripleextractionlogger",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".constructor()",
@@ -9153,7 +9153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L65",
       "id": "triple_extraction_logger_tripleextractionlogger_constructor",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".logExtraction()",
@@ -9161,7 +9161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L91",
       "id": "triple_extraction_logger_tripleextractionlogger_logextraction",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".createLogEntry()",
@@ -9169,7 +9169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L128",
       "id": "triple_extraction_logger_tripleextractionlogger_createlogentry",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".ensureLogDirectory()",
@@ -9177,7 +9177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L191",
       "id": "triple_extraction_logger_tripleextractionlogger_ensurelogdirectory",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".getLogFilePath()",
@@ -9185,7 +9185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L207",
       "id": "triple_extraction_logger_tripleextractionlogger_getlogfilepath",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".listLogFiles()",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L233",
       "id": "triple_extraction_logger_tripleextractionlogger_listlogfiles",
-      "community": 170
+      "community": 171
     },
     {
       "label": ".deleteOldLogs()",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L266",
       "id": "triple_extraction_logger_tripleextractionlogger_deleteoldlogs",
-      "community": 170
+      "community": 171
     },
     {
       "label": "database-optimize-tool.ts",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 395
+      "community": 396
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".constructor()",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 395
+      "community": 396
     },
     {
       "label": ".handle()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 395
+      "community": 396
     },
     {
       "label": "migration-history-service.ts",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "createBaseSchema()",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 622
+      "community": 623
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 623
+      "community": 624
     },
     {
       "label": "migration-monitor-service.ts",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "openLockTestDatabase()",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 624
+      "community": 625
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createPlan()",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 396
+      "community": 397
     },
     {
       "label": "createResult()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 396
+      "community": 397
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createProgress()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 625
+      "community": 626
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 626
+      "community": 627
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "createCoreMemoryTable()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 627
+      "community": 628
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "init.ts",
@@ -10161,7 +10161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "createDbPath()",
@@ -10169,7 +10169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 628
+      "community": 629
     },
     {
       "label": "migrate.spec.ts",
@@ -10177,7 +10177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "migrate.ts",
@@ -10209,7 +10209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "migration-runner.ts",
@@ -10217,7 +10217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_ts",
-      "community": 171
+      "community": 172
     },
     {
       "label": "MigrationRunner",
@@ -10225,7 +10225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L19",
       "id": "migration_runner_migrationrunner",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".constructor()",
@@ -10233,7 +10233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L24",
       "id": "migration_runner_migrationrunner_constructor",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".runMigration()",
@@ -10241,7 +10241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L33",
       "id": "migration_runner_migrationrunner_runmigration",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".rollbackMigration()",
@@ -10249,7 +10249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L174",
       "id": "migration_runner_migrationrunner_rollbackmigration",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".runMigrations()",
@@ -10257,7 +10257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L199",
       "id": "migration_runner_migrationrunner_runmigrations",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".calculateChecksum()",
@@ -10265,7 +10265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L222",
       "id": "migration_runner_migrationrunner_calculatechecksum",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".getBackupManager()",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L231",
       "id": "migration_runner_migrationrunner_getbackupmanager",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".getVersionManager()",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L238",
       "id": "migration_runner_migrationrunner_getversionmanager",
-      "community": 171
+      "community": 172
     },
     {
       "label": "migration-runner.integration.spec.ts",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "createBaseSchema()",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 629
+      "community": 630
     },
     {
       "label": "migration-logger.spec.ts",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "migration-detector.ts",
@@ -10497,7 +10497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "migration-detector.spec.ts",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "backup-manager.ts",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_ts",
-      "community": 172
+      "community": 173
     },
     {
       "label": "BackupManager",
@@ -10521,7 +10521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L37",
       "id": "backup_manager_backupmanager",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".constructor()",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L40",
       "id": "backup_manager_backupmanager_constructor",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".ensureBackupsDirectory()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L50",
       "id": "backup_manager_backupmanager_ensurebackupsdirectory",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".createBackup()",
@@ -10545,7 +10545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L68",
       "id": "backup_manager_backupmanager_createbackup",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".restoreBackup()",
@@ -10553,7 +10553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L132",
       "id": "backup_manager_backupmanager_restorebackup",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".cleanupOldBackups()",
@@ -10561,7 +10561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L165",
       "id": "backup_manager_backupmanager_cleanupoldbackups",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".findLatestBackup()",
@@ -10569,7 +10569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L210",
       "id": "backup_manager_backupmanager_findlatestbackup",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".getBackupsDirectory()",
@@ -10577,7 +10577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L244",
       "id": "backup_manager_backupmanager_getbackupsdirectory",
-      "community": 172
+      "community": 173
     },
     {
       "label": "backup-manager.spec.ts",
@@ -10585,7 +10585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "dependency-validator.ts",
@@ -10689,7 +10689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "schema-version-manager.ts",
@@ -10777,7 +10777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -10785,7 +10785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 397
+      "community": 398
     },
     {
       "label": "createMemoryItemTable()",
@@ -10793,7 +10793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 397
+      "community": 398
     },
     {
       "label": "columnExists()",
@@ -10801,7 +10801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 397
+      "community": 398
     },
     {
       "label": "indexExists()",
@@ -10809,7 +10809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 397
+      "community": 398
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -10905,7 +10905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_ts",
-      "community": 173
+      "community": 174
     },
     {
       "label": "AnchorTableMigration",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L20",
       "id": "004_anchor_table_anchortablemigration",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".executeSQL()",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L29",
       "id": "004_anchor_table_anchortablemigration_executesql",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".tableExists()",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L54",
       "id": "004_anchor_table_anchortablemigration_tableexists",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".indexExists()",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L65",
       "id": "004_anchor_table_anchortablemigration_indexexists",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".validateBefore()",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L76",
       "id": "004_anchor_table_anchortablemigration_validatebefore",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".up()",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L102",
       "id": "004_anchor_table_anchortablemigration_up",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".down()",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L136",
       "id": "004_anchor_table_anchortablemigration_down",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".validateAfter()",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L158",
       "id": "004_anchor_table_anchortablemigration_validateafter",
-      "community": 173
+      "community": 174
     },
     {
       "label": "020-process-attribute-table.ts",
@@ -11041,7 +11041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_ts",
-      "community": 174
+      "community": 175
     },
     {
       "label": "FactMetadataFieldsMigration",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L18",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".tableExists()",
@@ -11057,7 +11057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L23",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_tableexists",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".columnExists()",
@@ -11065,7 +11065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L30",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_columnexists",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".indexExists()",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L35",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_indexexists",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".validateBefore()",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L42",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validatebefore",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".up()",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L59",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_up",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".down()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L68",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_down",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".validateAfter()",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L96",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validateafter",
-      "community": 174
+      "community": 175
     },
     {
       "label": "032-add-project-id.ts",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 340
+      "community": 341
     },
     {
       "label": "createMemoryItemTable()",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 340
+      "community": 341
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 340
+      "community": 341
     },
     {
       "label": "columnExists()",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 340
+      "community": 341
     },
     {
       "label": "indexExists()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 340
+      "community": 341
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_025_memory_item_is_consolidated_ts",
-      "community": 175
+      "community": 176
     },
     {
       "label": "MemoryItemIsConsolidatedMigration",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L9",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".tableExists()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L14",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_tableexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".columnExists()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L21",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_columnexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".indexExists()",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L26",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_indexexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".validateBefore()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L33",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validatebefore",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".up()",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L35",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_up",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".down()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L49",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_down",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".validateAfter()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L58",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validateafter",
-      "community": 175
+      "community": 176
     },
     {
       "label": "030-triple-extraction-fields.spec.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 341
+      "community": 342
     },
     {
       "label": "createMemoryItemTable()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 341
+      "community": 342
     },
     {
       "label": "createSchemaVersionTable()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 341
+      "community": 342
     },
     {
       "label": "columnExists()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 341
+      "community": 342
     },
     {
       "label": "indexExists()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 341
+      "community": 342
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -11553,7 +11553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "createBaseSchema()",
@@ -11561,7 +11561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 630
+      "community": 631
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -11801,7 +11801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "createBaseSchema()",
@@ -11809,7 +11809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 631
+      "community": 632
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -12105,7 +12105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "createBaseSchema()",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 632
+      "community": 633
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -12121,7 +12121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createMemoryItemTable()",
@@ -12129,7 +12129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 342
+      "community": 343
     },
     {
       "label": "createSchemaVersionTable()",
@@ -12137,7 +12137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 342
+      "community": 343
     },
     {
       "label": "columnExists()",
@@ -12145,7 +12145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 342
+      "community": 343
     },
     {
       "label": "indexExists()",
@@ -12153,7 +12153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 342
+      "community": 343
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_ts",
-      "community": 176
+      "community": 177
     },
     {
       "label": "TripleExtractionFieldsMigration",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".tableExists()",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L15",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_tableexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".columnExists()",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L22",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_columnexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".indexExists()",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L27",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_indexexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".validateBefore()",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L34",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validatebefore",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".up()",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L36",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_up",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".down()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L61",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_down",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".validateAfter()",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L69",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validateafter",
-      "community": 176
+      "community": 177
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_021_feedback_event_attribution_ts",
-      "community": 177
+      "community": 178
     },
     {
       "label": "FeedbackEventAttributionMigration",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L9",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".tableExists()",
@@ -12337,7 +12337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L14",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_tableexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".columnExists()",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L21",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_columnexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".indexExists()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L26",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_indexexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".validateBefore()",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L33",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validatebefore",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".up()",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L57",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_up",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".down()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L89",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_down",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".validateAfter()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L107",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validateafter",
-      "community": 177
+      "community": 178
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -12761,7 +12761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_ts",
-      "community": 178
+      "community": 179
     },
     {
       "label": "ProceduralVersionIndexesMigration",
@@ -12769,7 +12769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L18",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".columnExists()",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L23",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_columnexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".tableExists()",
@@ -12785,7 +12785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L28",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_tableexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".indexExists()",
@@ -12793,7 +12793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L35",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_indexexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".validateBefore()",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L42",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validatebefore",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".up()",
@@ -12809,7 +12809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L62",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_up",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".down()",
@@ -12817,7 +12817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L73",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_down",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".validateAfter()",
@@ -12825,7 +12825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L81",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validateafter",
-      "community": 178
+      "community": 179
     },
     {
       "label": "002-mirix-schema-expansion.spec.ts",
@@ -12833,7 +12833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "createBaseSchema()",
@@ -12841,7 +12841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 633
+      "community": 634
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "createSchemaWith018()",
@@ -12953,7 +12953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 634
+      "community": 635
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -12961,7 +12961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "createBaseSchema()",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 635
+      "community": 636
     },
     {
       "label": "013-procedural-version-fields.spec.ts",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createMemoryLinkTable()",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 398
+      "community": 399
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_ts",
-      "community": 179
+      "community": 180
     },
     {
       "label": "MemoryItemAttributionMigration",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L18",
       "id": "016_memory_item_attribution_memoryitemattributionmigration",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".tableExists()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L23",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_tableexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".columnExists()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L30",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_columnexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".indexExists()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L35",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_indexexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".validateBefore()",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L42",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validatebefore",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".up()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L62",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_up",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".down()",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L69",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_down",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".validateAfter()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L87",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validateafter",
-      "community": 179
+      "community": 180
     },
     {
       "label": "036-agent-memory-promotion-schema.ts",
@@ -13249,7 +13249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createMemoryItemTable()",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 343
+      "community": 344
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 343
+      "community": 344
     },
     {
       "label": "columnExists()",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 343
+      "community": 344
     },
     {
       "label": "indexExists()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 343
+      "community": 344
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_ts",
-      "community": 180
+      "community": 181
     },
     {
       "label": "KgTripleTableMigration",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L17",
       "id": "018_kg_triple_table_kgtripletablemigration",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".tableExists()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L22",
       "id": "018_kg_triple_table_kgtripletablemigration_tableexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".columnExists()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L29",
       "id": "018_kg_triple_table_kgtripletablemigration_columnexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".indexExists()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L34",
       "id": "018_kg_triple_table_kgtripletablemigration_indexexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".validateBefore()",
@@ -13329,7 +13329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L41",
       "id": "018_kg_triple_table_kgtripletablemigration_validatebefore",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".up()",
@@ -13337,7 +13337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L58",
       "id": "018_kg_triple_table_kgtripletablemigration_up",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".down()",
@@ -13345,7 +13345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L80",
       "id": "018_kg_triple_table_kgtripletablemigration_down",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".validateAfter()",
@@ -13353,7 +13353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L91",
       "id": "018_kg_triple_table_kgtripletablemigration_validateafter",
-      "community": 180
+      "community": 181
     },
     {
       "label": "035-agent-integration-schema.contract.spec.ts",
@@ -13361,7 +13361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -13369,7 +13369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createMemoryItemTable()",
@@ -13377,7 +13377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 344
+      "community": 345
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13385,7 +13385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 344
+      "community": 345
     },
     {
       "label": "columnExists()",
@@ -13393,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 344
+      "community": 345
     },
     {
       "label": "indexExists()",
@@ -13401,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 344
+      "community": 345
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -13593,7 +13593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -13665,7 +13665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "createBaseSchema()",
@@ -13673,7 +13673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 636
+      "community": 637
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -13681,7 +13681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_ts",
-      "community": 181
+      "community": 182
     },
     {
       "label": "SoftDeleteFieldsMigration",
@@ -13689,7 +13689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_softdeletefieldsmigration",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".tableExists()",
@@ -13697,7 +13697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L14",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_tableexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".columnExists()",
@@ -13705,7 +13705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L21",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_columnexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".indexExists()",
@@ -13713,7 +13713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L26",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_indexexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".validateBefore()",
@@ -13721,7 +13721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L33",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validatebefore",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".up()",
@@ -13729,7 +13729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_up",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".down()",
@@ -13737,7 +13737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L52",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_down",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".validateAfter()",
@@ -13745,7 +13745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L59",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validateafter",
-      "community": 181
+      "community": 182
     },
     {
       "label": "006-fts5-reflection-notes.spec.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "createBaseSchema()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 637
+      "community": 638
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -13841,7 +13841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_ts",
-      "community": 182
+      "community": 183
     },
     {
       "label": "MemoryItemOwnerIdMigration",
@@ -13849,7 +13849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L17",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".tableExists()",
@@ -13857,7 +13857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L22",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_tableexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".columnExists()",
@@ -13865,7 +13865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L29",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_columnexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".indexExists()",
@@ -13873,7 +13873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L34",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_indexexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".validateBefore()",
@@ -13881,7 +13881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L41",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validatebefore",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".up()",
@@ -13889,7 +13889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L58",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_up",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".down()",
@@ -13897,7 +13897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L63",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_down",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".validateAfter()",
@@ -13905,7 +13905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L75",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validateafter",
-      "community": 182
+      "community": 183
     },
     {
       "label": "003-consolidation-score-fields.spec.ts",
@@ -13913,7 +13913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "createBaseSchema()",
@@ -13921,7 +13921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 638
+      "community": 639
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -13929,7 +13929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -13937,7 +13937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 399
+      "community": 400
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13945,7 +13945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 399
+      "community": 400
     },
     {
       "label": "getIndexNames()",
@@ -13953,7 +13953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 399
+      "community": 400
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -13961,7 +13961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 400
+      "community": 401
     },
     {
       "label": "createSchemaWith019()",
@@ -13969,7 +13969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 400
+      "community": 401
     },
     {
       "label": "tableExists()",
@@ -13977,7 +13977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 400
+      "community": 401
     },
     {
       "label": "columnExists()",
@@ -13985,7 +13985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 400
+      "community": 401
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -14137,7 +14137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -14913,7 +14913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "cache-service.ts",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "batch-scheduler.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 401
+      "community": 402
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 401
+      "community": 402
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -15641,7 +15641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 401
+      "community": 402
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 401
+      "community": 402
     },
     {
       "label": "health-checker.ts",
@@ -15705,7 +15705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -15713,7 +15713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 639
+      "community": 640
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -15721,7 +15721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -15729,7 +15729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 640
+      "community": 641
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -15740,18 +15740,18 @@
       "community": 504
     },
     {
-      "label": "readInsertedUpdated()",
+      "label": "readRunDetails()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
-      "source_location": "L6",
-      "id": "memory_review_candidates_run_diagnostics_readinsertedupdated",
+      "source_location": "L15",
+      "id": "memory_review_candidates_run_diagnostics_readrundetails",
       "community": 504
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
-      "source_location": "L23",
+      "source_location": "L46",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
       "community": 504
     },
@@ -15809,7 +15809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "validateBatchJobConfig()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 641
+      "community": 642
     },
     {
       "label": "retry-manager.ts",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_retry_manager_ts",
-      "community": 183
+      "community": 184
     },
     {
       "label": "RetryManager",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L103",
       "id": "retry_manager_retrymanager",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".constructor()",
@@ -15849,7 +15849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L107",
       "id": "retry_manager_retrymanager_constructor",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".shouldRetry()",
@@ -15857,7 +15857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L119",
       "id": "retry_manager_retrymanager_shouldretry",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".resetErrorCount()",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L158",
       "id": "retry_manager_retrymanager_reseterrorcount",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".incrementErrorCount()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L168",
       "id": "retry_manager_retrymanager_incrementerrorcount",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".getErrorCount()",
@@ -15881,7 +15881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L181",
       "id": "retry_manager_retrymanager_geterrorcount",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".clearAllErrorCounts()",
@@ -15889,7 +15889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L188",
       "id": "retry_manager_retrymanager_clearallerrorcounts",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".retry()",
@@ -15897,7 +15897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L218",
       "id": "retry_manager_retrymanager_retry",
-      "community": 183
+      "community": 184
     },
     {
       "label": "batch-job-execution-coordinator.ts",
@@ -15969,7 +15969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_file_logger_ts",
-      "community": 184
+      "community": 185
     },
     {
       "label": "FileLogger",
@@ -15977,7 +15977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L38",
       "id": "file_logger_filelogger",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".constructor()",
@@ -15985,7 +15985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L42",
       "id": "file_logger_filelogger_constructor",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".log()",
@@ -15993,7 +15993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L81",
       "id": "file_logger_filelogger_log",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".logWarn()",
@@ -16001,7 +16001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L128",
       "id": "file_logger_filelogger_logwarn",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".logError()",
@@ -16009,7 +16009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L160",
       "id": "file_logger_filelogger_logerror",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".sanitizeData()",
@@ -16017,7 +16017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L194",
       "id": "file_logger_filelogger_sanitizedata",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".getLogFilePath()",
@@ -16025,7 +16025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L211",
       "id": "file_logger_filelogger_getlogfilepath",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".setEnabled()",
@@ -16033,7 +16033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L220",
       "id": "file_logger_filelogger_setenabled",
-      "community": 184
+      "community": 185
     },
     {
       "label": "batch-job-timeout-resolver.ts",
@@ -16041,7 +16041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_timeout_resolver_ts",
-      "community": 402
+      "community": 403
     },
     {
       "label": "isTripleExtractionQueueJob()",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L5",
       "id": "batch_job_timeout_resolver_istripleextractionqueuejob",
-      "community": 402
+      "community": 403
     },
     {
       "label": "isJobTimeoutError()",
@@ -16057,7 +16057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L9",
       "id": "batch_job_timeout_resolver_isjobtimeouterror",
-      "community": 402
+      "community": 403
     },
     {
       "label": "resolveBatchJobTimeout()",
@@ -16065,7 +16065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L18",
       "id": "batch_job_timeout_resolver_resolvebatchjobtimeout",
-      "community": 402
+      "community": 403
     },
     {
       "label": "job-queue.ts",
@@ -16308,12 +16308,36 @@
       "community": 68
     },
     {
+      "label": "batch-scheduler-review-meta-handlers.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
+      "community": 505
+    },
+    {
+      "label": "createBaseSchema()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
+      "source_location": "L12",
+      "id": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
+      "community": 505
+    },
+    {
+      "label": "createContext()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
+      "source_location": "L41",
+      "id": "batch_scheduler_review_meta_handlers_spec_createcontext",
+      "community": 505
+    },
+    {
       "label": "batch-scheduler-consolidation-relation-handlers.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 345
+      "community": 346
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -16321,7 +16345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 345
+      "community": 346
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -16329,7 +16353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 345
+      "community": 346
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -16337,7 +16361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L124",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 345
+      "community": 346
     },
     {
       "label": "runLogRotation()",
@@ -16345,7 +16369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L179",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 345
+      "community": 346
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -16353,7 +16377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -16361,7 +16385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -16369,7 +16393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 505
+      "community": 506
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -16377,7 +16401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 505
+      "community": 506
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -16385,7 +16409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -16393,7 +16417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 506
+      "community": 507
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -16401,7 +16425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 506
+      "community": 507
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -16409,31 +16433,31 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 403
+      "community": 404
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L16",
+      "source_location": "L21",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 403
+      "community": 404
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L46",
+      "source_location": "L55",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 403
+      "community": 404
     },
     {
       "label": "runMetaMemoryIntrospection()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L83",
+      "source_location": "L143",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 403
+      "community": 404
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -16441,7 +16465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 346
+      "community": 347
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -16449,7 +16473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 346
+      "community": 347
     },
     {
       "label": "runMemoryCleanup()",
@@ -16457,7 +16481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 346
+      "community": 347
     },
     {
       "label": "runMonitoring()",
@@ -16465,7 +16489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 346
+      "community": 347
     },
     {
       "label": "runHealthCheck()",
@@ -16473,7 +16497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 346
+      "community": 347
     },
     {
       "label": "file-logger.spec.ts",
@@ -16481,7 +16505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "batch-job-execution-coordinator.spec.ts",
@@ -16489,7 +16513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_execution_coordinator_spec_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "createCoordinator()",
@@ -16497,7 +16521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L7",
       "id": "batch_job_execution_coordinator_spec_createcoordinator",
-      "community": 642
+      "community": 643
     },
     {
       "label": "batch-scheduler.spec.ts",
@@ -16569,7 +16593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "retry-manager.spec.ts",
@@ -16577,7 +16601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "shouldRetry()",
@@ -16585,7 +16609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 643
+      "community": 644
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -16593,7 +16617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "baseResult()",
@@ -16601,7 +16625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 644
+      "community": 645
     },
     {
       "label": "job-queue.spec.ts",
@@ -16609,7 +16633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 347
+      "community": 348
     },
     {
       "label": "job()",
@@ -16617,7 +16641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 347
+      "community": 348
     },
     {
       "label": "job1()",
@@ -16625,7 +16649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 347
+      "community": 348
     },
     {
       "label": "job2()",
@@ -16633,7 +16657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 347
+      "community": 348
     },
     {
       "label": "job3()",
@@ -16641,7 +16665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 347
+      "community": 348
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -16649,7 +16673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "batch-job-timeout-resolver.spec.ts",
@@ -16657,7 +16681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_timeout_resolver_spec_ts",
-      "community": 875
+      "community": 876
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -16665,7 +16689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "initializeTestDatabase()",
@@ -16673,7 +16697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 645
+      "community": 646
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -16769,7 +16793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 876
+      "community": 877
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -16777,7 +16801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 404
+      "community": 405
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -16785,7 +16809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 404
+      "community": 405
     },
     {
       "label": ".constructor()",
@@ -16793,7 +16817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 404
+      "community": 405
     },
     {
       "label": ".execute()",
@@ -16801,7 +16825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 404
+      "community": 405
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -16809,7 +16833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 877
+      "community": 878
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -16817,7 +16841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 405
+      "community": 406
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -16825,7 +16849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 405
+      "community": 406
     },
     {
       "label": ".constructor()",
@@ -16833,7 +16857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 405
+      "community": 406
     },
     {
       "label": ".execute()",
@@ -16841,7 +16865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 405
+      "community": 406
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -16849,7 +16873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 406
+      "community": 407
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -16857,7 +16881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 406
+      "community": 407
     },
     {
       "label": ".constructor()",
@@ -16865,7 +16889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 406
+      "community": 407
     },
     {
       "label": ".execute()",
@@ -16873,7 +16897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 406
+      "community": 407
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -16881,7 +16905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "generateId()",
@@ -16889,7 +16913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 507
+      "community": 508
     },
     {
       "label": "initializeTestDatabase()",
@@ -16897,7 +16921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 507
+      "community": 508
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -16905,7 +16929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "createQualityTables()",
@@ -16913,7 +16937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 646
+      "community": 647
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -16921,7 +16945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "generateId()",
@@ -16929,7 +16953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 508
+      "community": 509
     },
     {
       "label": "initializeTestDatabase()",
@@ -16937,7 +16961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 508
+      "community": 509
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -16945,7 +16969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 878
+      "community": 879
     },
     {
       "label": "jsonl-rotation.ts",
@@ -16953,7 +16977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_jsonl_rotation_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "rotateJsonlIfNeeded()",
@@ -16961,7 +16985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L3",
       "id": "jsonl_rotation_rotatejsonlifneeded",
-      "community": 647
+      "community": 648
     },
     {
       "label": "stopwords.spec.ts",
@@ -16969,7 +16993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 879
+      "community": 880
     },
     {
       "label": "type-guards.ts",
@@ -16977,7 +17001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_guards_ts",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isMemoryRow()",
@@ -16985,7 +17009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L32",
       "id": "type_guards_ismemoryrow",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isMemoryType()",
@@ -16993,7 +17017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L53",
       "id": "type_guards_ismemorytype",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isPrivacyScope()",
@@ -17001,7 +17025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L63",
       "id": "type_guards_isprivacyscope",
-      "community": 185
+      "community": 186
     },
     {
       "label": "convertMemoryRowToItem()",
@@ -17009,7 +17033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L74",
       "id": "type_guards_convertmemoryrowtoitem",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isRelationRow()",
@@ -17017,7 +17041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L144",
       "id": "type_guards_isrelationrow",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isExistingRelationRow()",
@@ -17025,7 +17049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L176",
       "id": "type_guards_isexistingrelationrow",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isMetadataRow()",
@@ -17033,7 +17057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L201",
       "id": "type_guards_ismetadatarow",
-      "community": 185
+      "community": 186
     },
     {
       "label": "isSqlParam()",
@@ -17041,7 +17065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L216",
       "id": "type_guards_issqlparam",
-      "community": 185
+      "community": 186
     },
     {
       "label": "procedural-memory-extractor.ts",
@@ -17153,7 +17177,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "validateTableName()",
@@ -17161,7 +17185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 509
+      "community": 510
     },
     {
       "label": "getVectorTableName()",
@@ -17169,7 +17193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 509
+      "community": 510
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -17177,7 +17201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -17185,7 +17209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 648
+      "community": 649
     },
     {
       "label": "environment-check.ts",
@@ -17193,7 +17217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 407
+      "community": 408
     },
     {
       "label": "isTestEnvironment()",
@@ -17201,7 +17225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 407
+      "community": 408
     },
     {
       "label": "isValidationDisabled()",
@@ -17209,7 +17233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 407
+      "community": 408
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -17217,7 +17241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 407
+      "community": 408
     },
     {
       "label": "db-path.spec.ts",
@@ -17225,7 +17249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 880
+      "community": 881
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -17233,7 +17257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 881
+      "community": 882
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -17241,7 +17265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 348
+      "community": 349
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -17249,7 +17273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L40",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 348
+      "community": 349
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -17257,7 +17281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L97",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 348
+      "community": 349
     },
     {
       "label": "extractKeyTokens()",
@@ -17265,7 +17289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L140",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 348
+      "community": 349
     },
     {
       "label": "getSearchQueryExamples()",
@@ -17273,7 +17297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L157",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 348
+      "community": 349
     },
     {
       "label": "relation-type-converter.ts",
@@ -17281,7 +17305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 349
+      "community": 350
     },
     {
       "label": "toDbRelationType()",
@@ -17289,7 +17313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 349
+      "community": 350
     },
     {
       "label": "fromDbRelationType()",
@@ -17297,7 +17321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 349
+      "community": 350
     },
     {
       "label": "isValidDbRelationType()",
@@ -17305,7 +17329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 349
+      "community": 350
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -17313,7 +17337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 349
+      "community": 350
     },
     {
       "label": "db-path.ts",
@@ -17321,7 +17345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -17329,7 +17353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 649
+      "community": 650
     },
     {
       "label": "error-handling.spec.ts",
@@ -17337,7 +17361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "operation()",
@@ -17345,7 +17369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 650
+      "community": 651
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -17409,7 +17433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_rate_limiter_ts",
-      "community": 186
+      "community": 187
     },
     {
       "label": "LoggingRateLimiter",
@@ -17417,7 +17441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L31",
       "id": "logging_rate_limiter_loggingratelimiter",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".constructor()",
@@ -17425,7 +17449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L38",
       "id": "logging_rate_limiter_loggingratelimiter_constructor",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".canSend()",
@@ -17433,7 +17457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L52",
       "id": "logging_rate_limiter_loggingratelimiter_cansend",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".consume()",
@@ -17441,7 +17465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L61",
       "id": "logging_rate_limiter_loggingratelimiter_consume",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".refill()",
@@ -17449,7 +17473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L76",
       "id": "logging_rate_limiter_loggingratelimiter_refill",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".getDroppedCount()",
@@ -17457,7 +17481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L88",
       "id": "logging_rate_limiter_loggingratelimiter_getdroppedcount",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".resetDroppedCount()",
@@ -17465,7 +17489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L95",
       "id": "logging_rate_limiter_loggingratelimiter_resetdroppedcount",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".getAvailableTokens()",
@@ -17473,7 +17497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L102",
       "id": "logging_rate_limiter_loggingratelimiter_getavailabletokens",
-      "community": 186
+      "community": 187
     },
     {
       "label": "type-param-validator.ts",
@@ -17529,7 +17553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 882
+      "community": 883
     },
     {
       "label": "relation-visualizer.ts",
@@ -17929,7 +17953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "issue()",
@@ -17937,7 +17961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L41",
       "id": "configuration_validator_issue",
-      "community": 510
+      "community": 511
     },
     {
       "label": "validateConfiguration()",
@@ -17945,7 +17969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L45",
       "id": "configuration_validator_validateconfiguration",
-      "community": 510
+      "community": 511
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -17953,7 +17977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 883
+      "community": 884
     },
     {
       "label": "cache-key-generator.ts",
@@ -18009,7 +18033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "transactionFn()",
@@ -18017,7 +18041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 511
+      "community": 512
     },
     {
       "label": "outerTransaction()",
@@ -18025,7 +18049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 511
+      "community": 512
     },
     {
       "label": "write-coalescing.ts",
@@ -18113,7 +18137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "validateReflectionNote()",
@@ -18121,7 +18145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 408
+      "community": 409
     },
     {
       "label": "validateReflectionNotes()",
@@ -18129,7 +18153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 408
+      "community": 409
     },
     {
       "label": "formatValidationErrors()",
@@ -18137,7 +18161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 408
+      "community": 409
     },
     {
       "label": "environment-check.spec.ts",
@@ -18145,7 +18169,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 884
+      "community": 885
     },
     {
       "label": "path-validator.ts",
@@ -18209,7 +18233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -18217,7 +18241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 651
+      "community": 652
     },
     {
       "label": "error-handling.ts",
@@ -18225,7 +18249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "withErrorHandling()",
@@ -18233,7 +18257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 652
+      "community": 653
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -18241,7 +18265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 885
+      "community": 886
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -18249,7 +18273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 886
+      "community": 887
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -18377,7 +18401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_ts",
-      "community": 187
+      "community": 188
     },
     {
       "label": "validateLogMetadata()",
@@ -18385,7 +18409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L54",
       "id": "logger_validatelogmetadata",
-      "community": 187
+      "community": 188
     },
     {
       "label": "isMCPMode()",
@@ -18393,7 +18417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L160",
       "id": "logger_ismcpmode",
-      "community": 187
+      "community": 188
     },
     {
       "label": "safeStringify()",
@@ -18401,7 +18425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L173",
       "id": "logger_safestringify",
-      "community": 187
+      "community": 188
     },
     {
       "label": "formatTime()",
@@ -18409,7 +18433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L181",
       "id": "logger_formattime",
-      "community": 187
+      "community": 188
     },
     {
       "label": "buildLogMessage()",
@@ -18417,7 +18441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L191",
       "id": "logger_buildlogmessage",
-      "community": 187
+      "community": 188
     },
     {
       "label": "logToStderr()",
@@ -18425,7 +18449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L209",
       "id": "logger_logtostderr",
-      "community": 187
+      "community": 188
     },
     {
       "label": "logWithMCPLogger()",
@@ -18433,7 +18457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L240",
       "id": "logger_logwithmcplogger",
-      "community": 187
+      "community": 188
     },
     {
       "label": "isCliQuiet()",
@@ -18441,7 +18465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L294",
       "id": "logger_iscliquiet",
-      "community": 187
+      "community": 188
     },
     {
       "label": "ensure-meta-memory-stats-schema.ts",
@@ -18449,7 +18473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -18457,7 +18481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 653
+      "community": 654
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -18465,7 +18489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createValidReflectionNote()",
@@ -18473,7 +18497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createLargeNote()",
@@ -18481,7 +18505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 512
+      "community": 513
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -18489,7 +18513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "initializeTestDatabase()",
@@ -18497,7 +18521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 654
+      "community": 655
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -18505,7 +18529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -18513,7 +18537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 655
+      "community": 656
     },
     {
       "label": "logging-helpers.ts",
@@ -18609,7 +18633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 887
+      "community": 888
     },
     {
       "label": "pii-masker.ts",
@@ -18681,7 +18705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getStopWords()",
@@ -18689,7 +18713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getEnglishStopWords()",
@@ -18697,7 +18721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 350
+      "community": 351
     },
     {
       "label": "getKoreanStopWords()",
@@ -18705,7 +18729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 350
+      "community": 351
     },
     {
       "label": "isStopWord()",
@@ -18713,7 +18737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 350
+      "community": 351
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -18721,7 +18745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 888
+      "community": 889
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -18729,7 +18753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 889
+      "community": 890
     },
     {
       "label": "pii-masker-api-key.spec.ts",
@@ -18737,7 +18761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
-      "community": 890
+      "community": 891
     },
     {
       "label": "path-validator.spec.ts",
@@ -18745,7 +18769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 891
+      "community": 892
     },
     {
       "label": "triple-cache.spec.ts",
@@ -18753,7 +18777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 892
+      "community": 893
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -18761,7 +18785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 893
+      "community": 894
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -18769,7 +18793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 894
+      "community": 895
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -18777,7 +18801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 895
+      "community": 896
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -18785,7 +18809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 896
+      "community": 897
     },
     {
       "label": "logger-schema.spec.ts",
@@ -18793,7 +18817,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 897
+      "community": 898
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -18801,7 +18825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 898
+      "community": 899
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -18809,7 +18833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "initializeTestDatabase()",
@@ -18817,7 +18841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 656
+      "community": 657
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -18825,7 +18849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 899
+      "community": 900
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -18833,7 +18857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 900
+      "community": 901
     },
     {
       "label": "benchmark.types.ts",
@@ -18841,7 +18865,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "assertMacroCategory()",
@@ -18849,7 +18873,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L27",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 657
+      "community": 658
     },
     {
       "label": "migration.types.ts",
@@ -18857,7 +18881,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 901
+      "community": 902
     },
     {
       "label": "consolidation-score.types.ts",
@@ -18865,7 +18889,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 902
+      "community": 903
     },
     {
       "label": "consolidation.types.ts",
@@ -18873,7 +18897,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 903
+      "community": 904
     },
     {
       "label": "vector-search.types.ts",
@@ -18881,7 +18905,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 904
+      "community": 905
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -18889,7 +18913,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 905
+      "community": 906
     },
     {
       "label": "procedural-versioning.ts",
@@ -18897,7 +18921,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 906
+      "community": 907
     },
     {
       "label": "triple-extraction.ts",
@@ -18905,7 +18929,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 907
+      "community": 908
     },
     {
       "label": "feedback.types.ts",
@@ -18913,7 +18937,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 908
+      "community": 909
     },
     {
       "label": "embedding.types.ts",
@@ -18921,7 +18945,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 909
+      "community": 910
     },
     {
       "label": "relation-graph.ts",
@@ -18929,7 +18953,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 910
+      "community": 911
     },
     {
       "label": "failure-event.ts",
@@ -18937,7 +18961,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 911
+      "community": 912
     },
     {
       "label": "index.ts",
@@ -18945,7 +18969,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "isMemoryItemType()",
@@ -18953,7 +18977,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 513
+      "community": 514
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -18961,7 +18985,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 513
+      "community": 514
     },
     {
       "label": "error-types.ts",
@@ -18969,7 +18993,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 912
+      "community": 913
     },
     {
       "label": "ranking.types.ts",
@@ -18977,7 +19001,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 913
+      "community": 914
     },
     {
       "label": "alerts.types.ts",
@@ -18985,7 +19009,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 914
+      "community": 915
     },
     {
       "label": "relation.ts",
@@ -18993,7 +19017,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "isApplicableRelationType()",
@@ -19001,7 +19025,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L151",
       "id": "relation_isapplicablerelationtype",
-      "community": 409
+      "community": 410
     },
     {
       "label": "getRelationCategory()",
@@ -19009,7 +19033,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L161",
       "id": "relation_getrelationcategory",
-      "community": 409
+      "community": 410
     },
     {
       "label": "getRelationBoost()",
@@ -19017,7 +19041,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L168",
       "id": "relation_getrelationboost",
-      "community": 409
+      "community": 410
     },
     {
       "label": "search.types.ts",
@@ -19025,7 +19049,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 915
+      "community": 916
     },
     {
       "label": "index.spec.ts",
@@ -19033,7 +19057,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 916
+      "community": 917
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -19041,7 +19065,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 917
+      "community": 918
     },
     {
       "label": "constants.ts",
@@ -19049,7 +19073,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 918
+      "community": 919
     },
     {
       "label": "environment.ts",
@@ -19193,7 +19217,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 919
+      "community": 920
     },
     {
       "label": "retry-options-loader.ts",
@@ -19249,7 +19273,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_llm_model_resolver_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "resolveProviderDefaultModel()",
@@ -19257,7 +19281,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L28",
       "id": "llm_model_resolver_resolveproviderdefaultmodel",
-      "community": 514
+      "community": 515
     },
     {
       "label": "resolveLlmModel()",
@@ -19265,7 +19289,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L51",
       "id": "llm_model_resolver_resolvellmmodel",
-      "community": 514
+      "community": 515
     },
     {
       "label": "index.ts",
@@ -19273,7 +19297,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "validateConfig()",
@@ -19281,7 +19305,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L161",
       "id": "index_validateconfig",
-      "community": 658
+      "community": 659
     },
     {
       "label": "config-loader-utils.ts",
@@ -19353,7 +19377,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 920
+      "community": 921
     },
     {
       "label": "constants.spec.ts",
@@ -19361,7 +19385,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 921
+      "community": 922
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -19369,7 +19393,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 922
+      "community": 923
     },
     {
       "label": "config-validation.spec.ts",
@@ -19377,7 +19401,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 923
+      "community": 924
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -19385,7 +19409,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 924
+      "community": 925
     },
     {
       "label": "environment-paths.spec.ts",
@@ -19393,7 +19417,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 925
+      "community": 926
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -19401,7 +19425,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 926
+      "community": 927
     },
     {
       "label": "relation-constants.ts",
@@ -19409,7 +19433,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 927
+      "community": 928
     },
     {
       "label": "introspection-constants.ts",
@@ -19417,7 +19441,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 928
+      "community": 929
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -19425,7 +19449,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 929
+      "community": 930
     },
     {
       "label": "http-bind-policy.ts",
@@ -19433,7 +19457,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_ts",
-      "community": 188
+      "community": 189
     },
     {
       "label": "MementoHttpSecurityStartupError",
@@ -19441,7 +19465,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L5",
       "id": "http_bind_policy_mementohttpsecuritystartuperror",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".constructor()",
@@ -19449,7 +19473,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L8",
       "id": "http_bind_policy_mementohttpsecuritystartuperror_constructor",
-      "community": 188
+      "community": 189
     },
     {
       "label": "isIpv4Loopback127Block()",
@@ -19457,7 +19481,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L17",
       "id": "http_bind_policy_isipv4loopback127block",
-      "community": 188
+      "community": 189
     },
     {
       "label": "isIpv4MappedLoopback()",
@@ -19465,7 +19489,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L32",
       "id": "http_bind_policy_isipv4mappedloopback",
-      "community": 188
+      "community": 189
     },
     {
       "label": "canonicalizeHttpBindHostForListen()",
@@ -19473,7 +19497,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L53",
       "id": "http_bind_policy_canonicalizehttpbindhostforlisten",
-      "community": 188
+      "community": 189
     },
     {
       "label": "formatHttpBindHostForUrl()",
@@ -19481,7 +19505,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L64",
       "id": "http_bind_policy_formathttpbindhostforurl",
-      "community": 188
+      "community": 189
     },
     {
       "label": "isHttpBindHostRemotelyReachable()",
@@ -19489,7 +19513,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L72",
       "id": "http_bind_policy_ishttpbindhostremotelyreachable",
-      "community": 188
+      "community": 189
     },
     {
       "label": "getMementoHttpSecurityStartupViolationMessage()",
@@ -19497,7 +19521,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L87",
       "id": "http_bind_policy_getmementohttpsecuritystartupviolationmessage",
-      "community": 188
+      "community": 189
     },
     {
       "label": "reflexion-worker.interface.ts",
@@ -19505,7 +19529,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 930
+      "community": 931
     },
     {
       "label": "retry-manager.interface.ts",
@@ -19513,7 +19537,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 931
+      "community": 932
     },
     {
       "label": "cache.interface.ts",
@@ -19521,7 +19545,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 932
+      "community": 933
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -19529,7 +19553,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 933
+      "community": 934
     },
     {
       "label": "error-logging.interface.ts",
@@ -19537,7 +19561,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 934
+      "community": 935
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -19545,7 +19569,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 935
+      "community": 936
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -19553,7 +19577,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 936
+      "community": 937
     },
     {
       "label": "database.interface.ts",
@@ -19561,7 +19585,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 937
+      "community": 938
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -19569,7 +19593,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 938
+      "community": 939
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -19577,7 +19601,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 939
+      "community": 940
     },
     {
       "label": "llm-client-initializer.ts",
@@ -19761,7 +19785,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "getMockMementoConfig()",
@@ -19769,7 +19793,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L21",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 515
+      "community": 516
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -19777,7 +19801,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L50",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 515
+      "community": 516
     },
     {
       "label": "initialize.spec.ts",
@@ -19785,7 +19809,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 940
+      "community": 941
     },
     {
       "label": "openai-client.spec.ts",
@@ -19793,7 +19817,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 941
+      "community": 942
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -19801,7 +19825,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 942
+      "community": 943
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -19809,7 +19833,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 943
+      "community": 944
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -19817,7 +19841,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 944
+      "community": 945
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -19825,7 +19849,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 945
+      "community": 946
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -19833,7 +19857,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 946
+      "community": 947
     },
     {
       "label": "environment-priority.spec.ts",
@@ -19841,7 +19865,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 947
+      "community": 948
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -19849,7 +19873,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 948
+      "community": 949
     },
     {
       "label": "gemini-client.spec.ts",
@@ -19857,7 +19881,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 949
+      "community": 950
     },
     {
       "label": "search-local-tool.ts",
@@ -19865,7 +19889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "SearchLocalTool",
@@ -19873,7 +19897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 410
+      "community": 411
     },
     {
       "label": ".constructor()",
@@ -19881,7 +19905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 410
+      "community": 411
     },
     {
       "label": ".handle()",
@@ -19889,7 +19913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 410
+      "community": 411
     },
     {
       "label": "get-anchor-tool.ts",
@@ -19897,7 +19921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "GetAnchorTool",
@@ -19905,7 +19929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 411
+      "community": 412
     },
     {
       "label": ".constructor()",
@@ -19913,7 +19937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 411
+      "community": 412
     },
     {
       "label": ".handle()",
@@ -19921,7 +19945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 411
+      "community": 412
     },
     {
       "label": "set-anchor-tool.ts",
@@ -19929,7 +19953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "SetAnchorTool",
@@ -19937,7 +19961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 412
+      "community": 413
     },
     {
       "label": ".constructor()",
@@ -19945,7 +19969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 412
+      "community": 413
     },
     {
       "label": ".handle()",
@@ -19953,7 +19977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 412
+      "community": 413
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -19961,7 +19985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "ClearAnchorTool",
@@ -19969,7 +19993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 413
+      "community": 414
     },
     {
       "label": ".constructor()",
@@ -19977,7 +20001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 413
+      "community": 414
     },
     {
       "label": ".handle()",
@@ -19985,7 +20009,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 413
+      "community": 414
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -19993,7 +20017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "RestoreAnchorsTool",
@@ -20001,7 +20025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 414
+      "community": 415
     },
     {
       "label": ".constructor()",
@@ -20009,7 +20033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 414
+      "community": 415
     },
     {
       "label": ".handle()",
@@ -20017,7 +20041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 414
+      "community": 415
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -20025,7 +20049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 351
+      "community": 352
     },
     {
       "label": "initializeTestDatabase()",
@@ -20033,7 +20057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 351
+      "community": 352
     },
     {
       "label": "createMockEmbeddingService()",
@@ -20041,7 +20065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 351
+      "community": 352
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -20049,7 +20073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 351
+      "community": 352
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -20057,7 +20081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 351
+      "community": 352
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -20065,7 +20089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 352
+      "community": 353
     },
     {
       "label": "initializeTestDatabase()",
@@ -20073,7 +20097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 352
+      "community": 353
     },
     {
       "label": "createMockEmbeddingService()",
@@ -20081,7 +20105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 352
+      "community": 353
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -20089,7 +20113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 352
+      "community": 353
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -20097,7 +20121,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 352
+      "community": 353
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -20105,7 +20129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 353
+      "community": 354
     },
     {
       "label": "initializeTestDatabase()",
@@ -20113,7 +20137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 353
+      "community": 354
     },
     {
       "label": "createMockEmbeddingService()",
@@ -20121,7 +20145,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 353
+      "community": 354
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -20129,7 +20153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 353
+      "community": 354
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -20137,7 +20161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 353
+      "community": 354
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -20145,7 +20169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "initializeTestDatabase()",
@@ -20153,7 +20177,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 659
+      "community": 660
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -20161,7 +20185,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "initializeTestDatabase()",
@@ -20169,7 +20193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 660
+      "community": 661
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -20177,7 +20201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 950
+      "community": 951
     },
     {
       "label": "query-filter-strategy.ts",
@@ -20185,7 +20209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 354
+      "community": 355
     },
     {
       "label": "QueryFilterStrategy",
@@ -20193,7 +20217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".constructor()",
@@ -20201,7 +20225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".filter()",
@@ -20209,7 +20233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 354
+      "community": 355
     },
     {
       "label": ".execute()",
@@ -20217,7 +20241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 354
+      "community": 355
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -20225,7 +20249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 951
+      "community": 952
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -20233,7 +20257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 952
+      "community": 953
     },
     {
       "label": "local-search-service.ts",
@@ -20305,7 +20329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 953
+      "community": 954
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -20313,7 +20337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 954
+      "community": 955
     },
     {
       "label": "anchor-interfaces.ts",
@@ -20441,7 +20465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 955
+      "community": 956
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -20449,7 +20473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -20457,7 +20481,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 661
+      "community": 662
     },
     {
       "label": "embedding-types.ts",
@@ -20465,7 +20489,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 956
+      "community": 957
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -20473,7 +20497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 957
+      "community": 958
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -20481,7 +20505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 355
+      "community": 356
     },
     {
       "label": "NHopSearchStrategy",
@@ -20489,7 +20513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".constructor()",
@@ -20497,7 +20521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".search()",
@@ -20505,7 +20529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 355
+      "community": 356
     },
     {
       "label": ".execute()",
@@ -20513,7 +20537,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 355
+      "community": 356
     },
     {
       "label": "query-filter-service.ts",
@@ -20681,7 +20705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 356
+      "community": 357
     },
     {
       "label": "FallbackSearchService",
@@ -20689,7 +20713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".setDatabase()",
@@ -20697,7 +20721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -20705,7 +20729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 356
+      "community": 357
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -20713,7 +20737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 356
+      "community": 357
     },
     {
       "label": "index.ts",
@@ -20721,7 +20745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 958
+      "community": 959
     },
     {
       "label": "fallback-strategy.ts",
@@ -20729,7 +20753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 357
+      "community": 358
     },
     {
       "label": "FallbackStrategy",
@@ -20737,7 +20761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".constructor()",
@@ -20745,7 +20769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".fallback()",
@@ -20753,7 +20777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 357
+      "community": 358
     },
     {
       "label": ".execute()",
@@ -20761,7 +20785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 357
+      "community": 358
     },
     {
       "label": "anchor-search-service.ts",
@@ -20905,7 +20929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 959
+      "community": 960
     },
     {
       "label": "anchor-cache-service.ts",
@@ -21153,7 +21177,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 960
+      "community": 961
     },
     {
       "label": "local-search-service.spec.ts",
@@ -21161,7 +21185,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 961
+      "community": 962
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -21169,7 +21193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 962
+      "community": 963
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -21177,7 +21201,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 963
+      "community": 964
     },
     {
       "label": "store.ts",
@@ -21185,7 +21209,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_store_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "key()",
@@ -21193,7 +21217,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L13",
       "id": "store_key",
-      "community": 415
+      "community": 416
     },
     {
       "label": "buildSnapshotsFromFixture()",
@@ -21201,7 +21225,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L38",
       "id": "store_buildsnapshotsfromfixture",
-      "community": 415
+      "community": 416
     },
     {
       "label": "getFixtureSnapshot()",
@@ -21209,7 +21233,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L172",
       "id": "store_getfixturesnapshot",
-      "community": 415
+      "community": 416
     },
     {
       "label": "types.ts",
@@ -21217,7 +21241,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 964
+      "community": 965
     },
     {
       "label": "index.ts",
@@ -21225,7 +21249,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 965
+      "community": 966
     },
     {
       "label": "getters.ts",
@@ -21233,7 +21257,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_getters_ts",
-      "community": 358
+      "community": 359
     },
     {
       "label": "EvolutionDemoNotFoundError",
@@ -21241,7 +21265,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L44",
       "id": "getters_evolutiondemonotfounderror",
-      "community": 358
+      "community": 359
     },
     {
       "label": ".constructor()",
@@ -21249,7 +21273,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L45",
       "id": "getters_evolutiondemonotfounderror_constructor",
-      "community": 358
+      "community": 359
     },
     {
       "label": "listEvolutionDemoScenarios()",
@@ -21257,7 +21281,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L55",
       "id": "getters_listevolutiondemoscenarios",
-      "community": 358
+      "community": 359
     },
     {
       "label": "getEvolutionDemoSnapshot()",
@@ -21265,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L61",
       "id": "getters_getevolutiondemosnapshot",
-      "community": 358
+      "community": 359
     },
     {
       "label": "spec.ts",
@@ -21273,7 +21297,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 966
+      "community": 967
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -21281,7 +21305,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 967
+      "community": 968
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -21289,7 +21313,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 968
+      "community": 969
     },
     {
       "label": "vector-search.factory.ts",
@@ -21345,7 +21369,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_hybrid_search_factory_ts",
-      "community": 189
+      "community": 190
     },
     {
       "label": "DefaultSearchLogger",
@@ -21353,7 +21377,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L27",
       "id": "hybrid_search_factory_defaultsearchlogger",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".logSearchStart()",
@@ -21361,7 +21385,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L28",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstart",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".logSearchStep()",
@@ -21369,7 +21393,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L32",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstep",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".logSearchComplete()",
@@ -21377,7 +21401,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L36",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchcomplete",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".logSearchError()",
@@ -21385,7 +21409,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L48",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearcherror",
-      "community": 189
+      "community": 190
     },
     {
       "label": "HybridSearchFactory",
@@ -21393,7 +21417,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L58",
       "id": "hybrid_search_factory_hybridsearchfactory",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".createDefaultEngine()",
@@ -21401,7 +21425,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L62",
       "id": "hybrid_search_factory_hybridsearchfactory_createdefaultengine",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".createEngine()",
@@ -21409,7 +21433,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L91",
       "id": "hybrid_search_factory_hybridsearchfactory_createengine",
-      "community": 189
+      "community": 190
     },
     {
       "label": "hybrid-search.factory.spec.ts",
@@ -21417,7 +21441,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -21425,7 +21449,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 662
+      "community": 663
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -21433,7 +21457,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 969
+      "community": 970
     },
     {
       "label": "search-result-combiner.ts",
@@ -21441,7 +21465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "SearchResultCombiner",
@@ -21449,7 +21473,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L19",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 416
+      "community": 417
     },
     {
       "label": ".combine()",
@@ -21457,7 +21481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L31",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 416
+      "community": 417
     },
     {
       "label": ".generateHybridReason()",
@@ -21465,7 +21489,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L103",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 416
+      "community": 417
     },
     {
       "label": "search-engine.ts",
@@ -21617,7 +21641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -21625,7 +21649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 417
+      "community": 418
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -21633,7 +21657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 417
+      "community": 418
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -21641,7 +21665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 417
+      "community": 418
     },
     {
       "label": "search-ranking.ts",
@@ -22505,7 +22529,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -22513,7 +22537,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 663
+      "community": 664
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -22633,7 +22657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "normalize()",
@@ -22641,7 +22665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 418
+      "community": 419
     },
     {
       "label": "toSet()",
@@ -22649,7 +22673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 418
+      "community": 419
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -22657,7 +22681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 418
+      "community": 419
     },
     {
       "label": "procedural-memory-matcher.spec.ts",
@@ -22665,7 +22689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 970
+      "community": 971
     },
     {
       "label": "search-ranking.spec.ts",
@@ -22673,7 +22697,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 971
+      "community": 972
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -22681,7 +22705,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "initializeTestDatabase()",
@@ -22689,7 +22713,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 516
+      "community": 517
     },
     {
       "label": "createValidReflectionNote()",
@@ -22697,7 +22721,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 516
+      "community": 517
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -22705,7 +22729,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_spec_ts",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockTextSearchEngine()",
@@ -22713,7 +22737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L44",
       "id": "hybrid_search_engine_spec_createmocktextsearchengine",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockEmbeddingService()",
@@ -22721,7 +22745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L48",
       "id": "hybrid_search_engine_spec_createmockembeddingservice",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -22729,7 +22753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L54",
       "id": "hybrid_search_engine_spec_createmockvectorsearchengine",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockResultCombiner()",
@@ -22737,7 +22761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L60",
       "id": "hybrid_search_engine_spec_createmockresultcombiner",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockWeightCalculator()",
@@ -22745,7 +22769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L64",
       "id": "hybrid_search_engine_spec_createmockweightcalculator",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createMockLogger()",
@@ -22753,7 +22777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L68",
       "id": "hybrid_search_engine_spec_createmocklogger",
-      "community": 190
+      "community": 191
     },
     {
       "label": "createTestMemory()",
@@ -22761,7 +22785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L536",
       "id": "hybrid_search_engine_spec_createtestmemory",
-      "community": 190
+      "community": 191
     },
     {
       "label": "p95()",
@@ -22769,7 +22793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L2621",
       "id": "hybrid_search_engine_spec_p95",
-      "community": 190
+      "community": 191
     },
     {
       "label": "hybrid-search-engine-consolidation.spec.ts",
@@ -22777,7 +22801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 972
+      "community": 973
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -22785,7 +22809,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 973
+      "community": 974
     },
     {
       "label": "search-engine.spec.ts",
@@ -22793,7 +22817,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "createCountingSearchDb()",
@@ -22801,7 +22825,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 419
+      "community": 420
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -22809,7 +22833,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 419
+      "community": 420
     },
     {
       "label": "createSearchRows()",
@@ -22817,7 +22841,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 419
+      "community": 420
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -22825,7 +22849,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 974
+      "community": 975
     },
     {
       "label": "vector-search.repository.ts",
@@ -23025,7 +23049,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 975
+      "community": 976
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -23033,7 +23057,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 976
+      "community": 977
     },
     {
       "label": "vector-search.service.ts",
@@ -23129,7 +23153,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -23137,7 +23161,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 664
+      "community": 665
     },
     {
       "label": "vector-performance-tester.ts",
@@ -23201,7 +23225,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "createMockRepository()",
@@ -23209,7 +23233,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 665
+      "community": 666
     },
     {
       "label": "vector-index-manager.ts",
@@ -23473,7 +23497,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 359
+      "community": 360
     },
     {
       "label": "selectScore()",
@@ -23481,7 +23505,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 359
+      "community": 360
     },
     {
       "label": "computeNormalizationRange()",
@@ -23489,7 +23513,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 359
+      "community": 360
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -23497,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 359
+      "community": 360
     },
     {
       "label": ".normalize()",
@@ -23505,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 359
+      "community": 360
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -23513,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "createMockRepositories()",
@@ -23521,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 666
+      "community": 667
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -23529,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 977
+      "community": 978
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -23537,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "createMockIndexRepository()",
@@ -23545,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 667
+      "community": 668
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -23721,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 978
+      "community": 979
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -23729,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 979
+      "community": 980
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -23737,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 980
+      "community": 981
     },
     {
       "label": "spaced-repetition.ts",
@@ -24065,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 981
+      "community": 982
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -24073,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "ForgettingStatsTool",
@@ -24081,7 +24105,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 420
+      "community": 421
     },
     {
       "label": ".constructor()",
@@ -24089,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 420
+      "community": 421
     },
     {
       "label": ".handle()",
@@ -24097,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 420
+      "community": 421
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -24105,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 982
+      "community": 983
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -24241,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 983
+      "community": 984
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -24249,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 984
+      "community": 985
     },
     {
       "label": "priority-calculation.service.ts",
@@ -25129,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 985
+      "community": 986
     },
     {
       "label": "recall-probability.service.ts",
@@ -25233,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 986
+      "community": 987
     },
     {
       "label": "telemetry.types.ts",
@@ -25241,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 987
+      "community": 988
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -25249,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "openTelemetryDb()",
@@ -25257,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 668
+      "community": 669
     },
     {
       "label": "telemetry-repository.ts",
@@ -25417,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_spec_ts",
-      "community": 360
+      "community": 361
     },
     {
       "label": "makeSearchQuality()",
@@ -25425,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L15",
       "id": "get_telemetry_summary_tool_spec_makesearchquality",
-      "community": 360
+      "community": 361
     },
     {
       "label": "makeMemoryQuality()",
@@ -25433,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L30",
       "id": "get_telemetry_summary_tool_spec_makememoryquality",
-      "community": 360
+      "community": 361
     },
     {
       "label": "makeConsolidationQuality()",
@@ -25441,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L43",
       "id": "get_telemetry_summary_tool_spec_makeconsolidationquality",
-      "community": 360
+      "community": 361
     },
     {
       "label": "makeContext()",
@@ -25449,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.spec.ts",
       "source_location": "L57",
       "id": "get_telemetry_summary_tool_spec_makecontext",
-      "community": 360
+      "community": 361
     },
     {
       "label": "get-telemetry-summary-tool.ts",
@@ -25457,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -25465,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 421
+      "community": 422
     },
     {
       "label": ".constructor()",
@@ -25473,7 +25497,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 421
+      "community": 422
     },
     {
       "label": ".handle()",
@@ -25481,7 +25505,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 421
+      "community": 422
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -25489,7 +25513,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 988
+      "community": 989
     },
     {
       "label": "telemetry-service.ts",
@@ -25617,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 989
+      "community": 990
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -25625,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 990
+      "community": 991
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -25633,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 991
+      "community": 992
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -25641,7 +25665,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -25649,7 +25673,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 669
+      "community": 670
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -25657,7 +25681,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "baseTags()",
@@ -25665,7 +25689,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 422
+      "community": 423
     },
     {
       "label": "pushUnique()",
@@ -25673,7 +25697,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 422
+      "community": 423
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -25681,7 +25705,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 422
+      "community": 423
     },
     {
       "label": "personal-agent-llm-error.ts",
@@ -25689,7 +25713,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "PersonalAgentLlmError",
@@ -25697,7 +25721,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L12",
       "id": "personal_agent_llm_error_personalagentllmerror",
-      "community": 423
+      "community": 424
     },
     {
       "label": ".constructor()",
@@ -25705,7 +25729,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L15",
       "id": "personal_agent_llm_error_personalagentllmerror_constructor",
-      "community": 423
+      "community": 424
     },
     {
       "label": "isPersonalAgentLlmError()",
@@ -25713,7 +25737,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L22",
       "id": "personal_agent_llm_error_ispersonalagentllmerror",
-      "community": 423
+      "community": 424
     },
     {
       "label": "personal-agent-llm-error.spec.ts",
@@ -25721,7 +25745,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 992
+      "community": 993
     },
     {
       "label": "llm-port.ts",
@@ -25729,7 +25753,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 993
+      "community": 994
     },
     {
       "label": "persistence-port.ts",
@@ -25737,7 +25761,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 994
+      "community": 995
     },
     {
       "label": "context-port.ts",
@@ -25745,7 +25769,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 995
+      "community": 996
     },
     {
       "label": "agent-types.ts",
@@ -25753,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 996
+      "community": 997
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -25761,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "readProviderToken()",
@@ -25769,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 517
+      "community": 518
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -25777,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 517
+      "community": 518
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -25785,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 997
+      "community": 998
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -25793,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 998
+      "community": 999
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -25801,7 +25825,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 361
+      "community": 362
     },
     {
       "label": "parseRememberSuccess()",
@@ -25809,7 +25833,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 361
+      "community": 362
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -25817,7 +25841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".constructor()",
@@ -25825,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 361
+      "community": 362
     },
     {
       "label": ".persistApproved()",
@@ -25833,7 +25857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 361
+      "community": 362
     },
     {
       "label": "openai-chat-llm-adapter.ts",
@@ -25841,7 +25865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "OpenAiChatLlmAdapter",
@@ -25849,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "openai_chat_llm_adapter_openaichatllmadapter",
-      "community": 424
+      "community": 425
     },
     {
       "label": ".constructor()",
@@ -25857,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
-      "community": 424
+      "community": 425
     },
     {
       "label": ".complete()",
@@ -25865,7 +25889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_complete",
-      "community": 424
+      "community": 425
     },
     {
       "label": "openai-chat-llm-adapter.spec.ts",
@@ -25873,7 +25897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 999
+      "community": 1000
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -25881,7 +25905,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "OllamaChatLlmAdapter",
@@ -25889,7 +25913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter",
-      "community": 425
+      "community": 426
     },
     {
       "label": ".constructor()",
@@ -25897,7 +25921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
-      "community": 425
+      "community": 426
     },
     {
       "label": ".complete()",
@@ -25905,7 +25929,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L27",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
-      "community": 425
+      "community": 426
     },
     {
       "label": "gemini-chat-llm-adapter.ts",
@@ -25913,7 +25937,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "GeminiChatLlmAdapter",
@@ -25921,7 +25945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter",
-      "community": 426
+      "community": 427
     },
     {
       "label": ".constructor()",
@@ -25929,7 +25953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
-      "community": 426
+      "community": 427
     },
     {
       "label": ".complete()",
@@ -25937,7 +25961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L21",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
-      "community": 426
+      "community": 427
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -25945,7 +25969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 362
+      "community": 363
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -25953,7 +25977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".constructor()",
@@ -25961,7 +25985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".buildContext()",
@@ -25969,7 +25993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 362
+      "community": 363
     },
     {
       "label": ".proposeCandidates()",
@@ -25977,7 +26001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 362
+      "community": 363
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -25985,7 +26009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 363
+      "community": 364
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -25993,7 +26017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".constructor()",
@@ -26001,7 +26025,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".complete()",
@@ -26009,7 +26033,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 363
+      "community": 364
     },
     {
       "label": ".createRequestId()",
@@ -26017,7 +26041,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 363
+      "community": 364
     },
     {
       "label": "gemini-chat-llm-adapter.spec.ts",
@@ -26025,7 +26049,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 1000
+      "community": 1001
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -26033,7 +26057,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 1001
+      "community": 1002
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -26041,7 +26065,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 1002
+      "community": 1003
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -26049,7 +26073,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "baseCandidate()",
@@ -26057,7 +26081,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 670
+      "community": 671
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -26065,7 +26089,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 364
+      "community": 365
     },
     {
       "label": "normalizeOwnerId()",
@@ -26073,7 +26097,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 364
+      "community": 365
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -26081,7 +26105,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 364
+      "community": 365
     },
     {
       "label": "assertUnreachable()",
@@ -26089,7 +26113,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 364
+      "community": 365
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -26097,7 +26121,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 364
+      "community": 365
     },
     {
       "label": "create-personal-agent-llm-port.spec.ts",
@@ -26105,7 +26129,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 1003
+      "community": 1004
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -26113,7 +26137,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "makeDeps()",
@@ -26121,7 +26145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 671
+      "community": 672
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -26129,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 365
+      "community": 366
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -26137,7 +26161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 365
+      "community": 366
     },
     {
       "label": ".constructor()",
@@ -26145,7 +26169,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 365
+      "community": 366
     },
     {
       "label": ".runOneTurn()",
@@ -26153,7 +26177,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 365
+      "community": 366
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -26161,7 +26185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 365
+      "community": 366
     },
     {
       "label": "create-personal-agent-llm-port.ts",
@@ -26169,7 +26193,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -26177,7 +26201,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 672
+      "community": 673
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -26185,7 +26209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -26193,7 +26217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 673
+      "community": 674
     },
     {
       "label": "core-memory-repository.ts",
@@ -26201,7 +26225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 1004
+      "community": 1005
     },
     {
       "label": "kg-triple-repository.ts",
@@ -26209,7 +26233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 1005
+      "community": 1006
     },
     {
       "label": "process-attribute-repository.ts",
@@ -26217,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 1006
+      "community": 1007
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -26225,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 1007
+      "community": 1008
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -26233,7 +26257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 1008
+      "community": 1009
     },
     {
       "label": "feedback-repository.ts",
@@ -26241,7 +26265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -26249,7 +26273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L9",
       "id": "feedback_repository_sigmoidnormalizednet",
-      "community": 518
+      "community": 519
     },
     {
       "label": "FeedbackRepository",
@@ -26257,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.ts",
       "source_location": "L14",
       "id": "feedback_repository_feedbackrepository",
-      "community": 518
+      "community": 519
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -26265,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 1009
+      "community": 1010
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -26273,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 1010
+      "community": 1011
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -26281,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 1011
+      "community": 1012
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -26289,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 1012
+      "community": 1013
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -26297,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 1013
+      "community": 1014
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -26305,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "createKgTripleTable()",
@@ -26313,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 674
+      "community": 675
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -26321,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "createProcessAttributeTable()",
@@ -26329,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 675
+      "community": 676
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -26337,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26345,7 +26369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 676
+      "community": 677
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -26353,7 +26377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 1014
+      "community": 1015
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -26361,7 +26385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "createCoreMemoryTable()",
@@ -26369,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 677
+      "community": 678
     },
     {
       "label": "recall-tool-host.ts",
@@ -26377,7 +26401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 1015
+      "community": 1016
     },
     {
       "label": "recall-tool-definition.ts",
@@ -26385,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 1016
+      "community": 1017
     },
     {
       "label": "remember-tool.ts",
@@ -26473,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "validateRecallQuery()",
@@ -26481,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 519
+      "community": 520
     },
     {
       "label": "validateRecallFilters()",
@@ -26489,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 519
+      "community": 520
     },
     {
       "label": "recall-tool-schema.ts",
@@ -26497,7 +26521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "normalizeProviderFilter()",
@@ -26505,7 +26529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 678
+      "community": 679
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -26513,7 +26537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -26521,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L27",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 427
+      "community": 428
     },
     {
       "label": ".constructor()",
@@ -26529,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L28",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 427
+      "community": 428
     },
     {
       "label": ".handle()",
@@ -26537,7 +26561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L81",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 427
+      "community": 428
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -26545,7 +26569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -26553,7 +26577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 428
+      "community": 429
     },
     {
       "label": ".constructor()",
@@ -26561,7 +26585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 428
+      "community": 429
     },
     {
       "label": ".handle()",
@@ -26569,7 +26593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 428
+      "community": 429
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -26577,7 +26601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "ProceduralRollbackTool",
@@ -26585,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 429
+      "community": 430
     },
     {
       "label": ".constructor()",
@@ -26593,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 429
+      "community": 430
     },
     {
       "label": ".handle()",
@@ -26601,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 429
+      "community": 430
     },
     {
       "label": "feedback-tool.ts",
@@ -26665,7 +26689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "CleanupMemoryTool",
@@ -26673,7 +26697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 430
+      "community": 431
     },
     {
       "label": ".constructor()",
@@ -26681,7 +26705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 430
+      "community": 431
     },
     {
       "label": ".handle()",
@@ -26689,7 +26713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 430
+      "community": 431
     },
     {
       "label": "recall-tool-filters.ts",
@@ -26697,7 +26721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -26705,7 +26729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 520
+      "community": 521
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -26713,7 +26737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 520
+      "community": 521
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -26817,7 +26841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -26825,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 679
+      "community": 680
     },
     {
       "label": "pin-tool.ts",
@@ -26993,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_neighbors_fetch_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -27001,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L16",
       "id": "recall_tool_neighbors_fetch_handleincludeneighbors",
-      "community": 680
+      "community": 681
     },
     {
       "label": "recall-tool-anchor-rotation.ts",
@@ -27009,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_anchor_rotation_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -27017,7 +27041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L12",
       "id": "recall_tool_anchor_rotation_handleautosetanchor",
-      "community": 681
+      "community": 682
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -27025,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "ProceduralDiffTool",
@@ -27033,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 431
+      "community": 432
     },
     {
       "label": ".constructor()",
@@ -27041,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 431
+      "community": 432
     },
     {
       "label": ".handle()",
@@ -27049,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 431
+      "community": 432
     },
     {
       "label": "recall-tool-direct.ts",
@@ -27057,7 +27081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_direct_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "recallCoreMemoryDirect()",
@@ -27065,7 +27089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L13",
       "id": "recall_tool_direct_recallcorememorydirect",
-      "community": 521
+      "community": 522
     },
     {
       "label": "recallVaultMemoryDirect()",
@@ -27073,7 +27097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L67",
       "id": "recall_tool_direct_recallvaultmemorydirect",
-      "community": 521
+      "community": 522
     },
     {
       "label": "unpin-tool.ts",
@@ -27193,7 +27217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -27201,7 +27225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 432
+      "community": 433
     },
     {
       "label": ".constructor()",
@@ -27209,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 432
+      "community": 433
     },
     {
       "label": ".handle()",
@@ -27217,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 432
+      "community": 433
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -27225,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "RememberProcedureTool",
@@ -27233,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 433
+      "community": 434
     },
     {
       "label": ".constructor()",
@@ -27241,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 433
+      "community": 434
     },
     {
       "label": ".handle()",
@@ -27249,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 433
+      "community": 434
     },
     {
       "label": "recall-tool-envelope.ts",
@@ -27257,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "getMetaStatsForResults()",
@@ -27265,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L33",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 522
+      "community": 523
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -27273,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L77",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 522
+      "community": 523
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -27281,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 366
+      "community": 367
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -27289,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 366
+      "community": 367
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -27297,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 366
+      "community": 367
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -27305,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 366
+      "community": 367
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -27313,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 366
+      "community": 367
     },
     {
       "label": "recall-tool-results.ts",
@@ -27321,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -27329,7 +27353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 682
+      "community": 683
     },
     {
       "label": "recall-tool.ts",
@@ -27337,7 +27361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_ts",
-      "community": 367
+      "community": 368
     },
     {
       "label": "RecallTool",
@@ -27345,7 +27369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L36",
       "id": "recall_tool_recalltool",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".constructor()",
@@ -27353,7 +27377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L37",
       "id": "recall_tool_recalltool_constructor",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".host()",
@@ -27361,7 +27385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L42",
       "id": "recall_tool_recalltool_host",
-      "community": 367
+      "community": 368
     },
     {
       "label": ".handle()",
@@ -27369,7 +27393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool.ts",
       "source_location": "L52",
       "id": "recall_tool_recalltool_handle",
-      "community": 367
+      "community": 368
     },
     {
       "label": "recall-tool-types.ts",
@@ -27377,7 +27401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 1017
+      "community": 1018
     },
     {
       "label": "forget-tool.ts",
@@ -27521,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "createSchema()",
@@ -27529,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 683
+      "community": 684
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -27537,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 1018
+      "community": 1019
     },
     {
       "label": "remember-tool.spec.ts",
@@ -27545,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "initializeTestDatabase()",
@@ -27553,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 523
+      "community": 524
     },
     {
       "label": "createValidReflectionNote()",
@@ -27561,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L826",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 523
+      "community": 524
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -27569,7 +27593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 1019
+      "community": 1020
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -27577,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "createSchema()",
@@ -27585,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 684
+      "community": 685
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -27593,7 +27617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "generateId()",
@@ -27601,7 +27625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 434
+      "community": 435
     },
     {
       "label": "initializeTestDatabase()",
@@ -27609,7 +27633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 434
+      "community": 435
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -27617,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 434
+      "community": 435
     },
     {
       "label": "forget-tool.spec.ts",
@@ -27625,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 1020
+      "community": 1021
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -27633,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 1021
+      "community": 1022
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -27641,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "initializeTestDatabase()",
@@ -27649,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 685
+      "community": 686
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -27657,7 +27681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "parseData()",
@@ -27665,7 +27689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 686
+      "community": 687
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -27673,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 1022
+      "community": 1023
     },
     {
       "label": "recall-tool.spec.ts",
@@ -27681,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "initializeTestDatabase()",
@@ -27689,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 524
+      "community": 525
     },
     {
       "label": "createValidReflectionNote()",
@@ -27697,7 +27721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1427",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 524
+      "community": 525
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -27705,7 +27729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1023
+      "community": 1024
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -27713,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1024
+      "community": 1025
     },
     {
       "label": "pin-tool.spec.ts",
@@ -27721,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1025
+      "community": 1026
     },
     {
       "label": "meta-memory-service.ts",
@@ -27849,7 +27873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "fieldDiff()",
@@ -27857,7 +27881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 435
+      "community": 436
     },
     {
       "label": "parseStepsJson()",
@@ -27865,7 +27889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 435
+      "community": 436
     },
     {
       "label": "computeProceduralDiff()",
@@ -27873,7 +27897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 435
+      "community": 436
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -27881,7 +27905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 368
+      "community": 369
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -27889,7 +27913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".constructor()",
@@ -27897,7 +27921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".notFound()",
@@ -27905,7 +27929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 368
+      "community": 369
     },
     {
       "label": ".notActionable()",
@@ -27913,7 +27937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 368
+      "community": 369
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -27921,31 +27945,47 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
-      "community": 436
+      "community": 313
     },
     {
       "label": "parseImportanceThreshold()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L7",
+      "source_location": "L12",
       "id": "memory_review_candidate_selection_env_parseimportancethreshold",
-      "community": 436
+      "community": 313
     },
     {
       "label": "parsePositiveInt()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L18",
+      "source_location": "L23",
       "id": "memory_review_candidate_selection_env_parsepositiveint",
-      "community": 436
+      "community": 313
+    },
+    {
+      "label": "parseNonNegativeInt()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
+      "source_location": "L34",
+      "id": "memory_review_candidate_selection_env_parsenonnegativeint",
+      "community": 313
     },
     {
       "label": "parseMemoryReviewSelectionEnv()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L29",
+      "source_location": "L45",
       "id": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
-      "community": 436
+      "community": 313
+    },
+    {
+      "label": "parseMemoryReviewQueueControlEnv()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
+      "source_location": "L53",
+      "id": "memory_review_candidate_selection_env_parsememoryreviewqueuecontrolenv",
+      "community": 313
     },
     {
       "label": "memory-review-candidate-persistence-service.spec.ts",
@@ -27953,15 +27993,15 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "createBaseSchema()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
-      "source_location": "L22",
+      "source_location": "L23",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 687
+      "community": 688
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -27969,7 +28009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_llm_extractor_ts",
-      "community": 191
+      "community": 192
     },
     {
       "label": "LlmProceduralExtractor",
@@ -27977,7 +28017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L32",
       "id": "procedural_llm_extractor_llmproceduralextractor",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".constructor()",
@@ -27985,7 +28025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L38",
       "id": "procedural_llm_extractor_llmproceduralextractor_constructor",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".extract()",
@@ -27993,7 +28033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L48",
       "id": "procedural_llm_extractor_llmproceduralextractor_extract",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".buildMessages()",
@@ -28001,7 +28041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L69",
       "id": "procedural_llm_extractor_llmproceduralextractor_buildmessages",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".callLLM()",
@@ -28009,7 +28049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L84",
       "id": "procedural_llm_extractor_llmproceduralextractor_callllm",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".callOpenAI()",
@@ -28017,7 +28057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L103",
       "id": "procedural_llm_extractor_llmproceduralextractor_callopenai",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".callGemini()",
@@ -28025,7 +28065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L133",
       "id": "procedural_llm_extractor_llmproceduralextractor_callgemini",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".parseResponse()",
@@ -28033,7 +28073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-llm-extractor.ts",
       "source_location": "L172",
       "id": "procedural_llm_extractor_llmproceduralextractor_parseresponse",
-      "community": 191
+      "community": 192
     },
     {
       "label": "memory-review-candidate-selection-scoring.spec.ts",
@@ -28041,7 +28081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "baseRow()",
@@ -28049,7 +28089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 688
+      "community": 689
     },
     {
       "label": "procedural-versioning.ts",
@@ -28089,7 +28129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -28097,7 +28137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 525
+      "community": 526
     },
     {
       "label": ".runScan()",
@@ -28105,7 +28145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 525
+      "community": 526
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -28113,7 +28153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "generateMemoryId()",
@@ -28121,7 +28161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 526
+      "community": 527
     },
     {
       "label": "rollbackToVersion()",
@@ -28129,7 +28169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 526
+      "community": 527
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -28201,7 +28241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "selectionWindowLimit()",
@@ -28209,7 +28249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 527
+      "community": 528
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -28217,7 +28257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 527
+      "community": 528
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -28225,7 +28265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 369
+      "community": 370
     },
     {
       "label": "IntrospectionScanCache",
@@ -28233,7 +28273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".set()",
@@ -28241,7 +28281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".get()",
@@ -28249,7 +28289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 369
+      "community": 370
     },
     {
       "label": ".clear()",
@@ -28257,7 +28297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 369
+      "community": 370
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -28265,7 +28305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1026
+      "community": 1027
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -28273,7 +28313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -28281,7 +28321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 689
+      "community": 690
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -28289,7 +28329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "openDb()",
@@ -28297,7 +28337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 690
+      "community": 691
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -28585,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
-      "community": 192
+      "community": 156
     },
     {
       "label": "upsertPendingMemoryReviewCandidates()",
@@ -28593,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L15",
       "id": "memory_review_candidate_persistence_service_upsertpendingmemoryreviewcandidates",
-      "community": 192
+      "community": 156
     },
     {
       "label": "mapRow()",
@@ -28601,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L77",
       "id": "memory_review_candidate_persistence_service_maprow",
-      "community": 192
+      "community": 156
     },
     {
       "label": "getMemoryReviewCandidateById()",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L93",
       "id": "memory_review_candidate_persistence_service_getmemoryreviewcandidatebyid",
-      "community": 192
+      "community": 156
     },
     {
       "label": "listMemoryReviewCandidates()",
@@ -28617,39 +28657,47 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
       "source_location": "L104",
       "id": "memory_review_candidate_persistence_service_listmemoryreviewcandidates",
-      "community": 192
+      "community": 156
+    },
+    {
+      "label": "countPendingMemoryReviewCandidates()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
+      "source_location": "L125",
+      "id": "memory_review_candidate_persistence_service_countpendingmemoryreviewcandidates",
+      "community": 156
     },
     {
       "label": "markMemoryReviewCandidateReviewed()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L125",
+      "source_location": "L136",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidatereviewed",
-      "community": 192
+      "community": 156
     },
     {
       "label": "markMemoryReviewCandidateDismissed()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L160",
+      "source_location": "L171",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidatedismissed",
-      "community": 192
+      "community": 156
     },
     {
       "label": "markMemoryReviewCandidateExpired()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L188",
+      "source_location": "L199",
       "id": "memory_review_candidate_persistence_service_markmemoryreviewcandidateexpired",
-      "community": 192
+      "community": 156
     },
     {
       "label": "bulkUpdatePendingMemoryReviewCandidates()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L216",
+      "source_location": "L227",
       "id": "memory_review_candidate_persistence_service_bulkupdatependingmemoryreviewcandidates",
-      "community": 192
+      "community": 156
     },
     {
       "label": "memory-review-queue-health-service.ts",
@@ -28897,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "createBaseSchema()",
@@ -28905,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 691
+      "community": 692
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -29169,7 +29217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1027
+      "community": 1028
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -29177,7 +29225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -29185,7 +29233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 528
+      "community": 529
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -29193,7 +29241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 528
+      "community": 529
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -29201,7 +29249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1028
+      "community": 1029
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -29209,7 +29257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1029
+      "community": 1030
     },
     {
       "label": "core-memory-service.ts",
@@ -29369,7 +29417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "createBaseSchema()",
@@ -29377,7 +29425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 692
+      "community": 693
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -29385,7 +29433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -29393,7 +29441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 693
+      "community": 694
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -29473,7 +29521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1030
+      "community": 1031
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -29481,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1031
+      "community": 1032
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -29489,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "createSchema()",
@@ -29497,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 694
+      "community": 695
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -29505,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1032
+      "community": 1033
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -29513,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "createSchema()",
@@ -29521,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 695
+      "community": 696
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -29529,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1033
+      "community": 1034
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -29537,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -29545,7 +29593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 696
+      "community": 697
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -29553,7 +29601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1034
+      "community": 1035
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -29561,7 +29609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "createSchema()",
@@ -29569,7 +29617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 697
+      "community": 698
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -29577,7 +29625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1035
+      "community": 1036
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -29585,7 +29633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1036
+      "community": 1037
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -29705,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1037
+      "community": 1038
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -29969,7 +30017,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1038
+      "community": 1039
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -29977,7 +30025,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -29985,7 +30033,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 698
+      "community": 699
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -29993,7 +30041,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1039
+      "community": 1040
     },
     {
       "label": "consolidation-repository.ts",
@@ -30001,7 +30049,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_ts",
-      "community": 156
+      "community": 157
     },
     {
       "label": "ConsolidationRepository",
@@ -30009,7 +30057,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L25",
       "id": "consolidation_repository_consolidationrepository",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".constructor()",
@@ -30017,7 +30065,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L26",
       "id": "consolidation_repository_consolidationrepository_constructor",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".getLookbackDays()",
@@ -30025,7 +30073,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L28",
       "id": "consolidation_repository_consolidationrepository_getlookbackdays",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".findEpisodicCandidates()",
@@ -30033,7 +30081,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L37",
       "id": "consolidation_repository_consolidationrepository_findepisodiccandidates",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".findSemanticsByOwner()",
@@ -30041,7 +30089,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L87",
       "id": "consolidation_repository_consolidationrepository_findsemanticsbyowner",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".updateSemanticMemory()",
@@ -30049,7 +30097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L103",
       "id": "consolidation_repository_consolidationrepository_updatesemanticmemory",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".loadEmbeddingsMap()",
@@ -30057,7 +30105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L118",
       "id": "consolidation_repository_consolidationrepository_loadembeddingsmap",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".insertSemanticMemory()",
@@ -30065,7 +30113,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L151",
       "id": "consolidation_repository_consolidationrepository_insertsemanticmemory",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".markEpisodicsConsolidated()",
@@ -30073,7 +30121,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L177",
       "id": "consolidation_repository_consolidationrepository_markepisodicsconsolidated",
-      "community": 156
+      "community": 157
     },
     {
       "label": "sleep-consolidation-service.ts",
@@ -30225,7 +30273,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "row()",
@@ -30233,7 +30281,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 699
+      "community": 700
     },
     {
       "label": "summarization-service.ts",
@@ -30241,7 +30289,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "SummarizationService",
@@ -30249,7 +30297,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L17",
       "id": "summarization_service_summarizationservice",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".hasLlmConfigured()",
@@ -30257,7 +30305,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L18",
       "id": "summarization_service_summarizationservice_hasllmconfigured",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".extractiveFallback()",
@@ -30265,7 +30313,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L24",
       "id": "summarization_service_summarizationservice_extractivefallback",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".summarizeCluster()",
@@ -30273,7 +30321,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L37",
       "id": "summarization_service_summarizationservice_summarizecluster",
-      "community": 313
+      "community": 314
     },
     {
       "label": ".summarizeMergeForConsolidation()",
@@ -30281,7 +30329,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.ts",
       "source_location": "L119",
       "id": "summarization_service_summarizationservice_summarizemergeforconsolidation",
-      "community": 313
+      "community": 314
     },
     {
       "label": "sleep-consolidation-service.spec.ts",
@@ -30289,7 +30337,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 370
+      "community": 371
     },
     {
       "label": "insertEpisodic()",
@@ -30297,7 +30345,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 370
+      "community": 371
     },
     {
       "label": "insertEmbedding()",
@@ -30305,7 +30353,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 370
+      "community": 371
     },
     {
       "label": "FailingRepo",
@@ -30313,7 +30361,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 370
+      "community": 371
     },
     {
       "label": ".insertSemanticMemory()",
@@ -30321,7 +30369,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 370
+      "community": 371
     },
     {
       "label": "clustering-service.spec.ts",
@@ -30329,7 +30377,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "ep()",
@@ -30337,7 +30385,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 700
+      "community": 701
     },
     {
       "label": "relation-graph.port.ts",
@@ -30345,7 +30393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1040
+      "community": 1041
     },
     {
       "label": "get-relations-tool.ts",
@@ -30385,7 +30433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -30393,7 +30441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 701
+      "community": 702
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -30529,7 +30577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_ts",
-      "community": 314
+      "community": 315
     },
     {
       "label": "resolveExtractTriplesOwner()",
@@ -30537,7 +30585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L37",
       "id": "extract_triples_tool_resolveextracttriplesowner",
-      "community": 314
+      "community": 315
     },
     {
       "label": "normalizeChunkOverlapForPipeline()",
@@ -30545,7 +30593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L42",
       "id": "extract_triples_tool_normalizechunkoverlapforpipeline",
-      "community": 314
+      "community": 315
     },
     {
       "label": "ExtractTriplesTool",
@@ -30553,7 +30601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L52",
       "id": "extract_triples_tool_extracttriplestool",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".constructor()",
@@ -30561,7 +30609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L53",
       "id": "extract_triples_tool_extracttriplestool_constructor",
-      "community": 314
+      "community": 315
     },
     {
       "label": ".handle()",
@@ -30569,7 +30617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L84",
       "id": "extract_triples_tool_extracttriplestool_handle",
-      "community": 314
+      "community": 315
     },
     {
       "label": "get-relations-tool.spec.ts",
@@ -30577,7 +30625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createBaseSchema()",
@@ -30585,7 +30633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createTestMemory()",
@@ -30593,7 +30641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 529
+      "community": 530
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -30601,7 +30649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createBaseSchema()",
@@ -30609,7 +30657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createTestMemory()",
@@ -30617,7 +30665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 530
+      "community": 531
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -30625,7 +30673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createBaseSchema()",
@@ -30633,7 +30681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 531
+      "community": 532
     },
     {
       "label": "createTestMemory()",
@@ -30641,7 +30689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 531
+      "community": 532
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -30649,7 +30697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1041
+      "community": 1042
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -30657,7 +30705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createBaseSchema()",
@@ -30665,7 +30713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 532
+      "community": 533
     },
     {
       "label": "createTestMemory()",
@@ -30673,7 +30721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 532
+      "community": 533
     },
     {
       "label": "relation-retry-manager.ts",
@@ -31489,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1042
+      "community": 1043
     },
     {
       "label": "relation-graph.spec.ts",
@@ -31497,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createBaseSchema()",
@@ -31505,7 +31553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 533
+      "community": 534
     },
     {
       "label": "createTestMemory()",
@@ -31513,7 +31561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 533
+      "community": 534
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -31521,7 +31569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "createTestMemory()",
@@ -31529,7 +31577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 702
+      "community": 703
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -31569,7 +31617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "createTestMemory()",
@@ -31577,7 +31625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 703
+      "community": 704
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -31641,7 +31689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1043
+      "community": 1044
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -31649,7 +31697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1044
+      "community": 1045
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -31657,7 +31705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "getMockMementoConfig()",
@@ -31665,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 534
+      "community": 535
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -31673,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 534
+      "community": 535
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -31681,7 +31729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1045
+      "community": 1046
     },
     {
       "label": "provider-openai.spec.ts",
@@ -31689,7 +31737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1046
+      "community": 1047
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -31697,7 +31745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1047
+      "community": 1048
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -31705,7 +31753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1048
+      "community": 1049
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -31713,7 +31761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 371
+      "community": 372
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -31721,7 +31769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".constructor()",
@@ -31729,7 +31777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".consume()",
@@ -31737,7 +31785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 371
+      "community": 372
     },
     {
       "label": ".refill()",
@@ -31745,7 +31793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 371
+      "community": 372
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -31785,7 +31833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "chunkSucceeded()",
@@ -31793,7 +31841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L20",
       "id": "triple_pipeline_orchestrator_chunksucceeded",
-      "community": 315
+      "community": 316
     },
     {
       "label": "failureMessageFromResult()",
@@ -31801,7 +31849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L27",
       "id": "triple_pipeline_orchestrator_failuremessagefromresult",
-      "community": 315
+      "community": 316
     },
     {
       "label": "TriplePipelineOrchestrator",
@@ -31809,7 +31857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L35",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".constructor()",
@@ -31817,7 +31865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L36",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_constructor",
-      "community": 315
+      "community": 316
     },
     {
       "label": ".run()",
@@ -31825,7 +31873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.ts",
       "source_location": "L40",
       "id": "triple_pipeline_orchestrator_triplepipelineorchestrator_run",
-      "community": 315
+      "community": 316
     },
     {
       "label": "triple-extraction-statistics.ts",
@@ -32025,7 +32073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "extract()",
@@ -32033,7 +32081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 704
+      "community": 705
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -32041,7 +32089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "tripleDedupeKey()",
@@ -32049,7 +32097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 535
+      "community": 536
     },
     {
       "label": "mergeTripleLists()",
@@ -32057,7 +32105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 535
+      "community": 536
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -32065,7 +32113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1049
+      "community": 1050
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -32073,7 +32121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 372
+      "community": 373
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -32081,7 +32129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 372
+      "community": 373
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -32089,7 +32137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L38",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 372
+      "community": 373
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -32097,7 +32145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L71",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 372
+      "community": 373
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -32105,7 +32153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L105",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 372
+      "community": 373
     },
     {
       "label": "triple-extraction-service.ts",
@@ -32249,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1050
+      "community": 1051
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -32257,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1051
+      "community": 1052
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -32265,7 +32313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1052
+      "community": 1053
     },
     {
       "label": "triple-extractor.ts",
@@ -32441,7 +32489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1053
+      "community": 1054
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -32481,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1054
+      "community": 1055
     },
     {
       "label": "triple-parser.ts",
@@ -32489,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 373
+      "community": 374
     },
     {
       "label": "TripleParser",
@@ -32497,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".parse()",
@@ -32505,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".extractJSON()",
@@ -32513,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 373
+      "community": 374
     },
     {
       "label": ".isValidTriple()",
@@ -32521,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 373
+      "community": 374
     },
     {
       "label": "triple-text-chunker.ts",
@@ -32529,7 +32577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "splitTextIntoChunks()",
@@ -32537,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 705
+      "community": 706
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -32545,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -32553,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 706
+      "community": 707
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -32561,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_ts",
-      "community": 157
+      "community": 158
     },
     {
       "label": "PredicateCanonicalizer",
@@ -32569,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L95",
       "id": "predicate_canonicalizer_predicatecanonicalizer",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".constructor()",
@@ -32577,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L99",
       "id": "predicate_canonicalizer_predicatecanonicalizer_constructor",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".buildReverseIndex()",
@@ -32585,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L107",
       "id": "predicate_canonicalizer_predicatecanonicalizer_buildreverseindex",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".normalizeKey()",
@@ -32593,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L125",
       "id": "predicate_canonicalizer_predicatecanonicalizer_normalizekey",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".canonicalize()",
@@ -32601,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L135",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalize",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".canonicalizeBatch()",
@@ -32609,7 +32657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L177",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalizebatch",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".addPredicate()",
@@ -32617,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L187",
       "id": "predicate_canonicalizer_predicatecanonicalizer_addpredicate",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".getDictionary()",
@@ -32625,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L206",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getdictionary",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".getCanonicalPredicates()",
@@ -32633,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L213",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getcanonicalpredicates",
-      "community": 157
+      "community": 158
     },
     {
       "label": "entity-linker.spec.ts",
@@ -32641,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1055
+      "community": 1056
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -32649,7 +32697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1056
+      "community": 1057
     },
     {
       "label": "interfaces.spec.ts",
@@ -32657,7 +32705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1057
+      "community": 1058
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -32665,7 +32713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1058
+      "community": 1059
     },
     {
       "label": "triple-parser.spec.ts",
@@ -32673,7 +32721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1059
+      "community": 1060
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -32681,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -32689,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 707
+      "community": 708
     },
     {
       "label": "extract-relations-openai.ts",
@@ -32697,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -32705,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 708
+      "community": 709
     },
     {
       "label": "types.ts",
@@ -32713,7 +32761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1060
+      "community": 1061
     },
     {
       "label": "ollama-chat-support.ts",
@@ -32753,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -32761,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 709
+      "community": 710
     },
     {
       "label": "provider-selection.ts",
@@ -32769,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -32777,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 536
+      "community": 537
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -32785,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 536
+      "community": 537
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -32793,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -32801,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 710
+      "community": 711
     },
     {
       "label": "llm-response-parse.ts",
@@ -32809,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 374
+      "community": 375
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -32817,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 374
+      "community": 375
     },
     {
       "label": "trimToValidJsonObject()",
@@ -32825,7 +32873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 374
+      "community": 375
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -32833,7 +32881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 374
+      "community": 375
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -32841,7 +32889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 374
+      "community": 375
     },
     {
       "label": "types.ts",
@@ -32849,7 +32897,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1061
+      "community": 1062
     },
     {
       "label": "agent-integration-repository.ts",
@@ -32857,7 +32905,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1062
+      "community": 1063
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -32865,7 +32913,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "candidate()",
@@ -32873,7 +32921,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 537
+      "community": 538
     },
     {
       "label": "source()",
@@ -32881,7 +32929,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 537
+      "community": 538
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -32889,7 +32937,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1063
+      "community": 1064
     },
     {
       "label": "agent-integration-error.ts",
@@ -32897,7 +32945,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "AgentIntegrationError",
@@ -32905,7 +32953,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 538
+      "community": 539
     },
     {
       "label": ".constructor()",
@@ -32913,7 +32961,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 538
+      "community": 539
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -32921,7 +32969,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1064
+      "community": 1065
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -32929,7 +32977,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "createSession()",
@@ -32937,7 +32985,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 539
+      "community": 540
     },
     {
       "label": "addObservation()",
@@ -32945,7 +32993,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 539
+      "community": 540
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -33409,7 +33457,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_provenance_graph_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "buildProvenanceTrace()",
@@ -33417,7 +33465,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L10",
       "id": "agent_provenance_graph_buildprovenancetrace",
-      "community": 711
+      "community": 712
     },
     {
       "label": "agent-context-injection-service.spec.ts",
@@ -33425,7 +33473,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1065
+      "community": 1066
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -33433,7 +33481,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_ts",
-      "community": 158
+      "community": 159
     },
     {
       "label": "SqliteHybridAgentContextSource",
@@ -33441,7 +33489,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L20",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".constructor()",
@@ -33449,7 +33497,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L25",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_constructor",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".recall()",
@@ -33457,7 +33505,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L30",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_recall",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".loadMemoryRows()",
@@ -33465,7 +33513,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L94",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_loadmemoryrows",
-      "community": 158
+      "community": 159
     },
     {
       "label": "scopeSearchFilters()",
@@ -33473,7 +33521,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L125",
       "id": "sqlite_hybrid_agent_context_source_scopesearchfilters",
-      "community": 158
+      "community": 159
     },
     {
       "label": "asMemoryType()",
@@ -33481,7 +33529,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L151",
       "id": "sqlite_hybrid_agent_context_source_asmemorytype",
-      "community": 158
+      "community": 159
     },
     {
       "label": "asPrivacyScope()",
@@ -33489,7 +33537,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L160",
       "id": "sqlite_hybrid_agent_context_source_asprivacyscope",
-      "community": 158
+      "community": 159
     },
     {
       "label": "clampConfidence()",
@@ -33497,7 +33545,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L166",
       "id": "sqlite_hybrid_agent_context_source_clampconfidence",
-      "community": 158
+      "community": 159
     },
     {
       "label": "parseTags()",
@@ -33505,7 +33553,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L173",
       "id": "sqlite_hybrid_agent_context_source_parsetags",
-      "community": 158
+      "community": 159
     },
     {
       "label": "agent-memory-promotion-service.spec.ts",
@@ -33513,7 +33561,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "addObservation()",
@@ -33521,7 +33569,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 540
+      "community": 541
     },
     {
       "label": "finishAndSummarize()",
@@ -33529,7 +33577,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 540
+      "community": 541
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -33537,7 +33585,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_capture_transaction_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "executeAgentCaptureTransaction()",
@@ -33545,7 +33593,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L21",
       "id": "agent_capture_transaction_executeagentcapturetransaction",
-      "community": 712
+      "community": 713
     },
     {
       "label": "agent-lifecycle-service.ts",
@@ -33953,7 +34001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1066
+      "community": 1067
     },
     {
       "label": "embedding-service.ts",
@@ -35065,7 +35113,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1067
+      "community": 1068
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -35073,7 +35121,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1068
+      "community": 1069
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -35081,7 +35129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "createSchema()",
@@ -35089,7 +35137,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 541
+      "community": 542
     },
     {
       "label": "seedMemoryItem()",
@@ -35097,7 +35145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 541
+      "community": 542
     },
     {
       "label": "embedding-service.spec.ts",
@@ -35105,7 +35153,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 1069
+      "community": 1070
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -35113,7 +35161,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1070
+      "community": 1071
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -35121,7 +35169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1071
+      "community": 1072
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -35161,7 +35209,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_alerts_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "executePerformanceAlerts()",
@@ -35169,7 +35217,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L66",
       "id": "performance_alerts_executeperformancealerts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "handleStats()",
@@ -35177,7 +35225,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L113",
       "id": "performance_alerts_handlestats",
-      "community": 316
+      "community": 317
     },
     {
       "label": "handleList()",
@@ -35185,7 +35233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L145",
       "id": "performance_alerts_handlelist",
-      "community": 316
+      "community": 317
     },
     {
       "label": "handleSearch()",
@@ -35193,7 +35241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L183",
       "id": "performance_alerts_handlesearch",
-      "community": 316
+      "community": 317
     },
     {
       "label": "handleResolve()",
@@ -35201,7 +35249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts",
       "source_location": "L208",
       "id": "performance_alerts_handleresolve",
-      "community": 316
+      "community": 317
     },
     {
       "label": "performance-stats-tool.ts",
@@ -35241,7 +35289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "executeResolveError()",
@@ -35249,7 +35297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 713
+      "community": 714
     },
     {
       "label": "error-stats.ts",
@@ -35257,7 +35305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "executeErrorStats()",
@@ -35265,7 +35313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 714
+      "community": 715
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -35273,7 +35321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1072
+      "community": 1073
     },
     {
       "label": "resolve-error.spec.ts",
@@ -35281,7 +35329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1073
+      "community": 1074
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -35289,7 +35337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "createBaseSchema()",
@@ -35297,7 +35345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 715
+      "community": 716
     },
     {
       "label": "error-stats.spec.ts",
@@ -35305,7 +35353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1074
+      "community": 1075
     },
     {
       "label": "performance-monitor.ts",
@@ -36049,7 +36097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_runtime_diagnostics_logger_ts",
-      "community": 317
+      "community": 318
     },
     {
       "label": "RuntimeDiagnosticsLogger",
@@ -36057,7 +36105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L5",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".constructor()",
@@ -36065,7 +36113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_constructor",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".writeSample()",
@@ -36073,7 +36121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L13",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writesample",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".writeEvent()",
@@ -36081,7 +36129,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L21",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_writeevent",
-      "community": 317
+      "community": 318
     },
     {
       "label": ".appendJsonl()",
@@ -36089,7 +36137,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/runtime-diagnostics-logger.ts",
       "source_location": "L29",
       "id": "runtime_diagnostics_logger_runtimediagnosticslogger_appendjsonl",
-      "community": 317
+      "community": 318
     },
     {
       "label": "error-logging-service.ts",
@@ -36217,7 +36265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1075
+      "community": 1076
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -36225,7 +36273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1076
+      "community": 1077
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -36233,7 +36281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1077
+      "community": 1078
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -36241,7 +36289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1078
+      "community": 1079
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -36249,7 +36297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 375
+      "community": 376
     },
     {
       "label": "toBytes()",
@@ -36257,7 +36305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 375
+      "community": 376
     },
     {
       "label": "createMetrics()",
@@ -36265,7 +36313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 375
+      "community": 376
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -36273,7 +36321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 375
+      "community": 376
     },
     {
       "label": "makeMonitor()",
@@ -36281,7 +36329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 375
+      "community": 376
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -36289,7 +36337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "restoreEnvValue()",
@@ -36297,7 +36345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 716
+      "community": 717
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -36401,7 +36449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -36409,7 +36457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 717
+      "community": 718
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -36489,7 +36537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -36497,7 +36545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 718
+      "community": 719
     },
     {
       "label": "quality-reporter.ts",
@@ -36505,7 +36553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_ts",
-      "community": 159
+      "community": 160
     },
     {
       "label": "escapeHtml()",
@@ -36513,7 +36561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L24",
       "id": "quality_reporter_escapehtml",
-      "community": 159
+      "community": 160
     },
     {
       "label": "QualityReporter",
@@ -36521,7 +36569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L175",
       "id": "quality_reporter_qualityreporter",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".constructor()",
@@ -36529,7 +36577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L179",
       "id": "quality_reporter_qualityreporter_constructor",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".collectReportData()",
@@ -36537,7 +36585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L193",
       "id": "quality_reporter_qualityreporter_collectreportdata",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".generateMarkdownReport()",
@@ -36545,7 +36593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L354",
       "id": "quality_reporter_qualityreporter_generatemarkdownreport",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".generateJsonReport()",
@@ -36553,7 +36601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L435",
       "id": "quality_reporter_qualityreporter_generatejsonreport",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".generateHtmlReport()",
@@ -36561,7 +36609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L445",
       "id": "quality_reporter_qualityreporter_generatehtmlreport",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".generateReport()",
@@ -36569,7 +36617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L731",
       "id": "quality_reporter_qualityreporter_generatereport",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".saveReportToFile()",
@@ -36577,7 +36625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L765",
       "id": "quality_reporter_qualityreporter_savereporttofile",
-      "community": 159
+      "community": 160
     },
     {
       "label": "quality-reporter.spec.ts",
@@ -36617,7 +36665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1079
+      "community": 1080
     },
     {
       "label": "quality-assurance-service.ts",
@@ -36929,7 +36977,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_migrate_embeddings_tool_ts",
-      "community": 318
+      "community": 319
     },
     {
       "label": "MigrateEmbeddingsTool",
@@ -36937,7 +36985,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L38",
       "id": "migrate_embeddings_tool_migrateembeddingstool",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".constructor()",
@@ -36945,7 +36993,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L42",
       "id": "migrate_embeddings_tool_migrateembeddingstool_constructor",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".loadVecExtension()",
@@ -36953,7 +37001,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L82",
       "id": "migrate_embeddings_tool_migrateembeddingstool_loadvecextension",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".createAndStoreEmbeddingForProvider()",
@@ -36961,7 +37009,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L95",
       "id": "migrate_embeddings_tool_migrateembeddingstool_createandstoreembeddingforprovider",
-      "community": 318
+      "community": 319
     },
     {
       "label": ".handle()",
@@ -36969,7 +37017,7 @@
       "source_file": "packages/memento-core/src/tools/migrate-embeddings-tool.ts",
       "source_location": "L183",
       "id": "migrate_embeddings_tool_migrateembeddingstool_handle",
-      "community": 318
+      "community": 319
     },
     {
       "label": "tool-registry.ts",
@@ -37113,7 +37161,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1080
+      "community": 1081
     },
     {
       "label": "base-tool.ts",
@@ -37409,7 +37457,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "testBootstrapIntegration()",
@@ -37417,7 +37465,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 719
+      "community": 720
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -37425,7 +37473,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "measureRecall()",
@@ -37433,7 +37481,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 720
+      "community": 721
     },
     {
       "label": "test-embedding.ts",
@@ -37441,7 +37489,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -37449,7 +37497,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 721
+      "community": 722
     },
     {
       "label": "test-tool-consistency.ts",
@@ -37457,7 +37505,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "compareToolResults()",
@@ -37465,7 +37513,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 542
+      "community": 543
     },
     {
       "label": "testToolConsistency()",
@@ -37473,7 +37521,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 542
+      "community": 543
     },
     {
       "label": "test-quality-assurance.ts",
@@ -37481,7 +37529,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "createQualityTables()",
@@ -37489,7 +37537,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 543
+      "community": 544
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -37497,7 +37545,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 543
+      "community": 544
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -37505,7 +37553,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 376
+      "community": 377
     },
     {
       "label": "PerformanceBenchmark",
@@ -37513,7 +37561,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".measureOperation()",
@@ -37521,7 +37569,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".getResults()",
@@ -37529,7 +37577,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 376
+      "community": 377
     },
     {
       "label": ".getSummary()",
@@ -37537,7 +37585,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 376
+      "community": 377
     },
     {
       "label": "test-search.ts",
@@ -37545,7 +37593,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "testSearchFunctionality()",
@@ -37553,7 +37601,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 722
+      "community": 723
     },
     {
       "label": "test-forgetting.ts",
@@ -37561,7 +37609,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "testForgettingFunctionality()",
@@ -37569,7 +37617,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 723
+      "community": 724
     },
     {
       "label": "mock-database.spec.ts",
@@ -37577,7 +37625,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1081
+      "community": 1082
     },
     {
       "label": "test-m1-completion.ts",
@@ -37585,7 +37633,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "testM1Completion()",
@@ -37593,7 +37641,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 724
+      "community": 725
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -37601,7 +37649,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 725
+      "community": 726
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -37609,7 +37657,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 725
+      "community": 726
     },
     {
       "label": "vitest.setup.ts",
@@ -37617,7 +37665,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1082
+      "community": 1083
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -37625,7 +37673,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 726
+      "community": 727
     },
     {
       "label": "parseItems()",
@@ -37633,7 +37681,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 726
+      "community": 727
     },
     {
       "label": "test-memory-resource.ts",
@@ -37641,7 +37689,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "setupResourceHandlers()",
@@ -37649,7 +37697,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createTestMemories()",
@@ -37657,7 +37705,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 544
+      "community": 545
     },
     {
       "label": "test-regression.ts",
@@ -37665,7 +37713,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 727
+      "community": 728
     },
     {
       "label": "testRegression()",
@@ -37673,7 +37721,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 727
+      "community": 728
     },
     {
       "label": "test-anchor-system.ts",
@@ -37737,7 +37785,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1083
+      "community": 1084
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -37809,7 +37857,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 728
+      "community": 729
     },
     {
       "label": "testSingleProviderRegression()",
@@ -37817,7 +37865,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 728
+      "community": 729
     },
     {
       "label": "visualize-recency.ts",
@@ -37881,7 +37929,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1084
+      "community": 1085
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -37945,7 +37993,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 729
+      "community": 730
     },
     {
       "label": "constructor()",
@@ -37953,7 +38001,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 729
+      "community": 730
     },
     {
       "label": "mock-database.ts",
@@ -38185,7 +38233,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1085
+      "community": 1086
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -38225,7 +38273,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "createTestMemories()",
@@ -38233,7 +38281,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 730
+      "community": 731
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -38241,7 +38289,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -38249,7 +38297,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 731
+      "community": 732
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -38257,7 +38305,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1086
+      "community": 1087
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -38265,7 +38313,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "seedCluster()",
@@ -38273,7 +38321,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 732
+      "community": 733
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -38281,7 +38329,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "readSource()",
@@ -38289,7 +38337,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 545
+      "community": 546
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -38297,7 +38345,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 545
+      "community": 546
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -38337,7 +38385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "writeFixtureDir()",
@@ -38345,7 +38393,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 733
+      "community": 734
     },
     {
       "label": "search-quality-metrics.ts",
@@ -38441,7 +38489,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1087
+      "community": 1088
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -38537,7 +38585,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1088
+      "community": 1089
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -38545,7 +38593,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1089
+      "community": 1090
     },
     {
       "label": "test-database.ts",
@@ -38577,7 +38625,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "mergeCandidateIds()",
@@ -38585,7 +38633,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 734
+      "community": 735
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -38593,7 +38641,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -38601,7 +38649,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 546
+      "community": 547
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -38609,7 +38657,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 546
+      "community": 547
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -38617,7 +38665,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1090
+      "community": 1091
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -38625,7 +38673,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1091
+      "community": 1092
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -38825,7 +38873,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1092
+      "community": 1093
     },
     {
       "label": "query-counter.ts",
@@ -39225,7 +39273,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 735
+      "community": 736
     },
     {
       "label": "copyDir()",
@@ -39233,7 +39281,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 735
+      "community": 736
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -39241,7 +39289,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "readRootPackageJson()",
@@ -39249,7 +39297,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 736
+      "community": 737
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -39257,7 +39305,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "readJson()",
@@ -39265,7 +39313,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 737
+      "community": 738
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -39273,7 +39321,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "readWorkflow()",
@@ -39281,7 +39329,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 738
+      "community": 739
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -39345,7 +39393,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "readStaticFile()",
@@ -39353,7 +39401,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 739
+      "community": 740
     },
     {
       "label": "agent-sessions.e2e.ts",
@@ -39361,7 +39409,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_e2e_ts",
-      "community": 1093
+      "community": 1094
     },
     {
       "label": "agent-sessions.fixtures.ts",
@@ -39425,7 +39473,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "extractFencedBlocks()",
@@ -39433,7 +39481,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 740
+      "community": 741
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -39537,7 +39585,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L1",
       "id": "scripts_check_magic_numbers_ts",
-      "community": 160
+      "community": 161
     },
     {
       "label": "isCoreModule()",
@@ -39545,7 +39593,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L73",
       "id": "check_magic_numbers_iscoremodule",
-      "community": 160
+      "community": 161
     },
     {
       "label": "isExcluded()",
@@ -39553,7 +39601,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L77",
       "id": "check_magic_numbers_isexcluded",
-      "community": 160
+      "community": 161
     },
     {
       "label": "findMagicNumbers()",
@@ -39561,7 +39609,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L82",
       "id": "check_magic_numbers_findmagicnumbers",
-      "community": 160
+      "community": 161
     },
     {
       "label": "getAllTsFiles()",
@@ -39569,7 +39617,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L130",
       "id": "check_magic_numbers_getalltsfiles",
-      "community": 160
+      "community": 161
     },
     {
       "label": "countMagicNumbers()",
@@ -39577,7 +39625,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L161",
       "id": "check_magic_numbers_countmagicnumbers",
-      "community": 160
+      "community": 161
     },
     {
       "label": "printResultsJSON()",
@@ -39585,7 +39633,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L195",
       "id": "check_magic_numbers_printresultsjson",
-      "community": 160
+      "community": 161
     },
     {
       "label": "printResultsCSV()",
@@ -39593,7 +39641,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L214",
       "id": "check_magic_numbers_printresultscsv",
-      "community": 160
+      "community": 161
     },
     {
       "label": "printResultsText()",
@@ -39601,7 +39649,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L222",
       "id": "check_magic_numbers_printresultstext",
-      "community": 160
+      "community": 161
     },
     {
       "label": "main()",
@@ -39609,7 +39657,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L233",
       "id": "check_magic_numbers_main",
-      "community": 160
+      "community": 161
     },
     {
       "label": "prepack-bundle-core.js",
@@ -39617,7 +39665,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 741
+      "community": 742
     },
     {
       "label": "shouldInclude()",
@@ -39625,7 +39673,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 741
+      "community": 742
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -39633,7 +39681,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 547
+      "community": 548
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -39641,7 +39689,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 547
+      "community": 548
     },
     {
       "label": "readTarString()",
@@ -39649,7 +39697,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 547
+      "community": 548
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -39713,7 +39761,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 742
+      "community": 743
     },
     {
       "label": "fixMigration()",
@@ -39721,7 +39769,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 742
+      "community": 743
     },
     {
       "label": "sync-root-server-dist.js",
@@ -39729,7 +39777,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1094
+      "community": 1095
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -40481,7 +40529,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 377
+      "community": 378
     },
     {
       "label": "parseArgs()",
@@ -40489,7 +40537,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 377
+      "community": 378
     },
     {
       "label": "printHelp()",
@@ -40497,7 +40545,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 377
+      "community": 378
     },
     {
       "label": "printThresholds()",
@@ -40505,7 +40553,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 377
+      "community": 378
     },
     {
       "label": "main()",
@@ -40513,7 +40561,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 377
+      "community": 378
     },
     {
       "label": "simple-update.js",
@@ -40521,7 +40569,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 743
+      "community": 744
     },
     {
       "label": "updateEmbeddings()",
@@ -40529,7 +40577,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 743
+      "community": 744
     },
     {
       "label": "agent-smoke-matrix.spec.ts",
@@ -40537,7 +40585,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "temporaryRoot()",
@@ -40545,7 +40593,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 548
+      "community": 549
     },
     {
       "label": "dependencies()",
@@ -40553,7 +40601,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 548
+      "community": 549
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -40721,7 +40769,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "analyzeEmbeddings()",
@@ -40729,7 +40777,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 744
+      "community": 745
     },
     {
       "label": "test-docker.js",
@@ -40737,7 +40785,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 745
+      "community": 746
     },
     {
       "label": "testDockerServer()",
@@ -40745,7 +40793,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 745
+      "community": 746
     },
     {
       "label": "pack-with-restore.js",
@@ -40753,7 +40801,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1095
+      "community": 1096
     },
     {
       "label": "run-migration.js",
@@ -40761,7 +40809,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 746
+      "community": 747
     },
     {
       "label": "runMigration()",
@@ -40769,7 +40817,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 746
+      "community": 747
     },
     {
       "label": "safe-migration.js",
@@ -40777,7 +40825,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 747
+      "community": 748
     },
     {
       "label": "safeMigration()",
@@ -40785,7 +40833,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 747
+      "community": 748
     },
     {
       "label": "generate-ground-truth.ts",
@@ -40849,7 +40897,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "saveWorkMemory()",
@@ -40857,7 +40905,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 748
+      "community": 749
     },
     {
       "label": "check-file-sizes.ts",
@@ -41097,7 +41145,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1096
+      "community": 1097
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -41105,7 +41153,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "main()",
@@ -41113,7 +41161,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 749
+      "community": 750
     },
     {
       "label": "agent-integration-release-gate.spec.ts",
@@ -41185,7 +41233,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1097
+      "community": 1098
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -41193,7 +41241,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1098
+      "community": 1099
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -41201,7 +41249,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 378
+      "community": 379
     },
     {
       "label": "getTriggerInfo()",
@@ -41209,7 +41257,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 378
+      "community": 379
     },
     {
       "label": "fixTriggers()",
@@ -41217,7 +41265,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 378
+      "community": 379
     },
     {
       "label": "checkMigrationVersion()",
@@ -41225,7 +41273,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 378
+      "community": 379
     },
     {
       "label": "main()",
@@ -41233,7 +41281,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 378
+      "community": 379
     },
     {
       "label": "simple-migrate.js",
@@ -41241,7 +41289,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 750
+      "community": 751
     },
     {
       "label": "analyzeEmbeddings()",
@@ -41249,7 +41297,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 750
+      "community": 751
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -41257,7 +41305,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 751
+      "community": 752
     },
     {
       "label": "fixVectorDimensions()",
@@ -41265,7 +41313,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 751
+      "community": 752
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -41305,7 +41353,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "loadVecExtension()",
@@ -41313,7 +41361,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 549
+      "community": 550
     },
     {
       "label": "fixTfidfDimensions()",
@@ -41321,7 +41369,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 549
+      "community": 550
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -41329,7 +41377,7 @@
       "source_file": "scripts/longmemeval-validation.spec.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_spec_ts",
-      "community": 1099
+      "community": 1100
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -41337,7 +41385,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "runUpdateMigration()",
@@ -41345,7 +41393,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 752
+      "community": 753
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -41353,7 +41401,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "reappearanceRate()",
@@ -41361,7 +41409,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 550
+      "community": 551
     },
     {
       "label": "main()",
@@ -41369,7 +41417,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 550
+      "community": 551
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -41377,7 +41425,7 @@
       "source_file": "scripts/acquire-longmemeval.spec.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_spec_ts",
-      "community": 1100
+      "community": 1101
     },
     {
       "label": "regenerate-embeddings.js",
@@ -41385,7 +41433,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 753
+      "community": 754
     },
     {
       "label": "regenerateEmbeddings()",
@@ -41393,7 +41441,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 753
+      "community": 754
     },
     {
       "label": "generate-relation-report.ts",
@@ -41465,7 +41513,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L1",
       "id": "scripts_check_sql_injection_ts",
-      "community": 161
+      "community": 162
     },
     {
       "label": "parseArgs()",
@@ -41473,7 +41521,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L56",
       "id": "check_sql_injection_parseargs",
-      "community": 161
+      "community": 162
     },
     {
       "label": "printHelp()",
@@ -41481,7 +41529,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L87",
       "id": "check_sql_injection_printhelp",
-      "community": 161
+      "community": 162
     },
     {
       "label": "matchesPattern()",
@@ -41489,7 +41537,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L110",
       "id": "check_sql_injection_matchespattern",
-      "community": 161
+      "community": 162
     },
     {
       "label": "shouldExclude()",
@@ -41497,7 +41545,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L129",
       "id": "check_sql_injection_shouldexclude",
-      "community": 161
+      "community": 162
     },
     {
       "label": "findFiles()",
@@ -41505,7 +41553,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L141",
       "id": "check_sql_injection_findfiles",
-      "community": 161
+      "community": 162
     },
     {
       "label": "findSqlInjectionPatterns()",
@@ -41513,7 +41561,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L179",
       "id": "check_sql_injection_findsqlinjectionpatterns",
-      "community": 161
+      "community": 162
     },
     {
       "label": "checkSqlInjection()",
@@ -41521,7 +41569,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L453",
       "id": "check_sql_injection_checksqlinjection",
-      "community": 161
+      "community": 162
     },
     {
       "label": "printResults()",
@@ -41529,7 +41577,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L483",
       "id": "check_sql_injection_printresults",
-      "community": 161
+      "community": 162
     },
     {
       "label": "main()",
@@ -41537,7 +41585,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L542",
       "id": "check_sql_injection_main",
-      "community": 161
+      "community": 162
     },
     {
       "label": "quality-benchmark-category-report.spec.ts",
@@ -41545,7 +41593,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "sampleReport()",
@@ -41553,7 +41601,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 754
+      "community": 755
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -41561,7 +41609,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1101
+      "community": 1102
     },
     {
       "label": "debug-embeddings.js",
@@ -41569,7 +41617,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 755
+      "community": 756
     },
     {
       "label": "debugEmbeddings()",
@@ -41577,7 +41625,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 755
+      "community": 756
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -41585,7 +41633,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1102
+      "community": 1103
     },
     {
       "label": "longmemeval-validation.ts",
@@ -41689,7 +41737,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L1",
       "id": "scripts_tune_weights_ts",
-      "community": 319
+      "community": 320
     },
     {
       "label": "mulberry32()",
@@ -41697,7 +41745,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L24",
       "id": "tune_weights_mulberry32",
-      "community": 319
+      "community": 320
     },
     {
       "label": "parseTuneArgs()",
@@ -41705,7 +41753,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L43",
       "id": "tune_weights_parsetuneargs",
-      "community": 319
+      "community": 320
     },
     {
       "label": "generateCandidate()",
@@ -41713,7 +41761,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L71",
       "id": "tune_weights_generatecandidate",
-      "community": 319
+      "community": 320
     },
     {
       "label": "compositeScore()",
@@ -41721,7 +41769,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L88",
       "id": "tune_weights_compositescore",
-      "community": 319
+      "community": 320
     },
     {
       "label": "main()",
@@ -41729,7 +41777,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L106",
       "id": "tune_weights_main",
-      "community": 319
+      "community": 320
     },
     {
       "label": "check-db-integrity.js",
@@ -42209,7 +42257,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 756
+      "community": 757
     },
     {
       "label": "backupEmbeddings()",
@@ -42217,7 +42265,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 756
+      "community": 757
     },
     {
       "label": "count-any-types.ts",
@@ -42225,7 +42273,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L1",
       "id": "scripts_count_any_types_ts",
-      "community": 162
+      "community": 163
     },
     {
       "label": "parseArgs()",
@@ -42233,7 +42281,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L56",
       "id": "count_any_types_parseargs",
-      "community": 162
+      "community": 163
     },
     {
       "label": "printHelp()",
@@ -42241,7 +42289,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L92",
       "id": "count_any_types_printhelp",
-      "community": 162
+      "community": 163
     },
     {
       "label": "matchesPattern()",
@@ -42249,7 +42297,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L118",
       "id": "count_any_types_matchespattern",
-      "community": 162
+      "community": 163
     },
     {
       "label": "shouldExclude()",
@@ -42257,7 +42305,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L137",
       "id": "count_any_types_shouldexclude",
-      "community": 162
+      "community": 163
     },
     {
       "label": "findFiles()",
@@ -42265,7 +42313,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L149",
       "id": "count_any_types_findfiles",
-      "community": 162
+      "community": 163
     },
     {
       "label": "findAnyTypes()",
@@ -42273,7 +42321,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L186",
       "id": "count_any_types_findanytypes",
-      "community": 162
+      "community": 163
     },
     {
       "label": "countAnyTypes()",
@@ -42281,7 +42329,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L251",
       "id": "count_any_types_countanytypes",
-      "community": 162
+      "community": 163
     },
     {
       "label": "printResults()",
@@ -42289,7 +42337,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L278",
       "id": "count_any_types_printresults",
-      "community": 162
+      "community": 163
     },
     {
       "label": "main()",
@@ -42297,7 +42345,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L318",
       "id": "count_any_types_main",
-      "community": 162
+      "community": 163
     },
     {
       "label": "count-console-logs.ts",
@@ -42433,7 +42481,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "makeRng()",
@@ -42441,7 +42489,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 757
+      "community": 758
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -42449,7 +42497,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1103
+      "community": 1104
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -42457,7 +42505,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1104
+      "community": 1105
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -42465,7 +42513,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1105
+      "community": 1106
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -42473,7 +42521,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "jsonEmbedding()",
@@ -42481,7 +42529,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 758
+      "community": 759
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -42489,7 +42537,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1106
+      "community": 1107
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -42497,7 +42545,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1107
+      "community": 1108
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -42505,7 +42553,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1108
+      "community": 1109
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -42513,7 +42561,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -42521,7 +42569,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 759
+      "community": 760
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -42529,7 +42577,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1109
+      "community": 1110
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -42537,7 +42585,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "jsonEmbedding()",
@@ -42545,7 +42593,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 760
+      "community": 761
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -42553,7 +42601,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "main()",
@@ -42561,7 +42609,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 761
+      "community": 762
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -42569,7 +42617,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -42577,7 +42625,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 762
+      "community": 763
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -42585,7 +42633,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "createBackup()",
@@ -42593,7 +42641,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 551
+      "community": 552
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -42601,7 +42649,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 551
+      "community": 552
     },
     {
       "label": "restore-legacy.ps1",
@@ -42609,7 +42657,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1110
+      "community": 1111
     },
     {
       "label": "check-retry-usage.ts",
@@ -42681,7 +42729,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_simple_throws_ts",
-      "community": 320
+      "community": 321
     },
     {
       "label": "isTestFile()",
@@ -42689,7 +42737,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L29",
       "id": "analyze_simple_throws_istestfile",
-      "community": 320
+      "community": 321
     },
     {
       "label": "shouldExcludeDir()",
@@ -42697,7 +42745,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L38",
       "id": "analyze_simple_throws_shouldexcludedir",
-      "community": 320
+      "community": 321
     },
     {
       "label": "findThrows()",
@@ -42705,7 +42753,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L45",
       "id": "analyze_simple_throws_findthrows",
-      "community": 320
+      "community": 321
     },
     {
       "label": "scanDirectory()",
@@ -42713,7 +42761,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L102",
       "id": "analyze_simple_throws_scandirectory",
-      "community": 320
+      "community": 321
     },
     {
       "label": "main()",
@@ -42721,7 +42769,7 @@
       "source_file": "scripts/archive/analyze-simple-throws.ts",
       "source_location": "L126",
       "id": "analyze_simple_throws_main",
-      "community": 320
+      "community": 321
     },
     {
       "label": "analyze-benchmark-test-data.ts",
@@ -42729,7 +42777,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -42737,7 +42785,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 763
+      "community": 764
     },
     {
       "label": "check-no-console-violations.ts",
@@ -42833,7 +42881,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "fixVecTableDimensions()",
@@ -42841,7 +42889,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 764
+      "community": 765
     },
     {
       "label": "sources.ts",
@@ -42849,7 +42897,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 163
+      "community": 164
     },
     {
       "label": "splitJsonlLines()",
@@ -42857,7 +42905,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L17",
       "id": "sources_splitjsonllines",
-      "community": 163
+      "community": 164
     },
     {
       "label": "cursorKey()",
@@ -42865,7 +42913,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L32",
       "id": "sources_cursorkey",
-      "community": 163
+      "community": 164
     },
     {
       "label": "findLastNewlineBefore()",
@@ -42873,7 +42921,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L36",
       "id": "sources_findlastnewlinebefore",
-      "community": 163
+      "community": 164
     },
     {
       "label": "readStreamLines()",
@@ -42881,7 +42929,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L56",
       "id": "sources_readstreamlines",
-      "community": 163
+      "community": 164
     },
     {
       "label": "readIncrementalJsonlLines()",
@@ -42889,7 +42937,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L113",
       "id": "sources_readincrementaljsonllines",
-      "community": 163
+      "community": 164
     },
     {
       "label": "runDocker()",
@@ -42897,7 +42945,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L148",
       "id": "sources_rundocker",
-      "community": 163
+      "community": 164
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -42905,7 +42953,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L168",
       "id": "sources_resolvedockerlogsref",
-      "community": 163
+      "community": 164
     },
     {
       "label": "readDockerLogs()",
@@ -42913,7 +42961,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L215",
       "id": "sources_readdockerlogs",
-      "community": 163
+      "community": 164
     },
     {
       "label": "readJsonlFiles()",
@@ -42921,7 +42969,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L244",
       "id": "sources_readjsonlfiles",
-      "community": 163
+      "community": 164
     },
     {
       "label": "types.ts",
@@ -42929,7 +42977,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1111
+      "community": 1112
     },
     {
       "label": "issue-body.ts",
@@ -42969,7 +43017,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "normalizeMessage()",
@@ -42977,7 +43025,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 552
+      "community": 553
     },
     {
       "label": "createFingerprint()",
@@ -42985,7 +43033,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 552
+      "community": 553
     },
     {
       "label": "sanitizer.ts",
@@ -42993,7 +43041,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "limitUtf8Bytes()",
@@ -43001,7 +43049,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 553
+      "community": 554
     },
     {
       "label": "sanitizeExcerpt()",
@@ -43009,7 +43057,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 553
+      "community": 554
     },
     {
       "label": "parsers.ts",
@@ -43081,7 +43129,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -43089,7 +43137,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 765
+      "community": 766
     },
     {
       "label": "state-store.ts",
@@ -43097,7 +43145,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_state_store_ts",
-      "community": 321
+      "community": 322
     },
     {
       "label": "emptyState()",
@@ -43105,7 +43153,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L5",
       "id": "state_store_emptystate",
-      "community": 321
+      "community": 322
     },
     {
       "label": "loadState()",
@@ -43113,7 +43161,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L9",
       "id": "state_store_loadstate",
-      "community": 321
+      "community": 322
     },
     {
       "label": "saveState()",
@@ -43121,7 +43169,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L20",
       "id": "state_store_savestate",
-      "community": 321
+      "community": 322
     },
     {
       "label": "upsertOccurrence()",
@@ -43129,7 +43177,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L27",
       "id": "state_store_upsertoccurrence",
-      "community": 321
+      "community": 322
     },
     {
       "label": "appendOccurrence()",
@@ -43137,7 +43185,7 @@
       "source_file": "scripts/log-issue-monitor/state-store.ts",
       "source_location": "L55",
       "id": "state_store_appendoccurrence",
-      "community": 321
+      "community": 322
     },
     {
       "label": "monitor.ts",
@@ -43145,7 +43193,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_monitor_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "recordMonitorError()",
@@ -43153,7 +43201,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L21",
       "id": "monitor_recordmonitorerror",
-      "community": 322
+      "community": 323
     },
     {
       "label": "recordJsonlSkip()",
@@ -43161,7 +43209,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L30",
       "id": "monitor_recordjsonlskip",
-      "community": 322
+      "community": 323
     },
     {
       "label": "withFingerprint()",
@@ -43169,7 +43217,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L46",
       "id": "monitor_withfingerprint",
-      "community": 322
+      "community": 323
     },
     {
       "label": "syncFingerprint()",
@@ -43177,7 +43225,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L63",
       "id": "monitor_syncfingerprint",
-      "community": 322
+      "community": 323
     },
     {
       "label": "runMonitorCycle()",
@@ -43185,7 +43233,7 @@
       "source_file": "scripts/log-issue-monitor/monitor.ts",
       "source_location": "L120",
       "id": "monitor_runmonitorcycle",
-      "community": 322
+      "community": 323
     },
     {
       "label": "github-client.ts",
@@ -43369,7 +43417,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1112
+      "community": 1113
     },
     {
       "label": "issue-body.spec.ts",
@@ -43377,7 +43425,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1113
+      "community": 1114
     },
     {
       "label": "github-client.spec.ts",
@@ -43385,7 +43433,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1114
+      "community": 1115
     },
     {
       "label": "config.spec.ts",
@@ -43393,7 +43441,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1115
+      "community": 1116
     },
     {
       "label": "detectors.spec.ts",
@@ -43401,7 +43449,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1116
+      "community": 1117
     },
     {
       "label": "sources.spec.ts",
@@ -43409,7 +43457,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1117
+      "community": 1118
     },
     {
       "label": "parsers.spec.ts",
@@ -43417,7 +43465,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1118
+      "community": 1119
     },
     {
       "label": "monitor.spec.ts",
@@ -43425,7 +43473,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "config()",
@@ -43433,7 +43481,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 766
+      "community": 767
     },
     {
       "label": "fingerprint.spec.ts",
@@ -43441,7 +43489,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1119
+      "community": 1120
     },
     {
       "label": "state-store.spec.ts",
@@ -43449,7 +43497,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1120
+      "community": 1121
     },
     {
       "label": "sanitizer.spec.ts",
@@ -43457,7 +43505,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1121
+      "community": 1122
     },
     {
       "label": "entrypoint.spec.ts",
@@ -43465,7 +43513,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1122
+      "community": 1123
     },
     {
       "label": "index.ts",
@@ -43505,7 +43553,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1123
+      "community": 1124
     },
     {
       "label": "memento-admin-fetch.js",
@@ -43513,7 +43561,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L1",
       "id": "static_js_memento_admin_fetch_js",
-      "community": 323
+      "community": 324
     },
     {
       "label": "getDashboardAuth()",
@@ -43521,7 +43569,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L8",
       "id": "memento_admin_fetch_getdashboardauth",
-      "community": 323
+      "community": 324
     },
     {
       "label": "waitForSession()",
@@ -43529,7 +43577,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L12",
       "id": "memento_admin_fetch_waitforsession",
-      "community": 323
+      "community": 324
     },
     {
       "label": "buildRequestOptions()",
@@ -43537,7 +43585,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L20",
       "id": "memento_admin_fetch_buildrequestoptions",
-      "community": 323
+      "community": 324
     },
     {
       "label": "performFetch()",
@@ -43545,7 +43593,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L28",
       "id": "memento_admin_fetch_performfetch",
-      "community": 323
+      "community": 324
     },
     {
       "label": "mementoAdminFetch()",
@@ -43553,7 +43601,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L51",
       "id": "memento_admin_fetch_mementoadminfetch",
-      "community": 323
+      "community": 324
     },
     {
       "label": "memory-evolution-demo-shell-render.js",
@@ -43561,7 +43609,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1124
+      "community": 1125
     },
     {
       "label": "dashboard-auth.js",
@@ -44073,7 +44121,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 767
+      "community": 768
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -44081,7 +44129,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 767
+      "community": 768
     },
     {
       "label": "graph.js",
@@ -44217,7 +44265,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_timeline_js",
-      "community": 379
+      "community": 380
     },
     {
       "label": "buildComparisonHintMarkup()",
@@ -44225,7 +44273,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_timeline_buildcomparisonhintmarkup",
-      "community": 379
+      "community": 380
     },
     {
       "label": "updateComparisonHint()",
@@ -44233,7 +44281,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L36",
       "id": "memory_evolution_demo_shell_render_timeline_updatecomparisonhint",
-      "community": 379
+      "community": 380
     },
     {
       "label": "syncSegmentSelection()",
@@ -44241,7 +44289,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L51",
       "id": "memory_evolution_demo_shell_render_timeline_syncsegmentselection",
-      "community": 379
+      "community": 380
     },
     {
       "label": "renderPointSegment()",
@@ -44249,7 +44297,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L66",
       "id": "memory_evolution_demo_shell_render_timeline_renderpointsegment",
-      "community": 379
+      "community": 380
     },
     {
       "label": "agent-sessions-panel-data.js",
@@ -44257,7 +44305,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_data_js",
-      "community": 324
+      "community": 325
     },
     {
       "label": "value()",
@@ -44265,7 +44313,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_data_value",
-      "community": 324
+      "community": 325
     },
     {
       "label": "loadSessions()",
@@ -44273,7 +44321,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L17",
       "id": "agent_sessions_panel_data_loadsessions",
-      "community": 324
+      "community": 325
     },
     {
       "label": "selectSession()",
@@ -44281,7 +44329,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L57",
       "id": "agent_sessions_panel_data_selectsession",
-      "community": 324
+      "community": 325
     },
     {
       "label": "loadTimeline()",
@@ -44289,7 +44337,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L73",
       "id": "agent_sessions_panel_data_loadtimeline",
-      "community": 324
+      "community": 325
     },
     {
       "label": "loadProvenance()",
@@ -44297,7 +44345,7 @@
       "source_file": "static/js/agent-sessions-panel-data.js",
       "source_location": "L102",
       "id": "agent_sessions_panel_data_loadprovenance",
-      "community": 324
+      "community": 325
     },
     {
       "label": "memory-evolution-demo-shell-shared.js",
@@ -44473,7 +44521,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1125
+      "community": 1126
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -44537,7 +44585,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_import_js",
-      "community": 325
+      "community": 326
     },
     {
       "label": "transcriptValue()",
@@ -44545,7 +44593,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_import_transcriptvalue",
-      "community": 325
+      "community": 326
     },
     {
       "label": "invalidateDryRun()",
@@ -44553,7 +44601,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L17",
       "id": "agent_sessions_panel_import_invalidatedryrun",
-      "community": 325
+      "community": 326
     },
     {
       "label": "renderImportResult()",
@@ -44561,7 +44609,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L25",
       "id": "agent_sessions_panel_import_renderimportresult",
-      "community": 325
+      "community": 326
     },
     {
       "label": "submitTranscript()",
@@ -44569,7 +44617,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L57",
       "id": "agent_sessions_panel_import_submittranscript",
-      "community": 325
+      "community": 326
     },
     {
       "label": "readTranscriptFile()",
@@ -44577,7 +44625,7 @@
       "source_file": "static/js/agent-sessions-panel-import.js",
       "source_location": "L89",
       "id": "agent_sessions_panel_import_readtranscriptfile",
-      "community": 325
+      "community": 326
     },
     {
       "label": "agent-sessions-panel.js",
@@ -44617,7 +44665,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_consolidation_js",
-      "community": 380
+      "community": 381
     },
     {
       "label": "renderEpisodicSources()",
@@ -44625,7 +44673,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_consolidation_renderepisodicsources",
-      "community": 380
+      "community": 381
     },
     {
       "label": "renderSemanticResult()",
@@ -44633,7 +44681,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersemanticresult",
-      "community": 380
+      "community": 381
     },
     {
       "label": "renderSearchComparison()",
@@ -44641,7 +44689,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L110",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersearchcomparison",
-      "community": 380
+      "community": 381
     },
     {
       "label": "renderConsolidationPanel()",
@@ -44649,7 +44697,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L128",
       "id": "memory_evolution_demo_shell_render_consolidation_renderconsolidationpanel",
-      "community": 380
+      "community": 381
     },
     {
       "label": "memory-evolution-demo-shell.js",
@@ -44657,7 +44705,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 768
+      "community": 769
     },
     {
       "label": "init()",
@@ -44665,7 +44713,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 768
+      "community": 769
     },
     {
       "label": "review-candidates-panel-health.js",
@@ -44993,7 +45041,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 381
+      "community": 382
     },
     {
       "label": "getTabButtons()",
@@ -45001,7 +45049,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L14",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 381
+      "community": 382
     },
     {
       "label": "dispatchGraphIframeResize()",
@@ -45009,7 +45057,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_dispatchgraphiframeresize",
-      "community": 381
+      "community": 382
     },
     {
       "label": "setRovingTabindex()",
@@ -45017,7 +45065,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L25",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 381
+      "community": 382
     },
     {
       "label": "activateTab()",
@@ -45025,7 +45073,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L31",
       "id": "dashboard_tabs_activatetab",
-      "community": 381
+      "community": 382
     },
     {
       "label": "review-candidates-panel-render.js",
@@ -74381,19 +74429,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
-      "source_location": "L6",
+      "source_location": "L15",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "_tgt": "memory_review_candidates_run_diagnostics_readinsertedupdated",
+      "_tgt": "memory_review_candidates_run_diagnostics_readrundetails",
       "source": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "target": "memory_review_candidates_run_diagnostics_readinsertedupdated",
+      "target": "memory_review_candidates_run_diagnostics_readrundetails",
       "confidence_score": 1.0
     },
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
-      "source_location": "L23",
+      "source_location": "L46",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
       "_tgt": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
@@ -74405,11 +74453,11 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
-      "source_location": "L26",
+      "source_location": "L56",
       "weight": 1.0,
       "_src": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "_tgt": "memory_review_candidates_run_diagnostics_readinsertedupdated",
-      "source": "memory_review_candidates_run_diagnostics_readinsertedupdated",
+      "_tgt": "memory_review_candidates_run_diagnostics_readrundetails",
+      "source": "memory_review_candidates_run_diagnostics_readrundetails",
       "target": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
       "confidence_score": 1.0
     },
@@ -75448,6 +75496,30 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
+      "_tgt": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
+      "target": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
+      "source_location": "L41",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
+      "_tgt": "batch_scheduler_review_meta_handlers_spec_createcontext",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
+      "target": "batch_scheduler_review_meta_handlers_spec_createcontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "weight": 1.0,
@@ -75545,7 +75617,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L16",
+      "source_location": "L21",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
       "_tgt": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
@@ -75557,7 +75629,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L46",
+      "source_location": "L55",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
       "_tgt": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
@@ -75569,7 +75641,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L83",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
       "_tgt": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
@@ -75581,7 +75653,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
-      "source_location": "L52",
+      "source_location": "L97",
       "weight": 1.0,
       "_src": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
       "_tgt": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
@@ -94205,7 +94277,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L7",
+      "source_location": "L12",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
       "_tgt": "memory_review_candidate_selection_env_parseimportancethreshold",
@@ -94217,7 +94289,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L18",
+      "source_location": "L23",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
       "_tgt": "memory_review_candidate_selection_env_parsepositiveint",
@@ -94229,7 +94301,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L29",
+      "source_location": "L34",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
+      "_tgt": "memory_review_candidate_selection_env_parsenonnegativeint",
+      "source": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
+      "target": "memory_review_candidate_selection_env_parsenonnegativeint",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
+      "source_location": "L45",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
       "_tgt": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
@@ -94238,10 +94322,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
+      "source_location": "L53",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
+      "_tgt": "memory_review_candidate_selection_env_parsememoryreviewqueuecontrolenv",
+      "source": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_ts",
+      "target": "memory_review_candidate_selection_env_parsememoryreviewqueuecontrolenv",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L31",
+      "source_location": "L47",
       "weight": 1.0,
       "_src": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
       "_tgt": "memory_review_candidate_selection_env_parseimportancethreshold",
@@ -94253,7 +94349,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
-      "source_location": "L32",
+      "source_location": "L48",
       "weight": 1.0,
       "_src": "memory_review_candidate_selection_env_parsememoryreviewselectionenv",
       "_tgt": "memory_review_candidate_selection_env_parsepositiveint",
@@ -94262,10 +94358,22 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts",
+      "source_location": "L55",
+      "weight": 1.0,
+      "_src": "memory_review_candidate_selection_env_parsememoryreviewqueuecontrolenv",
+      "_tgt": "memory_review_candidate_selection_env_parsenonnegativeint",
+      "source": "memory_review_candidate_selection_env_parsenonnegativeint",
+      "target": "memory_review_candidate_selection_env_parsememoryreviewqueuecontrolenv",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
-      "source_location": "L22",
+      "source_location": "L23",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
       "_tgt": "memory_review_candidate_persistence_service_spec_createbaseschema",
@@ -95408,6 +95516,18 @@
       "source_location": "L125",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
+      "_tgt": "memory_review_candidate_persistence_service_countpendingmemoryreviewcandidates",
+      "source": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
+      "target": "memory_review_candidate_persistence_service_countpendingmemoryreviewcandidates",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
+      "source_location": "L136",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
       "_tgt": "memory_review_candidate_persistence_service_markmemoryreviewcandidatereviewed",
       "source": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
       "target": "memory_review_candidate_persistence_service_markmemoryreviewcandidatereviewed",
@@ -95417,7 +95537,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L160",
+      "source_location": "L171",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
       "_tgt": "memory_review_candidate_persistence_service_markmemoryreviewcandidatedismissed",
@@ -95429,7 +95549,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L188",
+      "source_location": "L199",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
       "_tgt": "memory_review_candidate_persistence_service_markmemoryreviewcandidateexpired",
@@ -95441,7 +95561,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts",
-      "source_location": "L216",
+      "source_location": "L227",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_ts",
       "_tgt": "memory_review_candidate_persistence_service_bulkupdatependingmemoryreviewcandidates",

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts
@@ -6,6 +6,7 @@ import {
   upsertPendingMemoryReviewCandidates,
   getMemoryReviewCandidateById,
   listMemoryReviewCandidates,
+  countPendingMemoryReviewCandidates,
   markMemoryReviewCandidateReviewed,
   markMemoryReviewCandidateDismissed,
   markMemoryReviewCandidateExpired,
@@ -118,6 +119,7 @@ describe('memory-review-candidate-persistence upsert', () => {
     );
     const rows = listMemoryReviewCandidates(db, { status: 'pending' });
     expect(rows).toHaveLength(1);
+    expect(countPendingMemoryReviewCandidates(db)).toBe(1);
     const one = getMemoryReviewCandidateById(db, rows[0].id);
     expect(one?.memory_id).toBe('mem_a');
     expect(one?.status).toBe('pending');

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.ts
@@ -122,6 +122,17 @@ export function listMemoryReviewCandidates(
     .map((row) => mapRow(row));
 }
 
+export function countPendingMemoryReviewCandidates(db: Database.Database): number {
+  ensureMemoryReviewCandidateSchema(db);
+  return (
+    db
+      .prepare<[], { count: number }>(
+        `SELECT COUNT(*) AS count FROM memory_review_candidate WHERE status = 'pending'`,
+      )
+      .get() ?? { count: 0 }
+  ).count;
+}
+
 export function markMemoryReviewCandidateReviewed(
   db: Database.Database,
   candidateId: string,

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { parseMemoryReviewSelectionEnv } from './memory-review-candidate-selection-env.js';
+import {
+  parseMemoryReviewQueueControlEnv,
+  parseMemoryReviewSelectionEnv,
+} from './memory-review-candidate-selection-env.js';
 
 describe('parseMemoryReviewSelectionEnv', () => {
   beforeEach(() => {
@@ -42,5 +45,40 @@ describe('parseMemoryReviewSelectionEnv', () => {
   it('falls back maxCandidates when value is negative', () => {
     vi.stubEnv('MEMORY_REVIEW_MAX_CANDIDATES', '-3');
     expect(parseMemoryReviewSelectionEnv().maxCandidates).toBe(50);
+  });
+});
+
+describe('parseMemoryReviewQueueControlEnv', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses safe defaults when queue control vars are unset', () => {
+    expect(parseMemoryReviewQueueControlEnv()).toEqual({
+      maxBacklog: 500,
+      candidateTtlDays: 30,
+    });
+  });
+
+  it('accepts zero to disable each automatic queue control', () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_BACKLOG', '0');
+    vi.stubEnv('MEMORY_REVIEW_CANDIDATE_TTL_DAYS', '0');
+    expect(parseMemoryReviewQueueControlEnv()).toEqual({
+      maxBacklog: 0,
+      candidateTtlDays: 0,
+    });
+  });
+
+  it('falls back invalid queue control values independently', () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_BACKLOG', '-1');
+    vi.stubEnv('MEMORY_REVIEW_CANDIDATE_TTL_DAYS', 'abc');
+    expect(parseMemoryReviewQueueControlEnv()).toEqual({
+      maxBacklog: 500,
+      candidateTtlDays: 30,
+    });
   });
 });

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.ts
@@ -1,8 +1,13 @@
-import type { MemoryReviewCandidateSelectionThresholds } from './memory-review-candidate-selection.types.js';
+import type {
+  MemoryReviewCandidateSelectionThresholds,
+  MemoryReviewQueueControlConfig,
+} from './memory-review-candidate-selection.types.js';
 
 const DEFAULT_IMPORTANCE_THRESHOLD = 0.7;
 const DEFAULT_STALE_DAYS = 14;
 const DEFAULT_MAX_CANDIDATES = 50;
+const DEFAULT_MAX_BACKLOG = 500;
+const DEFAULT_CANDIDATE_TTL_DAYS = 30;
 
 function parseImportanceThreshold(raw: string | undefined): number {
   if (raw === undefined || raw === '') {
@@ -26,10 +31,31 @@ function parsePositiveInt(raw: string | undefined, defaultValue: number): number
   return n;
 }
 
+function parseNonNegativeInt(raw: string | undefined, defaultValue: number): number {
+  if (raw === undefined || raw === '') {
+    return defaultValue;
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) {
+    return defaultValue;
+  }
+  return n;
+}
+
 export function parseMemoryReviewSelectionEnv(): MemoryReviewCandidateSelectionThresholds {
   return {
     importanceThreshold: parseImportanceThreshold(process.env.MEMORY_REVIEW_IMPORTANCE_THRESHOLD),
     staleDays: parsePositiveInt(process.env.MEMORY_REVIEW_STALE_DAYS, DEFAULT_STALE_DAYS),
     maxCandidates: parsePositiveInt(process.env.MEMORY_REVIEW_MAX_CANDIDATES, DEFAULT_MAX_CANDIDATES),
+  };
+}
+
+export function parseMemoryReviewQueueControlEnv(): MemoryReviewQueueControlConfig {
+  return {
+    maxBacklog: parseNonNegativeInt(process.env.MEMORY_REVIEW_MAX_BACKLOG, DEFAULT_MAX_BACKLOG),
+    candidateTtlDays: parseNonNegativeInt(
+      process.env.MEMORY_REVIEW_CANDIDATE_TTL_DAYS,
+      DEFAULT_CANDIDATE_TTL_DAYS,
+    ),
   };
 }

--- a/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts
@@ -24,6 +24,11 @@ export interface MemoryReviewCandidateSelectionThresholds {
   maxCandidates: number;
 }
 
+export interface MemoryReviewQueueControlConfig {
+  maxBacklog: number;
+  candidateTtlDays: number;
+}
+
 export interface MemoryReviewCandidateSelectionOptions extends MemoryReviewCandidateSelectionThresholds {
   now: Date;
 }

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -55,19 +55,24 @@ export {
   selectMemoryReviewCandidates,
   selectionWindowLimit
 } from './domains/memory/services/memory-review-candidate-selection-service.js';
-export { parseMemoryReviewSelectionEnv } from './domains/memory/services/memory-review-candidate-selection-env.js';
+export {
+  parseMemoryReviewQueueControlEnv,
+  parseMemoryReviewSelectionEnv
+} from './domains/memory/services/memory-review-candidate-selection-env.js';
 export type {
   MemoryReviewStaleAnchorKind as StaleAnchorKind,
   MemoryReviewCandidateSourceRow as SourceRow,
   MemoryReviewCandidateScoreBreakdown as ScoreBreakdown,
   MemoryReviewCandidateSelectionItem as SelectionItem,
   MemoryReviewCandidateSelectionThresholds as Thresholds,
-  MemoryReviewCandidateSelectionOptions as Options
+  MemoryReviewCandidateSelectionOptions as Options,
+  MemoryReviewQueueControlConfig
 } from './domains/memory/services/memory-review-candidate-selection.types.js';
 export {
   upsertPendingMemoryReviewCandidates,
   getMemoryReviewCandidateById,
   listMemoryReviewCandidates,
+  countPendingMemoryReviewCandidates,
   markMemoryReviewCandidateReviewed,
   markMemoryReviewCandidateDismissed,
   markMemoryReviewCandidateExpired,

--- a/packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts
@@ -25,7 +25,14 @@ describe('buildMemoryReviewCandidatesRunDiagnosticsPayload', () => {
   it('성공 시 삽입·갱신·에러 카운트 키를 포함한다', () => {
     const payload = buildMemoryReviewCandidatesRunDiagnosticsPayload(
       baseResult({
-        details: { inserted: 2, updated: 1 }
+        details: {
+          inserted: 2,
+          updated: 1,
+          expired: 4,
+          pendingBefore: 8,
+          pendingAfter: 6,
+          skippedForBacklog: false
+        }
       })
     );
 
@@ -35,6 +42,10 @@ describe('buildMemoryReviewCandidatesRunDiagnosticsPayload', () => {
     expect(payload.result).toBe('success');
     expect(payload.inserted).toBe(2);
     expect(payload.updated).toBe(1);
+    expect(payload.expired).toBe(4);
+    expect(payload.pending_before).toBe(8);
+    expect(payload.pending_after).toBe(6);
+    expect(payload.skipped_for_backlog).toBe(false);
     expect(payload.error_count).toBe(0);
     expect(payload.selected_count).toBe(3);
     expect(payload.first_error).toBeNull();

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { MetaMemoryStatsSchemaMigration } from '../../database/database/migration/migrations/011-meta-memory-stats-schema.js';
+import { MemoryReviewCandidateSchemaMigration } from '../../database/database/migration/migrations/033-memory-review-candidate-schema.js';
+import {
+  listMemoryReviewCandidates,
+  upsertPendingMemoryReviewCandidates,
+} from '../../../domains/memory/services/memory-review-candidate-persistence-service.js';
+import { runMemoryReviewCandidatesJob } from './batch-scheduler-review-meta-handlers.js';
+import type { BatchSchedulerRunContext } from './batch-scheduler-run-context.js';
+
+function createBaseSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      last_accessed_at TEXT,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      project_id TEXT,
+      is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+      deleted_at TEXT
+    );
+    CREATE TABLE memento_schema_version (
+      version TEXT PRIMARY KEY,
+      applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      migration_name TEXT NOT NULL,
+      checksum TEXT,
+      applied_by TEXT DEFAULT 'system',
+      description TEXT
+    );
+  `);
+}
+
+function createContext(db: Database.Database): BatchSchedulerRunContext {
+  return {
+    db,
+    log: vi.fn(),
+    emitMemoryReviewCandidatesRunRecord: vi.fn().mockResolvedValue(undefined),
+  } as unknown as BatchSchedulerRunContext;
+}
+
+describe('runMemoryReviewCandidatesJob queue controls', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    vi.unstubAllEnvs();
+    db = new Database(':memory:');
+    createBaseSchema(db);
+    await new MetaMemoryStatsSchemaMigration().up(db);
+    await new MemoryReviewCandidateSchemaMigration().up(db);
+    db.exec(`
+      INSERT INTO memory_item (
+        id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at
+      ) VALUES (
+        'mem_old', 'semantic', 'old', 0.9, 'private', '2020-01-01 00:00:00', 0, 0, NULL
+      );
+    `);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    db.close();
+  });
+
+  it('skips selection when pending backlog is at the configured maximum', async () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_BACKLOG', '1');
+    vi.stubEnv('MEMORY_REVIEW_CANDIDATE_TTL_DAYS', '0');
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_old', priority: 1, reason: 'seed', due_at: '2026-07-01T00:00:00.000Z' }],
+      new Date().toISOString(),
+    );
+
+    const result = await runMemoryReviewCandidatesJob(createContext(db));
+
+    expect(result.success).toBe(true);
+    expect(result.processed).toBe(0);
+    expect(result.details).toMatchObject({
+      inserted: 0,
+      updated: 0,
+      expired: 0,
+      pendingBefore: 1,
+      pendingAfter: 1,
+      skippedForBacklog: true,
+    });
+  });
+
+  it('expires pending candidates older than the configured TTL before selection', async () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_BACKLOG', '10');
+    vi.stubEnv('MEMORY_REVIEW_CANDIDATE_TTL_DAYS', '30');
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_old', priority: 1, reason: 'seed', due_at: '2026-01-02T00:00:00.000Z' }],
+      '2026-01-01T00:00:00.000Z',
+    );
+
+    const result = await runMemoryReviewCandidatesJob(createContext(db));
+
+    expect(result.success).toBe(true);
+    expect(result.details).toMatchObject({
+      expired: 1,
+      pendingBefore: 0,
+      skippedForBacklog: false,
+    });
+    expect(listMemoryReviewCandidates(db, { status: 'expired' })).toHaveLength(1);
+  });
+
+  it('limits selection to the remaining backlog capacity', async () => {
+    vi.stubEnv('MEMORY_REVIEW_MAX_BACKLOG', '2');
+    vi.stubEnv('MEMORY_REVIEW_CANDIDATE_TTL_DAYS', '0');
+    db.exec(`
+      INSERT INTO memory_item (
+        id, type, content, importance, privacy_scope, created_at, pinned, is_deleted, deleted_at
+      ) VALUES
+        ('mem_two', 'semantic', 'two', 0.8, 'private', '2020-01-02 00:00:00', 0, 0, NULL),
+        ('mem_three', 'semantic', 'three', 0.7, 'private', '2020-01-03 00:00:00', 0, 0, NULL);
+    `);
+    upsertPendingMemoryReviewCandidates(
+      db,
+      [{ memory_id: 'mem_old', priority: 1, reason: 'seed', due_at: '2026-07-01T00:00:00.000Z' }],
+      new Date().toISOString(),
+    );
+
+    const result = await runMemoryReviewCandidatesJob(createContext(db));
+
+    expect(result.success).toBe(true);
+    expect(result.processed).toBe(1);
+    expect(result.details).toMatchObject({
+      inserted: 1,
+      pendingBefore: 1,
+      pendingAfter: 2,
+      skippedForBacklog: false,
+    });
+    expect(listMemoryReviewCandidates(db, { status: 'pending' })).toHaveLength(2);
+  });
+});

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts
@@ -1,7 +1,12 @@
 import type Database from 'better-sqlite3';
 import { MetaMemoryIntrospectionService } from '../../../domains/memory/services/meta-memory-introspection-service.js';
+import { parseMemoryReviewQueueControlEnv } from '../../../domains/memory/services/memory-review-candidate-selection-env.js';
 import { selectMemoryReviewCandidates } from '../../../domains/memory/services/memory-review-candidate-selection-service.js';
-import { upsertPendingMemoryReviewCandidates } from '../../../domains/memory/services/memory-review-candidate-persistence-service.js';
+import {
+  bulkUpdatePendingMemoryReviewCandidates,
+  countPendingMemoryReviewCandidates,
+  upsertPendingMemoryReviewCandidates
+} from '../../../domains/memory/services/memory-review-candidate-persistence-service.js';
 import { recordMemoryReviewQueueHealthSnapshot } from '../../../domains/memory/services/memory-review-queue-health-service.js';
 import { resolveValidatedNumber } from '../../../shared/config/environment.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
@@ -13,7 +18,10 @@ import {
 } from '../batch-scheduler-internal-helpers.js';
 import type { BatchSchedulerRunContext } from './batch-scheduler-run-context.js';
 
-export function buildMemoryReviewCandidateUpsertInputs(db: Database.Database): {
+export function buildMemoryReviewCandidateUpsertInputs(
+  db: Database.Database,
+  maxCandidates?: number
+): {
   inputs: Array<{
     memory_id: string;
     priority: number;
@@ -21,17 +29,18 @@ export function buildMemoryReviewCandidateUpsertInputs(db: Database.Database): {
     due_at: string;
     metadata_json: string;
   }>;
-  nowIso: string;
   selectedCount: number;
 } {
-  const items = selectMemoryReviewCandidates(db);
+  const items = selectMemoryReviewCandidates(
+    db,
+    maxCandidates === undefined ? undefined : { maxCandidates }
+  );
   const dueDays = resolveValidatedNumber(
     'MEMORY_REVIEW_CANDIDATE_DUE_DAYS',
     14,
     n => n >= 1 && n <= 366,
     '1-366'
   );
-  const nowIso = new Date().toISOString();
   const dueAt = new Date(Date.now() + dueDays * 86_400_000).toISOString();
   const inputs = items.map(i => ({
     memory_id: i.memory_id,
@@ -40,7 +49,7 @@ export function buildMemoryReviewCandidateUpsertInputs(db: Database.Database): {
     due_at: dueAt,
     metadata_json: JSON.stringify({ score_breakdown: i.score_breakdown })
   }));
-  return { inputs, nowIso, selectedCount: items.length };
+  return { inputs, selectedCount: items.length };
 }
 
 export async function runMemoryReviewCandidatesJob(ctx: BatchSchedulerRunContext): Promise<BatchJobResult> {
@@ -49,16 +58,67 @@ export async function runMemoryReviewCandidatesJob(ctx: BatchSchedulerRunContext
   try {
     assertSchedulerDbOpen(ctx.db);
 
-    const { inputs, nowIso, selectedCount } = buildMemoryReviewCandidateUpsertInputs(ctx.db!);
+    const nowIso = new Date().toISOString();
+    const queueControl = parseMemoryReviewQueueControlEnv();
+    const expired =
+      queueControl.candidateTtlDays > 0
+        ? bulkUpdatePendingMemoryReviewCandidates(
+            ctx.db!,
+            'expire',
+            { older_than_days: queueControl.candidateTtlDays },
+            nowIso
+          ).updated
+        : 0;
+    const pendingBefore = countPendingMemoryReviewCandidates(ctx.db!);
+    const skippedForBacklog =
+      queueControl.maxBacklog > 0 && pendingBefore >= queueControl.maxBacklog;
+
+    if (skippedForBacklog) {
+      result.success = true;
+      result.details = {
+        inserted: 0,
+        updated: 0,
+        expired,
+        pendingBefore,
+        pendingAfter: pendingBefore,
+        skippedForBacklog: true,
+        ...queueControl
+      };
+      ctx.log('Memory review candidates batch skipped at backlog limit', {
+        expired,
+        pending: pendingBefore,
+        maxBacklog: queueControl.maxBacklog
+      });
+      return result;
+    }
+
+    const remainingCapacity =
+      queueControl.maxBacklog === 0 ? undefined : queueControl.maxBacklog - pendingBefore;
+    const { inputs, selectedCount } = buildMemoryReviewCandidateUpsertInputs(
+      ctx.db!,
+      remainingCapacity
+    );
     const upsert = upsertPendingMemoryReviewCandidates(ctx.db!, inputs, nowIso);
+    const pendingAfter = countPendingMemoryReviewCandidates(ctx.db!);
     result.success = true;
     result.processed = inputs.length;
-    result.details = { inserted: upsert.inserted, updated: upsert.updated };
+    result.details = {
+      inserted: upsert.inserted,
+      updated: upsert.updated,
+      expired,
+      pendingBefore,
+      pendingAfter,
+      skippedForBacklog: false,
+      ...queueControl
+    };
 
     ctx.log('Memory review candidates batch completed', {
       selected: selectedCount,
       inserted: upsert.inserted,
-      updated: upsert.updated
+      updated: upsert.updated,
+      expired,
+      pendingBefore,
+      pendingAfter
     });
   } catch (error) {
     result.errors.push(error instanceof Error ? error.message : String(error));

--- a/packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts
@@ -3,16 +3,39 @@ import type { BatchJobResult } from './batch-scheduler-types.js';
 /** Issue #293: diagnostics / log aggregation용 고정 타입 */
 export const MEMORY_REVIEW_CANDIDATES_RUN_EVENT_TYPE = 'memory_review_candidates_run' as const;
 
-function readInsertedUpdated(details: unknown): { inserted: number; updated: number } {
+interface MemoryReviewCandidatesRunDetails {
+  inserted: number;
+  updated: number;
+  expired: number;
+  pendingBefore: number;
+  pendingAfter: number;
+  skippedForBacklog: boolean;
+}
+
+function readRunDetails(details: unknown): MemoryReviewCandidatesRunDetails {
   if (!details || typeof details !== 'object') {
-    return { inserted: 0, updated: 0 };
+    return {
+      inserted: 0,
+      updated: 0,
+      expired: 0,
+      pendingBefore: 0,
+      pendingAfter: 0,
+      skippedForBacklog: false
+    };
   }
   const d = details as Record<string, unknown>;
   const inserted = Number(d.inserted);
   const updated = Number(d.updated);
+  const expired = Number(d.expired);
+  const pendingBefore = Number(d.pendingBefore);
+  const pendingAfter = Number(d.pendingAfter);
   return {
     inserted: Number.isFinite(inserted) ? inserted : 0,
-    updated: Number.isFinite(updated) ? updated : 0
+    updated: Number.isFinite(updated) ? updated : 0,
+    expired: Number.isFinite(expired) ? expired : 0,
+    pendingBefore: Number.isFinite(pendingBefore) ? pendingBefore : 0,
+    pendingAfter: Number.isFinite(pendingAfter) ? pendingAfter : 0,
+    skippedForBacklog: d.skippedForBacklog === true
   };
 }
 
@@ -23,7 +46,14 @@ function readInsertedUpdated(details: unknown): { inserted: number; updated: num
 export function buildMemoryReviewCandidatesRunDiagnosticsPayload(
   result: BatchJobResult
 ): Record<string, unknown> {
-  const { inserted, updated } = readInsertedUpdated(result.details);
+  const {
+    inserted,
+    updated,
+    expired,
+    pendingBefore,
+    pendingAfter,
+    skippedForBacklog
+  } = readRunDetails(result.details);
   const errorCount = result.errors.length;
   const firstError =
     errorCount > 0 ? String(result.errors[0] ?? '').slice(0, 2000) : null;
@@ -38,6 +68,10 @@ export function buildMemoryReviewCandidatesRunDiagnosticsPayload(
     result: result.success ? 'success' : 'failure',
     inserted,
     updated,
+    expired,
+    pending_before: pendingBefore,
+    pending_after: pendingAfter,
+    skipped_for_backlog: skippedForBacklog,
     error_count: errorCount,
     selected_count: result.processed,
     first_error: firstError


### PR DESCRIPTION
## 변경 사항
- pending backlog 상한과 TTL 환경 설정을 추가합니다.
- 스케줄러 실행 전에 오래된 pending 후보를 만료시키고 남은 용량만 선택합니다.
- 실행 diagnostics에 backlog/expiration 메타를 기록하고 운영 문서를 갱신합니다.

## 변경 유형
- [x] 새로운 기능
- [x] 문서 업데이트
- [x] 테스트 추가/수정

## 관련 이슈
- Closes #520
- Related to #517
- Depends on #518

## 테스트
- 121 related tests passed
- core/server type-check passed
- lint: 0 errors
- graphify rebuild and `git diff --check` passed

## 코드 리뷰 포인트
- 상한이 기존 pending 수를 포함해 절대 초과하지 않는지
- `0` 설정이 상한/TTL을 각각 비활성화하는지
- 만료 수와 skip 사유가 diagnostics에 일관되게 기록되는지

## 지식 복리
- [x] 해당 없음

## 주의사항
- 기본값은 max pending 500, TTL 30일입니다.

## 체크리스트
- [x] 자체 검토 완료
- [x] API/환경 설정 문서 업데이트 완료
- [x] 새로운 경고나 오류 없음
- [x] 새 의존성 없음

## 배포
- [x] 환경 변수 변경 가능
- [x] DB 마이그레이션 불필요