### PR TITLE
docs: 에이전트 가이드 분리 및 Docker DB 배포 가드

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -6,34 +6,53 @@ alwaysApply: true
 
 # memento Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-14
+상세: [AGENTS.md](../../AGENTS.md) · [docs/agents/](../../docs/agents/README.md)
+
+Last updated: 2026-06-17
 
 ## Active Technologies
-- TypeScript 5.x, Node.js ≥ 24, ES modules + npm workspaces — `packages/memento-core` (`@memento/core`), `packages/memento-server` (MCP + Express HTTP admin), `packages/memento-client` (`@memento/client`); `better-sqlite3`, `zod`, Vitest, Express 5.x (server) (013-refactor-approach)
-- SQLite (`better-sqlite3`); **first wave** — no migrations or stored-format changes (FR-009) (013-refactor-approach)
-- 브라우저 정적 JS(`static/js/anchor-map.js`), D3.js, `mementoAdminFetch`/`fetch`; 스키마 변경 없음 (015-fix-anchor-map-search)
 
-- TypeScript (Node.js ≥ 24, ES modules) + Express 5.x, `cors`, `@memento/core`, `better-sqlite3` (001-http-trust-security)
+- TypeScript 5.x, Node.js ≥24, ES modules, npm workspaces
+- `packages/memento-core` (`@memento/core`), `memento-server`, `@memento/client`, `@memento/assistant`, `@memento/agent-integration`
+- SQLite (`better-sqlite3`, `sqlite-vec`), Zod, Vitest, Express 5.x
+- Admin UI: `static/js/`, D3.js; 스타일은 `static/css/tokens.css` 토큰 우선
 
 ## Project Structure
 
 ```text
-src/
+packages/
+  memento-core/src/domains/   # memory, search, embedding, forgetting, anchor, relation, procedural
+  memento-server/             # MCP stdio + Express HTTP admin
+  memento-client/
+  memento-assistant/
+  memento-agent-integration/
+apps/experimental-example/
 tests/
+static/                       # admin dashboard
+scripts/
 ```
 
 ## Commands
 
-npm test && npm run lint
+```bash
+npm install && npm run build && npm test
+npm run lint && npm run type-check   # 커밋 전 필수
+npm run dev          # MCP
+npm run dev:http     # HTTP admin
+```
+
+Docker·DB 운영: `npm run db:backup`, `db:pre-docker-deploy` — [commands.md](../../docs/agents/commands.md)
 
 ## Code Style
 
-TypeScript (Node.js ≥ 24, ES modules): Follow standard conventions
+TypeScript strict, 2-space indent, kebab-case 파일명 — [DEVELOPMENT_RULES.md](../../DEVELOPMENT_RULES.md)
 
 ## Recent Changes
-- 015-fix-anchor-map-search: Dashboard `static/js/anchor-map.js` 검색 시 nodes 미초기화 수정; D3; 스키마 변경 없음
-- 013-refactor-approach: Added TypeScript 5.x, Node.js ≥ 24, ES modules + npm workspaces — `packages/memento-core` (`@memento/core`), `packages/memento-server` (MCP + Express HTTP admin), `packages/memento-client` (`@memento/client`); `better-sqlite3`, `zod`, Vitest, Express 5.x (server)
 
+- `docs/agents/` 분리: AGENTS.md 마스터 + commands/architecture/agent-workflow 상세
+- Docker DB 운영 스크립트 (`db:backup`, `db:pre-docker-deploy`, `db:restore-from-corrupt`)
+- 015-fix-anchor-map-search: `static/js/anchor-map.js` 검색 시 nodes 미초기화 수정
+- 013-refactor-approach: npm workspaces 모노레포 (`packages/*`)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,88 +1,76 @@
 # Memento Agent Guidelines (Master Guide)
 
-이 파일은 Memento 저장소에서 작업하는 모든 AI 에이전트(Gemini, Claude 등)와 개발자를 위한 통합 가이드라인입니다. `CLAUDE.md`와 `GEMINI.md`의 내용을 모두 포함하고 있으며, 이 저장소의 근본적인 명령(Foundational Mandates)으로 간주됩니다.
+에이전트 가이드 **진입점**입니다. 상세는 [docs/agents/](./docs/agents/README.md)에 분리되어 있으며, **Karpathy 코딩 행동 지침(§4)은 이 파일에 유지**합니다. `CLAUDE.md`·`GEMINI.md`는 여기를 가리킵니다.
 
-## 1. 프로젝트 개요 (Project Overview)
+| 문서 | 내용 |
+|------|------|
+| [architecture.md](./docs/agents/architecture.md) | 패키지·도메인 |
+| [commands.md](./docs/agents/commands.md) | 명령·환경·Docker (배포 전 `db:pre-docker-deploy`) |
+| [agent-workflow.md](./docs/agents/agent-workflow.md) | MCP·graphify·UI·복리 |
+| [search-ranking.md](./docs/agents/search-ranking.md) | 랭킹 공식 |
+| [DEVELOPMENT_RULES.md](./DEVELOPMENT_RULES.md) | 코딩 표준 |
 
-Memento는 AI 에이전트를 위한 지능형 메모리 관리 시스템으로, 인간의 메모리 구조를 모델링한 MCP(Model Context Protocol) 서버입니다.
-- **메모리 유형**: Working (48h TTL), Episodic (90d TTL), Semantic (∞), Procedural (∞).
-- **기술 스택**: Node.js (≥24), TypeScript, SQLite (better-sqlite3), Vitest.
-- **핵심 기능**: 하이브리드 검색(FTS5 + Vector), 망각 정책(Forgetting Policies), 성능 모니터링, 다중 임베딩 프로바이더.
+## 1. 프로젝트 개요
 
-## 2. 프로젝트 구조 및 아키텍처 (Architecture)
+Memento는 AI 에이전트용 MCP 메모리 서버입니다.
+- **메모리**: Working (48h), Episodic (90d), Semantic/Procedural (∞)
+- **스택**: Node.js ≥24, TypeScript, SQLite, Vitest
+- **기능**: 하이브리드 검색(FTS5+Vector), 망각 정책, 다중 임베딩
 
-루트는 npm workspaces 기반의 모노레포 구조입니다.
+## 2. 빠른 시작
 
-### 패키지 구성
-- **packages/memento-core** (`@memento/core`): 모든 도메인 로직, DB, 서비스가 포함된 핵심 라이브러리.
-- **packages/memento-server**: MCP stdio 및 HTTP 관리 서버. core를 소비함.
-- **packages/memento-client** (`@memento/client`): 서버 연결용 클라이언트 라이브러리.
-- **apps/experimental-example**: core를 in-process로 사용하는 데모 앱.
-
-### 도메인 구조 (memento-core/src/domains/)
-- `memory/`: 저장(remember), 검색(recall), 고정(pin), 망각(forget).
-- `search/`: 하이브리드 검색 및 랭킹 엔진.
-- `embedding/`: 다중 프로바이더 지원 (TF-IDF, MiniLM, OpenAI, Gemini).
-- `forgetting/`: TTL 정책 및 데이터 정리.
-- `anchor/`: 컨텍스트 앵커 (A/B/C 슬롯) 기반 검색.
-- `relation/`: 메모리 관계 추출 및 시각화.
-- `procedural/`: 버전 관리가 가능한 절차적 메모리.
-
-## 3. 주요 명령어 (Commands)
-
-### 설정 및 빌드
 ```bash
-npm install          # 의존성 설치
-npm run build        # 전체 빌드 (core → server → client)
-npm run db:init      # SQLite 스키마 초기화
-npm run db:migrate   # 보류 중인 마이그레이션 실행
+npm install && npm run build && npm test
+npm run dev          # MCP
+npm run dev:http     # HTTP 관리
+npm run lint && npm run type-check  # 커밋 전 필수
 ```
 
-### 개발 및 실행
-```bash
-npm run dev          # MCP 서버 실행 (Watch 모드)
-npm run dev:http     # HTTP 관리 서버 실행 (Watch 모드)
-npm run start        # 컴파일된 서버 실행
-```
+전체 명령·환경: [commands.md](./docs/agents/commands.md) · 구조: [architecture.md](./docs/agents/architecture.md)
 
-### 테스트 및 품질 관리
-```bash
-npm test             # 전체 테스트 실행
-npm run lint         # 린트 체크
-npm run type-check   # 타입 체크
-npm run test:search  # 검색 시나리오 테스트
-```
+## 3. 에이전트 필수 습관
 
-## 4. 개발 규칙 및 코딩 스타일 (Development Guidelines)
+- 작업 전 `recall`/`memory_injection`, 후 `remember`
+- 아키텍처 질문 전 `graphify-out/GRAPH_REPORT.md` 확인; 코드 수정 후 graphify 재빌드
+- 커밋 전 `lint`, `type-check`, `test`
 
-모든 코딩 표준, 아키텍처 원칙, 스타일 가이드는 **[DEVELOPMENT_RULES.md](./DEVELOPMENT_RULES.md)**에 정의되어 있습니다. 에이전트와 개발자는 작업 시작 전 이 문서를 반드시 숙지해야 합니다.
+상세: [agent-workflow.md](./docs/agents/agent-workflow.md)
 
-- **핵심 원칙**: Functional Core, Structured Shell
-- **의존성 방향**: shared ← domains ← infrastructure
-- **품질 게이트**: 커밋 전 `lint`, `type-check`, `test` 통과 필수.
+## 4. 코딩 에이전트 행동 지침 (Karpathy Guidelines)
 
-## 5. 검색 랭킹 공식 (Search Ranking Formula)
+> 출처: [andrej-karpathy-skills/CLAUDE.md](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)
 
-검색 결과는 다음과 같은 가중치 공식을 통해 정렬됩니다 (`config/ranking-weights.toml` 참조):
-```
-S = α·relevance + β·recency + γ·importance + δ·usage + ζ·relation_weight + ζ_fb·(feedback_norm − 0.5) − ε·duplication_penalty
-(α=0.45, β=0.20, γ=0.20, δ=0.10, ζ=0.15, ζ_fb=0.05, ε=0.10)
-```
+**트레이드오프:** 속도보다 신중함 우선. 사소한 작업은 유연 적용.
 
-## 6. 에이전트 전용 지침 (Specialized Agent Instructions)
+### 4.1 구현 전에 생각하기 (Think Before Coding)
 
-에이전트의 도구 사용법 및 지식 관리 절차는 **[DEVELOPMENT_RULES.md#4-ai-에이전트-전용-지침-specialized-agent-rules](./DEVELOPMENT_RULES.md#4-ai-에이전트-전용-지침-specialized-agent-rules)**를 참조하십시오.
+**가정하지 말 것. 혼란을 숨기지 말 것. 트레이드오프를 드러낼 것.**
 
-- **MCP 사용**: 작업 전 `recall`, 작업 후 `remember`.
-- **Serena 활용**: 심볼 기반의 효율적 코드 탐색.
-- **graphify 분석 우선**: 코드베이스 구조나 아키텍처 관련 질문에 답하기 전 `graphify-out/GRAPH_REPORT.md`를 먼저 확인하고, `graphify-out/wiki/index.md`가 있으면 원시 파일보다 우선 탐색합니다.
-- **graphify 갱신**: 코드 수정 후 반드시 지식 그래프를 재빌드합니다.
-- **Design System (Dashboard)**: 웹 대시보드 UI 수정 시 `static/css/tokens.css`의 토큰을 우선적으로 사용하며, 리터럴 값 사용을 지양합니다. ([DESIGN.md](./docs/DESIGN.md) 참조)
-- **UI 수정 시 토큰 우선 사용**: 새로운 스타일이나 컴포넌트를 추가할 때 항상 디자인 토큰을 기반으로 구현하세요.
-- **PR·지식 복리 (Compound Engineering)**: 작업을 마치고 Pull Request를 준비하는 단계에서, 재현·진단이 어려웠던 버그 수정, 통합·운영·환경 이슈, 같은 실수가 반복될 수 있는 함정 정리 등에 해당하면 **`/ce-compound`** 로 해결 사례를 문서화하도록 사용자에게 제안한다. 전제는 **문제 해결 및 검증 완료**이며, 단순 오타·자명한 변경은 생략해도 된다. PR 본문에서는 [.github/PULL_REQUEST_TEMPLATE.md](./.github/PULL_REQUEST_TEMPLATE.md)의 **「지식 복리」** 칸을 채운다. 기여 절차 요약은 [CONTRIBUTING.md](./CONTRIBUTING.md)를 참조한다.
-- **해결 사례 문서 위치**: 이 저장소에서 작업용 해결 사례를 두는 경로는 **`docs/_work/solutions/`** 이다([docs/README.md](./docs/README.md)). Compound Engineering 기본 출력이 `docs/solutions/`인 경우, 저장소 규칙에 맞게 옮기거나 정리한다.
+- 가정을 명시한다. 불확실하면 질문한다.
+- 해석이 여러 가지면 제시한다.
+- 더 단순한 접근이 있으면 말한다.
+- 불명확하면 멈추고 질문한다.
 
-## 7. 최근 변경 사항 및 활성 기술
-- **016-env-config-cleanup**: 환경 설정 파일 및 문서 정리.
-- **005-sleep-consolidation**: 에피소딕 → 시맨틱 오프라인 증류 서비스 추가.
-- **011-docker-security-hardening**: 보안 강화 및 Helmet.js 적용.
+### 4.2 단순함 우선 (Simplicity First)
+
+**최소 코드만. 추측성 코드 금지.**
+
+- 요청 범위 초과·단일용 추상화·미요청 설정성·불가능 시나리오 에러 처리 금지
+- 200줄이 50줄이 될 수 있으면 다시 쓴다
+
+### 4.3 수술적 변경 (Surgical Changes)
+
+**꼭 필요한 것만 수정. 자신이 만든 unused만 정리.**
+
+- 인접 코드·포맷 "개선", 무관 리팩터, 기존 dead code 삭제 금지
+- 변경 줄은 사용자 요청에 직접 연결되어야 한다
+
+### 4.4 목표 기반 실행 (Goal-Driven Execution)
+
+**성공 기준을 정의하고 검증될 때까지 반복.**
+
+- "검증 추가" → 잘못된 입력 테스트 작성 후 통과
+- "버그 수정" → 재현 테스트 후 통과
+- 다단계 작업은 `단계 → 검증 방법` 계획을 먼저 제시
+
+**잘 작동하면:** diff 노이즈·과도한 재작성이 줄고, 구현 전에 질문이 나온다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,13 @@
 # CLAUDE.md
 
-This repository follows a unified guidance system for AI agents. 
+이 저장소의 프로젝트 컨텍스트·명령어·에이전트 워크플로는 **[AGENTS.md](./AGENTS.md)** 에서만 관리합니다.
 
-**IMPORTANT: Please read [AGENTS.md](./AGENTS.md) for the master guide on project overview, architecture, commands, and development workflows.**
+**작업 시작 전 [AGENTS.md](./AGENTS.md)를 읽으십시오.**
 
-## Quick Reference
-- **Master Guide**: [AGENTS.md](./AGENTS.md)
-- **Architecture**: npm workspaces (@memento/core, memento-server, @memento/client)
-- **Primary Commands**: `npm install`, `npm run build`, `npm run dev`, `npm test`
-- **MCP Usage**: Use `recall`/`memory_injection` before work and `remember` after work.
-- **PR / compound learnings**: See [AGENTS.md](./AGENTS.md) §6 — suggest conditional `/ce-compound` before opening a PR when applicable; PR template「지식 복리」.
+| 상세 문서 (`docs/agents/`) | |
+|---------------------------|---|
+| [commands.md](./docs/agents/commands.md) | npm·Docker·DB 운영 |
+| [architecture.md](./docs/agents/architecture.md) | 패키지·도메인 구조 |
+| [agent-workflow.md](./docs/agents/agent-workflow.md) | MCP·graphify·UI |
+
+**요구사항:** Node.js ≥24, npm ≥10

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,13 +1,13 @@
 # GEMINI.md
 
-이 저장소는 AI 에이전트를 위한 통합 가이드 시스템을 따릅니다.
+이 저장소의 프로젝트 컨텍스트·명령어·에이전트 워크플로는 **[AGENTS.md](./AGENTS.md)** 에서만 관리합니다.
 
-**중요: 프로젝트 개요, 아키텍처, 명령어, 개발 워크플로우에 대한 마스터 가이드는 [AGENTS.md](./AGENTS.md)를 참조하십시오.**
+**작업 시작 전 [AGENTS.md](./AGENTS.md)를 읽으십시오.**
 
-## 빠른 참조 (Quick Reference)
-- **마스터 가이드**: [AGENTS.md](./AGENTS.md)
-- **아키텍처**: npm workspaces (@memento/core, memento-server, @memento/client)
-- **핵심 명령어**: `npm install`, `npm run build`, `npm run dev`, `npm test`
-- **MCP 사용**: 작업 전 `recall`/`memory_injection` 조회, 작업 후 `remember` 저장.
-- **graphify**: 코드 수정 후 지식 그래프 재빌드 명령 실행 필수.
-- **PR·지식 복리**: [AGENTS.md](./AGENTS.md) 6절 — PR 준비 시 해당하면 **`/ce-compound`** 제안, PR 템플릿 「지식 복리」 참고.
+| 상세 문서 (`docs/agents/`) | |
+|---------------------------|---|
+| [commands.md](./docs/agents/commands.md) | npm·Docker·DB 운영 |
+| [architecture.md](./docs/agents/architecture.md) | 패키지·도메인 구조 |
+| [agent-workflow.md](./docs/agents/agent-workflow.md) | MCP·graphify·UI |
+
+**요구사항:** Node.js ≥24, npm ≥10

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -59,6 +59,7 @@ services:
       - ${HOME}/.memento/data:/app/data
       - ${HOME}/.memento/logs:/app/logs
     restart: unless-stopped
+    stop_grace_period: 30s
     stdin_open: true
     tty: true
     # Docker 엔진 내부의 json-file 로그가 무한정 커져서

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ MCP·CLI·대시보드를 **설치·연동·운영**할 때 필요한 문서입�
 | Cursor / MCP 설정 | [cursor-mcp-setup.md](guides/ko/cursor-mcp-setup.md) | [cursor-mcp-setup.md](guides/en/cursor-mcp-setup.md) |
 | Memento CLI for AI | [memento-cli-for-ai.md](guides/ko/memento-cli-for-ai.md) | — |
 
-- **저장소 루트**: [README.md](../README.md), [README.en.md](../README.en.md), [GEMINI.md](../GEMINI.md), [AGENTS.md](../AGENTS.md)
+- **저장소 루트**: [README.md](../README.md), [README.en.md](../README.en.md), [GEMINI.md](../GEMINI.md), [AGENTS.md](../AGENTS.md) (상세: [agents/](agents/README.md))
 
 ### 연동·레퍼런스
 
@@ -77,6 +77,7 @@ MCP·CLI·대시보드를 **설치·연동·운영**할 때 필요한 문서입�
 | 검토 큐 안전 정리 | [review-queue-cleanup.md](operations/ko/review-queue-cleanup.md) | [review-queue-cleanup.md](operations/en/review-queue-cleanup.md) |
 | 문서 전수 검수 (worktree) | [doc-audit-workflow.md](operations/ko/doc-audit-workflow.md) | — |
 | 배포 전 환경변수 점검 | [env-deployment-checklist.md](operations/env-deployment-checklist.md) | — |
+| Docker 배포 절차 (DB 백업 포함) | [docker-deploy-procedure.md](operations/ko/docker-deploy-procedure.md) | — |
 | 트러블슈팅 | [npx-troubleshooting.md](operations/ko/npx-troubleshooting.md) 등 | [operations/en/](operations/en/) |
 
 ### 참조 (reference)

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,12 @@
+# 에이전트 가이드 (상세)
+
+[AGENTS.md](../../AGENTS.md)의 상세 문서입니다. 마스터 진입점은 루트 `AGENTS.md`이며, Karpathy 코딩 행동 지침은 거기에 유지됩니다.
+
+| 문서 | 내용 |
+|------|------|
+| [architecture.md](./architecture.md) | 모노레포 패키지·도메인 구조 |
+| [commands.md](./commands.md) | npm 명령·환경 변수·Docker/DB 운영 |
+| [agent-workflow.md](./agent-workflow.md) | MCP·graphify·대시보드·지식 복리 |
+| [search-ranking.md](./search-ranking.md) | 검색 랭킹 가중치 공식 |
+
+코딩 표준·에이전트 규칙 상세: [DEVELOPMENT_RULES.md](../../DEVELOPMENT_RULES.md)

--- a/docs/agents/agent-workflow.md
+++ b/docs/agents/agent-workflow.md
@@ -1,0 +1,34 @@
+# 에이전트 워크플로
+
+[DEVELOPMENT_RULES.md §4](../../DEVELOPMENT_RULES.md#4-ai-에이전트-전용-지침-specialized-agent-rules)와 함께 적용합니다.
+
+## MCP·메모리
+
+- **작업 전**: `recall` 또는 `memory_injection`
+- **작업 후**: `remember` (타입: working/episodic/semantic/procedural 구분)
+
+## 코드 탐색 (Serena)
+
+- 파일 전체 읽기 전 `get_symbols_overview`·`find_symbol` 우선
+- 50줄 미만 파일만 전체 읽기
+
+## graphify
+
+- **분석 전**: `graphify-out/GRAPH_REPORT.md` 확인; `graphify-out/wiki/index.md` 있으면 위키 우선
+- **코드 수정 후** 재빌드:
+
+```bash
+python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"
+```
+
+## 대시보드 UI
+
+- `static/css/tokens.css` 디자인 토큰 우선 ([DESIGN.md](../DESIGN.md))
+- 리터럴 색·간격 값 지양
+
+## PR·지식 복리
+
+- 재현 어려운 버그·운영 함정 해결 후 PR 준비 시 `/ce-compound` 제안 (검증 완료 후)
+- 해결 사례 경로: `docs/_work/solutions/` ([docs/README.md](../README.md))
+- PR 템플릿 「지식 복리」: [.github/PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md)
+- 기여 절차: [CONTRIBUTING.md](../../CONTRIBUTING.md)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,39 @@
+# 아키텍처
+
+루트는 npm workspaces 기반 모노레포입니다.
+
+## 패키지 구성
+
+| 패키지 | 역할 |
+|--------|------|
+| `packages/memento-core` (`@memento/core`) | 도메인 로직, DB, 서비스 |
+| `packages/memento-server` | MCP stdio·HTTP 관리 서버 |
+| `packages/memento-client` (`@memento/client`) | 서버 연결 클라이언트 |
+| `packages/memento-assistant` (`@memento/assistant`) | 에이전트 어시스턴트 유틸리티 |
+| `packages/memento-agent-integration` (`@memento/agent-integration`) | 에이전트 통합 계약·어댑터 |
+| `apps/experimental-example` | core in-process 데모 |
+
+## 도메인 구조 (`memento-core/src/domains/`)
+
+| 경로 | 역할 |
+|------|------|
+| `memory/` | remember, recall, pin, forget |
+| `search/` | 하이브리드 검색·랭킹 |
+| `embedding/` | TF-IDF, MiniLM, OpenAI, Gemini |
+| `forgetting/` | TTL·데이터 정리 |
+| `anchor/` | 앵커 슬롯(A/B/C) 검색 |
+| `relation/` | 관계 추출·시각화 |
+| `procedural/` | 버전 관리 절차 메모리 |
+
+## 개발 원칙
+
+- **Functional Core, Structured Shell**
+- **의존성 방향**: `shared` ← `domains` ← `infrastructure`
+- 상세: [DEVELOPMENT_RULES.md](../../DEVELOPMENT_RULES.md)
+
+## 최근 활성 기술
+
+- Docker DB 운영 (`db:backup`, `db:pre-docker-deploy` 등)
+- 에피소딕 → 시맨틱 오프라인 증류 (`005-sleep-consolidation`)
+- Docker 보안 강화·Helmet.js (`011-docker-security-hardening`)
+- 환경 설정 정리 (`016-env-config-cleanup`)

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -1,0 +1,53 @@
+# 명령어·환경·운영
+
+## 설정 및 빌드
+
+```bash
+npm install          # 의존성 설치
+npm run build        # 전체 빌드 (core → server → client)
+npm run db:init      # SQLite 스키마 초기화
+npm run db:migrate   # 보류 중인 마이그레이션 실행
+```
+
+## 개발 및 실행
+
+```bash
+npm run dev          # MCP 서버 (Watch)
+npm run dev:http     # HTTP 관리 서버 (Watch)
+npm run dev:http-v2  # HTTP v2 관리 서버 (Watch)
+npm run start        # 컴파일된 MCP 서버
+npm run start:http   # 컴파일된 HTTP 서버
+```
+
+## 테스트 및 품질
+
+```bash
+npm test             # 전체 테스트
+npm run lint         # 린트
+npm run type-check   # 타입 체크
+npm run test:search  # 검색 시나리오 테스트
+```
+
+커밋 전 `lint`, `type-check`, `test` 통과 필수.
+
+## Docker 및 DB 운영
+
+```bash
+npm run db:backup                 # 메모리 DB 백업
+npm run db:restore-from-corrupt   # 손상 DB 복구
+npm run db:pre-docker-deploy      # Docker 배포 전 무결성 점검
+npm run docker:build              # 이미지 빌드
+npm run docker:up                 # 컨테이너 기동
+```
+
+배포 절차: [docker-deploy-procedure.md](../operations/ko/docker-deploy-procedure.md)
+
+## 환경 변수 (요약)
+
+| 변수 | 용도 |
+|------|------|
+| `DB_PATH` | SQLite 경로 (프로덕션은 절대 경로; `~` 미확장) |
+| `ADMIN_API_KEY` | HTTP 관리 API 키 (프로덕션 필수) |
+| `MEMENTO_HTTP_BIND_HOST` | HTTP 바인드 (기본 `127.0.0.1`) |
+
+상세: [environment-variable-governance.md](../guides/ko/environment-variable-governance.md), [env-deployment-checklist.md](../operations/env-deployment-checklist.md)

--- a/docs/agents/search-ranking.md
+++ b/docs/agents/search-ranking.md
@@ -1,0 +1,19 @@
+# 검색 랭킹 공식
+
+검색 결과 정렬 가중치 (`config/ranking-weights.toml`):
+
+```
+S = α·relevance + β·recency + γ·importance + δ·usage + ζ·relation_weight + ζ_fb·(feedback_norm − 0.5) − ε·duplication_penalty
+```
+
+| 계수 | 값 |
+|------|-----|
+| α (relevance) | 0.45 |
+| β (recency) | 0.20 |
+| γ (importance) | 0.20 |
+| δ (usage) | 0.10 |
+| ζ (relation_weight) | 0.15 |
+| ζ_fb (feedback) | 0.05 |
+| ε (duplication) | 0.10 |
+
+튜닝: [recall-performance-tuning.md](../guides/ko/recall-performance-tuning.md)

--- a/docs/operations/env-deployment-checklist.md
+++ b/docs/operations/env-deployment-checklist.md
@@ -22,3 +22,4 @@
 ## 검증
 
 - [ ] `npm run lint`, `npm run type-check`, `npm test`가 통과했는가?
+- [ ] Docker 재배포 전 [Docker 배포 절차](ko/docker-deploy-procedure.md)에 따라 `npm run db:pre-docker-deploy`를 실행했는가?

--- a/docs/operations/ko/docker-deploy-procedure.md
+++ b/docs/operations/ko/docker-deploy-procedure.md
@@ -1,0 +1,221 @@
+# Docker 배포 절차 (권장)
+
+Memento MCP/HTTP 서버를 Docker로 **재배포·재시작**할 때 따르는 공식 절차입니다.  
+`memory.db`는 호스트 `~/.memento/data/`에 마운트되므로, 컨테이너 재기동만으로도 DB 무결성 검사(`quick_check`)가 실행됩니다. 손상된 DB는 서버가 **의도적으로 기동을 거부**합니다.
+
+관련 문서:
+
+- [배포 전 환경변수 점검](../env-deployment-checklist.md)
+- [Docker 설정 가이드](../../../DOCKER_SETUP_GUIDE.md)
+- [scripts/ 스크립트 인덱스](scripts-index.md)
+
+---
+
+## 언제 이 절차를 따르나
+
+다음 작업 **전·후**에 적용합니다.
+
+- `docker compose build` 후 `up -d` (이미지 재빌드·배포)
+- `docker compose up -d`로 컨테이너 재생성
+- Dockerfile·서버 코드·정적 대시보드 변경을 운영 인스턴스에 반영할 때
+
+로컬에서 `npm run dev`만 쓰는 경우에는 **Docker와 동시에 같은 `memory.db`를 쓰지 마세요** (writer는 한 프로세스만).
+
+---
+
+## 사전 조건
+
+| 항목 | 내용 |
+|------|------|
+| DB 경로 (호스트) | `~/.memento/data/memory.db` |
+| DB 경로 (컨테이너) | `/app/data/memory.db` (`DB_PATH`) |
+| 백업 출력 | `~/.memento/data/backups/memory-backup-<timestamp>.db` |
+| 저장소 루트 | `git clone`된 memento 디렉터리에서 명령 실행 |
+
+---
+
+## 표준 배포 절차
+
+### 1. 서버 중지
+
+DB에 대한 **유일한 writer**를 제거합니다. 백업 API가 빈 파일을 만들지 않도록 먼저 중지합니다.
+
+```bash
+cd /path/to/memento
+docker compose stop memento-mcp-server
+```
+
+### 2. 배포 전 DB 검사 및 백업
+
+```bash
+npm run db:pre-docker-deploy
+```
+
+이 명령은 다음을 수행합니다.
+
+1. `npm run db:backup` — SQLite **online backup API**로 일관된 스냅샷 생성 (`copy` / `copyFileSync` 사용 안 함)
+2. 백업 파일에 대해 `PRAGMA quick_check` 실행
+3. 실패 시 **종료 코드 1** (배포 중단)
+
+성공 시 JSON 예시:
+
+```json
+{
+  "ok": true,
+  "dbPath": "/home/<user>/.memento/data/memory.db",
+  "backupPath": "/home/<user>/.memento/data/backups/memory-backup-....db",
+  "quick_check": "ok",
+  "memory_item": 26474
+}
+```
+
+> **주의:** 컨테이너가 DB를 잡고 있는 상태에서 백업하면 0바이트 파일이 생길 수 있습니다. 반드시 **1단계 중지 후** 실행하세요.
+
+### 3. (선택) 코드 품질 게이트
+
+```bash
+npm run lint && npm run type-check && npm test
+```
+
+### 4. 이미지 빌드 및 기동
+
+```bash
+docker compose build memento-mcp-server
+docker compose up -d memento-mcp-server
+```
+
+`docker-compose.base.yml`에는 `stop_grace_period: 30s`가 설정되어 있어, 정상 `stop` 시 WAL flush 시간을 확보합니다. 컨테이너 기동 시 `scripts/start-container.sh`가 `PRAGMA wal_checkpoint(PASSIVE)`를 시도합니다.
+
+### 5. 배포 후 확인
+
+```bash
+docker compose ps memento-mcp-server
+docker compose logs --tail=50 memento-mcp-server
+curl -sf http://localhost:9001/health
+sqlite3 ~/.memento/data/memory.db "PRAGMA quick_check; SELECT count(*) FROM memory_item;"
+```
+
+`health` 응답에 `"database":"connected"`가 포함되고, `quick_check`가 `ok`이면 정상입니다.
+
+---
+
+## 한 줄 요약 (체크리스트)
+
+```bash
+docker compose stop memento-mcp-server
+npm run db:pre-docker-deploy
+docker compose build memento-mcp-server
+docker compose up -d memento-mcp-server
+curl -sf http://localhost:9001/health
+```
+
+---
+
+## npm 스크립트 참고
+
+| 명령 | 용도 |
+|------|------|
+| `npm run db:backup` | online backup만 수행 (서버 중지 후 권장) |
+| `npm run db:pre-docker-deploy` | 백업 + `quick_check`; 실패 시 배포 중단 |
+| `npm run db:pre-docker-deploy -- --force` | 검사 실패해도 계속 (**위험**, 손상 DB 확인 후에만) |
+| `npm run db:restore-from-corrupt` | 손상 DB에서 테이블별 복구 (아래 복구 절 참고) |
+
+환경 변수 `DB_PATH`로 대상 DB를 바꿀 수 있습니다 (기본: `~/.memento/data/memory.db`).
+
+```bash
+DB_PATH=/custom/path/memory.db npm run db:backup
+```
+
+---
+
+## 롤백
+
+배포 후 문제가 있으면 **가장 최근 성공 백업**으로 되돌립니다.
+
+```bash
+docker compose stop memento-mcp-server
+
+BACKUP=~/.memento/data/backups/memory-backup-<timestamp>.db   # pre-docker-deploy 출력 경로
+cp ~/.memento/data/memory.db ~/.memento/data/memory.db.before-rollback-$(date -u +%Y%m%dT%H%M%SZ).db
+cp "$BACKUP" ~/.memento/data/memory.db
+
+sqlite3 ~/.memento/data/memory.db "PRAGMA quick_check;"
+
+docker compose up -d memento-mcp-server
+```
+
+이전 Docker 이미지로 되돌리려면 해당 태그/이미지 ID로 `docker compose up` 전에 이미지를 지정합니다.
+
+---
+
+## DB 손상 시 복구 (배포 실패·crash loop)
+
+### 증상
+
+- 컨테이너가 `database disk image is malformed` 등으로 **재시작 반복**
+- `npm run db:pre-docker-deploy`에서 `quick_check` 실패
+
+### 하지 말 것
+
+| 방법 | 이유 |
+|------|------|
+| `sqlite3 .recover` 결과를 곧바로 `memory.db`로 교체 | 대부분 행이 누락될 수 있음 (실제 사례: 2만+건 → 10건) |
+| 실행 중 DB를 `cp` / `copyFileSync`로 복사 | WAL 미반영·불완전 복사 위험 |
+| 손상 파일을 그대로 production에 사용 | `quick_check` 실패; 추가 손상 가능 |
+
+### 권장 복구
+
+1. 손상본을 **이름 변경으로 보존** (`memory.db.pre-recover-<timestamp>.db`)
+2. `scripts/restore-memory-db-from-corrupt.mjs`로 깨끗한 DB에 **테이블별 복사**
+
+```bash
+docker compose stop memento-mcp-server
+
+node scripts/restore-memory-db-from-corrupt.mjs \
+  --source ~/.memento/data/memory.db.pre-recover-<timestamp>.db \
+  --target ~/.memento/data/memory-restored.db
+
+sqlite3 ~/.memento/data/memory-restored.db "PRAGMA quick_check;"
+
+# 확인 후 교체
+cp ~/.memento/data/memory.db ~/.memento/data/memory.db.before-restore-$(date -u +%Y%m%dT%H%M%SZ).db
+mv ~/.memento/data/memory-restored.db ~/.memento/data/memory.db
+
+docker compose up -d memento-mcp-server
+```
+
+특정 테이블만 다시 합칠 때 (`memory_embedding` 등):
+
+```bash
+node scripts/restore-memory-db-from-corrupt.mjs \
+  --source ~/.memento/data/memory.db.pre-recover-<timestamp>.db \
+  --target ~/.memento/data/memory.db \
+  --only-tables memory_embedding
+```
+
+`memory_embedding` 복구 시 vec0 트리거가 없는 환경에서는 스크립트가 트리거를 DROP한 뒤 복사합니다. 서버 재기동 시 마이그레이션·vec 인덱스가 다시 맞춰집니다.
+
+손상본은 `~/.memento/data/quarantine/`에도 복사될 수 있습니다. crash loop 시 **15분 내 동일 크기 파일은 한 번만** quarantine에 저장됩니다.
+
+---
+
+## 재발 방지 요약
+
+1. **배포 전** `npm run db:pre-docker-deploy` (이 문서의 표준 절차)
+2. **Docker와 로컬 dev 동시 접근 금지** — 같은 `memory.db`에 writer 2개 금지
+3. **정상 종료** — `docker compose stop` (kill -9 지양); `stop_grace_period: 30s` 활용
+4. **백업 보관** — `~/.memento/data/backups/`에 타임스탬프 백업 유지; 오래된 quarantine 중복본은 정리 검토
+5. **배포 전 환경변수** — [env-deployment-checklist.md](../env-deployment-checklist.md)
+
+---
+
+## 문제 해결
+
+| 현상 | 조치 |
+|------|------|
+| `db:backup`이 빈 파일(0바이트) | `docker compose stop memento-mcp-server` 후 재실행 |
+| `quick_check` 실패 | 위 [DB 손상 시 복구](#db-손상-시-복구-배포-실패crash-loop) 절차 |
+| health는 ok인데 검색 품질 저하 | `memory_embedding` 건수 확인; `--only-tables memory_embedding` 병합 검토 |
+| quarantine 디스크 과다 | pre-recover·최신 backup 확인 후 중복 quarantine 파일 정리 |
+
+추가 Docker 설정은 [DOCKER_SETUP_GUIDE.md](../../../DOCKER_SETUP_GUIDE.md)를 참고하세요.

--- a/docs/operations/ko/scripts-index.md
+++ b/docs/operations/ko/scripts-index.md
@@ -19,6 +19,9 @@
 | tune-weights.ts | 랭킹 가중치 자동 튜닝 (후보 생성·평가·게이트) | `npm run quality:benchmark:tune-weights` |
 | tune-report.ts | 튜닝 run 결과 리포트 출력 | `npm run quality:benchmark:tune-report` |
 | migrate-embedding-data.js | 임베딩 데이터 마이그레이션 | `npm run migrate:embedding`, `migrate:embedding:analyze`, `migrate:embedding:rollback` |
+| backup-memory-db.mjs | memory.db online backup (배포 전) | `npm run db:backup` |
+| pre-docker-deploy.mjs | 배포 전 백업 + quick_check | `npm run db:pre-docker-deploy` |
+| restore-memory-db-from-corrupt.mjs | 손상 DB 테이블별 복구 | `npm run db:restore-from-corrupt` (인자: `--source`, `--target`, 선택 `--only-tables`) |
 | backup-embeddings.js | 임베딩 백업 | `npm run backup:embeddings` |
 | regenerate-embeddings.js | 임베딩 재생성 | `npm run regenerate:embeddings` |
 | debug-embeddings.js | 임베딩 디버깅 | `npm run debug:embeddings` |

--- a/scripts/backup-memory-db.mjs
+++ b/scripts/backup-memory-db.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Create a consistent SQLite backup using the online backup API (not cp/copyFileSync).
+ *
+ * Usage:
+ *   DB_PATH=~/.memento/data/memory.db node scripts/backup-memory-db.mjs
+ *   npm run db:backup
+ */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+function resolveDbPath() {
+  if (process.env.DB_PATH) {
+    return path.resolve(process.env.DB_PATH);
+  }
+  return path.join(os.homedir(), '.memento', 'data', 'memory.db');
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+const dbPath = resolveDbPath();
+if (!fs.existsSync(dbPath)) {
+  console.error(JSON.stringify({ ok: false, error: `DB not found: ${dbPath}` }));
+  process.exit(1);
+}
+
+const backupDir = path.join(path.dirname(dbPath), 'backups');
+fs.mkdirSync(backupDir, { recursive: true });
+const backupPath = path.join(backupDir, `memory-backup-${timestamp()}.db`);
+
+if (fs.existsSync(backupPath)) {
+  fs.unlinkSync(backupPath);
+}
+
+const source = new Database(dbPath, { readonly: true, fileMustExist: true });
+source.pragma('busy_timeout = 10000');
+
+try {
+  await source.backup(backupPath);
+} catch (error) {
+  source.close();
+  if (fs.existsSync(backupPath)) {
+    fs.unlinkSync(backupPath);
+  }
+  console.error(
+    JSON.stringify({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      hint: 'Stop the MCP server (docker compose stop) and retry if the DB is locked.',
+    })
+  );
+  process.exit(1);
+} finally {
+  source.close();
+}
+
+for (const suffix of ['-wal', '-shm']) {
+  const sidecar = backupPath + suffix;
+  if (fs.existsSync(sidecar)) {
+    fs.unlinkSync(sidecar);
+  }
+}
+
+const backupStat = fs.statSync(backupPath);
+if (backupStat.size === 0) {
+  fs.unlinkSync(backupPath);
+  console.error(JSON.stringify({ ok: false, error: 'Backup file is empty', dbPath, backupPath }));
+  process.exit(1);
+}
+
+const verify = new Database(backupPath, { readonly: true });
+const quickCheck = verify.pragma('quick_check', { simple: true });
+let memoryItemCount = null;
+try {
+  memoryItemCount = verify.prepare('SELECT count(*) AS c FROM memory_item').get().c;
+} catch {
+  // schema without memory_item (test DB)
+}
+verify.close();
+
+const result = {
+  ok: quickCheck === 'ok',
+  dbPath,
+  backupPath,
+  quick_check: quickCheck,
+  memory_item: memoryItemCount,
+};
+
+console.log(JSON.stringify(result, null, 2));
+if (!result.ok) {
+  process.exit(1);
+}

--- a/scripts/pre-docker-deploy.mjs
+++ b/scripts/pre-docker-deploy.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Safe guard before `docker compose up` / image rebuild:
+ * 1) online backup via sqlite backup API
+ * 2) quick_check on live DB (abort when corrupt unless --force)
+ *
+ * Usage:
+ *   node scripts/pre-docker-deploy.mjs
+ *   node scripts/pre-docker-deploy.mjs --force
+ */
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const force = process.argv.includes('--force');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const backupScript = path.join(root, 'scripts', 'backup-memory-db.mjs');
+
+const backup = spawnSync(process.execPath, [backupScript], {
+  cwd: root,
+  encoding: 'utf8',
+  env: process.env,
+});
+
+if (backup.stdout) {
+  process.stdout.write(backup.stdout);
+}
+if (backup.stderr) {
+  process.stderr.write(backup.stderr);
+}
+
+if (backup.status !== 0) {
+  if (force) {
+    console.warn('[pre-docker-deploy] backup/quick_check failed; continuing because --force was set');
+    process.exit(0);
+  }
+  console.error(
+    '[pre-docker-deploy] Aborting: fix DB or pass --force only if you accept the risk.'
+  );
+  process.exit(backup.status ?? 1);
+}
+
+console.log('[pre-docker-deploy] Backup OK; safe to restart Docker.');

--- a/scripts/restore-memory-db-from-corrupt.mjs
+++ b/scripts/restore-memory-db-from-corrupt.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Copy readable rows from a corrupt-but-queryable memory.db into a clean schema shell.
+ * Usage (host):
+ *   docker run --rm -v "$HOME/.memento/data:/data" memento-memento-mcp-server:latest \
+ *     node /app/scripts/restore-memory-db-from-corrupt.mjs \
+ *     --source /data/memory.db.pre-recover-20260615T120932Z.db \
+ *     --target /data/memory-restored-final.db
+ */
+import Database from 'better-sqlite3';
+import fs from 'fs';
+import path from 'path';
+import { normalizeReflectionNotes } from '../packages/memento-core/dist/shared/utils/reflection-notes-normalize.js';
+
+function parseArgs(argv) {
+  const out = { source: '', target: '', onlyTables: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--source') out.source = argv[++i] ?? '';
+    if (argv[i] === '--target') out.target = argv[++i] ?? '';
+    if (argv[i] === '--only-tables') {
+      const raw = argv[++i] ?? '';
+      out.onlyTables = raw.split(',').map((name) => name.trim()).filter(Boolean);
+    }
+  }
+  if (!out.source || !out.target) {
+    throw new Error('Usage: --source <corrupt.db> --target <output.db> [--only-tables table1,table2]');
+  }
+  return out;
+}
+
+function tableNames(db) {
+  return db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )
+    .all()
+    .map((row) => row.name);
+}
+
+function columnInfo(db, table, schema = 'main') {
+  if (schema === 'main') {
+    return db.prepare(`PRAGMA table_info("${table}")`).all();
+  }
+  return db.prepare('SELECT * FROM pragma_table_info(?, ?)').all(table, schema);
+}
+
+function columns(db, table, schema = 'main') {
+  return columnInfo(db, table, schema).map((row) => row.name);
+}
+
+function selectExpr(targetCol, targetInfo) {
+  const meta = targetInfo.find((row) => row.name === targetCol);
+  const ref = `"${targetCol}"`;
+  if (!meta || !meta.notnull) {
+    return ref;
+  }
+  if (meta.dflt_value != null && meta.dflt_value !== '') {
+    return `COALESCE(${ref}, ${meta.dflt_value})`;
+  }
+  if (meta.type.toUpperCase().includes('BOOL')) {
+    return `COALESCE(${ref}, 0)`;
+  }
+  if (meta.type.toUpperCase().includes('INT')) {
+    return `COALESCE(${ref}, 0)`;
+  }
+  if (meta.type.toUpperCase().includes('REAL')) {
+    return `COALESCE(${ref}, 0.0)`;
+  }
+  return `COALESCE(${ref}, '')`;
+}
+
+function shouldSkipTable(name) {
+  return (
+    name.startsWith('memory_item_vec') ||
+    name.startsWith('memory_item_fts') ||
+    name === 'sqlite_sequence'
+  );
+}
+
+const { source, target, onlyTables } = parseArgs(process.argv);
+if (!fs.existsSync(source)) {
+  throw new Error(`Source not found: ${source}`);
+}
+if (onlyTables && !fs.existsSync(target)) {
+  throw new Error(`Merge target not found: ${target}`);
+}
+
+const onlyTableSet = onlyTables ? new Set(onlyTables) : null;
+
+for (const suffix of ['-wal', '-shm']) {
+  const sidecar = target + suffix;
+  if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
+}
+
+const tgt = new Database(target);
+tgt.function('normalize_reflection_notes', { deterministic: true }, (value) =>
+  normalizeReflectionNotes(value)
+);
+tgt.pragma('foreign_keys = OFF');
+tgt.exec(`ATTACH '${source.replace(/'/g, "''")}' AS src`);
+
+const srcTables = new Set(
+  tgt
+    .prepare("SELECT name FROM src.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+    .all()
+    .map((row) => row.name)
+);
+
+function dropVecTriggers(db, table) {
+  if (table !== 'memory_embedding') return;
+  for (const name of [
+    'memory_embedding_vec_insert',
+    'memory_embedding_vec_update',
+    'memory_embedding_vec_delete',
+  ]) {
+    db.exec(`DROP TRIGGER IF EXISTS ${name}`);
+  }
+}
+
+const results = [];
+const tablesToCopy = tableNames(tgt).filter((table) => {
+  if (shouldSkipTable(table) || !srcTables.has(table)) return false;
+  if (onlyTableSet) return onlyTableSet.has(table);
+  return true;
+});
+
+for (const table of tablesToCopy) {
+  const common = columns(tgt, table).filter((col) => columns(tgt, table, 'src').includes(col));
+  if (common.length === 0) continue;
+  const targetInfo = columnInfo(tgt, table);
+  const colList = common.map((col) => `"${col}"`).join(', ');
+  const selectList = common.map((col) => selectExpr(col, targetInfo)).join(', ');
+  try {
+    dropVecTriggers(tgt, table);
+    tgt.exec(`DELETE FROM "${table}"`);
+    const info = tgt
+      .prepare(`INSERT INTO "${table}" (${colList}) SELECT ${selectList} FROM src."${table}"`)
+      .run();
+    results.push({ table, status: 'ok', rows: info.changes });
+  } catch (error) {
+    results.push({
+      table,
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+tgt.exec('DETACH src');
+
+// Rebuild FTS shadow index from memory_item rows.
+if (!onlyTableSet || onlyTableSet.has('memory_item')) {
+try {
+  tgt.exec('DELETE FROM memory_item_fts');
+  tgt.exec(`
+    INSERT INTO memory_item_fts(rowid, content, tags, source, reflection_notes)
+    SELECT rowid, content, tags, source, normalize_reflection_notes(reflection_notes)
+    FROM memory_item
+  `);
+  results.push({ table: 'memory_item_fts(rebuild)', status: 'ok' });
+} catch (error) {
+  results.push({
+    table: 'memory_item_fts(rebuild)',
+    status: 'error',
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+}
+
+const summary = {
+  memory_item: tgt.prepare('SELECT count(*) AS c FROM memory_item').get().c,
+  memory_review_candidate: tgt.prepare('SELECT count(*) AS c FROM memory_review_candidate').get().c,
+  memory_embedding: tgt.prepare('SELECT count(*) AS c FROM memory_embedding').get().c,
+  quick_check: tgt.pragma('quick_check', { simple: true }),
+};
+
+console.log(JSON.stringify({ source, target, results, summary }, null, 2));
+tgt.close();


### PR DESCRIPTION
## Summary

- `AGENTS.md`를 마스터 진입점으로 축소하고 상세(명령·아키텍처·워크플로·랭킹)를 `docs/agents/`로 분리
- `CLAUDE.md`·`GEMINI.md`에 `docs/agents/` 문서 맵과 Node.js ≥24 요구사항 추가; 빠른 시작에 `lint`/`type-check` 반영
- Docker 재배포 전 DB 백업·무결성 검사 스크립트 추가 (`db:backup`, `db:pre-docker-deploy`, `db:restore-from-corrupt`) 및 운영 문서·체크리스트 연동
- `.cursor/rules/specify-rules.mdc`를 현재 npm workspaces 모노레포 구조에 맞게 갱신
- `docker-compose.base.yml`에 `stop_grace_period: 30s` 추가로 graceful shutdown 여유 확보

## Test plan

- [ ] `npm run docs:verify-npm-scripts` 통과
- [ ] `docs/agents/` 링크가 `AGENTS.md`·`CLAUDE.md`에서 정상 동작
- [ ] `npm run db:pre-docker-deploy` (정상 DB) 백업·quick_check 성공
- [ ] `docker-compose.base.yml` 변경이 기존 배포 플로우에 영향 없음 확인


Made with [Cursor](https://cursor.com)