### PR TITLE
feat(monitoring): add auto-resolve for database and query alerts

### DIFF
--- a/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
+++ b/packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts
@@ -458,3 +458,104 @@ describe('PerformanceMonitor 메모리 메트릭 (rss/totalmem 축)', () => {
     expect(m.heapShareOfBudgetPercent).toBeCloseTo(6.25, 5);
   });
 });
+
+describe('PerformanceMonitor database/query auto-resolve', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const MB = 1024 * 1024;
+
+  // database: threshold 이하로 크기 감소 시 auto-resolve
+  it('database: 알림 발생 후 크기 임계값 이하로 감소 시 auto-resolve', async () => {
+    const monitor = new PerformanceMonitor({ databaseSizeMB: 100 });
+
+    const highDbMetrics = createMetrics({ database: { size: 120 * MB, memoryCount: 5000, queryTime: 0 } });
+    await (monitor as any).checkAlerts(highDbMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'database')).toHaveLength(1);
+
+    const lowDbMetrics = createMetrics({ database: { size: 80 * MB, memoryCount: 4000, queryTime: 0 } });
+    await (monitor as any).checkAlerts(lowDbMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'database')).toHaveLength(0);
+  });
+
+  // database: auto-resolve 후 재발생 시 새 알림 생성
+  it('database: auto-resolve 후 크기 재증가 시 새 알림 생성', async () => {
+    const monitor = new PerformanceMonitor({ databaseSizeMB: 100 });
+
+    const highDbMetrics = createMetrics({ database: { size: 120 * MB, memoryCount: 5000, queryTime: 0 } });
+    const lowDbMetrics = createMetrics({ database: { size: 80 * MB, memoryCount: 4000, queryTime: 0 } });
+
+    await (monitor as any).checkAlerts(highDbMetrics);
+    await (monitor as any).checkAlerts(lowDbMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'database')).toHaveLength(0);
+
+    await (monitor as any).checkAlerts(highDbMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'database')).toHaveLength(1);
+  });
+
+  // query: 연속 N회(기본 3) 임계값 이하 시 auto-resolve
+  it('query: 연속 3회 임계값 이하 시 auto-resolve', async () => {
+    const monitor = new PerformanceMonitor({ queryTimeMs: 1000, queryResolveWindow: 3 });
+
+    const highQueryMetrics = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 1500 } });
+    const okQueryMetrics   = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 500  } });
+
+    await (monitor as any).checkAlerts(highQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(1);
+
+    // 1회 ok — 아직 resolve 안 됨
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(1);
+
+    // 2회 ok — 아직 resolve 안 됨
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(1);
+
+    // 3회 ok — resolve
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(0);
+  });
+
+  // query: 스파이크 발생 시 카운터 리셋
+  it('query: ok 중 스파이크 발생 시 카운터 리셋 후 N회 다시 채워야 resolve', async () => {
+    const monitor = new PerformanceMonitor({ queryTimeMs: 1000, queryResolveWindow: 3 });
+
+    const highQueryMetrics = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 1500 } });
+    const okQueryMetrics   = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 500  } });
+
+    await (monitor as any).checkAlerts(highQueryMetrics);
+    // ok 2회
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    // 스파이크 — 카운터 리셋
+    await (monitor as any).checkAlerts(highQueryMetrics);
+    // ok 2회 더 — 아직 3회 미달
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(1);
+
+    // 3번째 ok — resolve
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(0);
+  });
+
+  // clearAlerts() 시 query window 카운터 리셋
+  it('clearAlerts() 호출 시 query 연속 카운터가 리셋된다', async () => {
+    const monitor = new PerformanceMonitor({ queryTimeMs: 1000, queryResolveWindow: 3 });
+
+    const highQueryMetrics = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 1500 } });
+    const okQueryMetrics   = createMetrics({ database: { size: 10 * MB, memoryCount: 100, queryTime: 500  } });
+
+    await (monitor as any).checkAlerts(highQueryMetrics);
+    // ok 2회 진행 후 clearAlerts
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    monitor.clearAlerts();
+
+    // 새 알림 발생 후 ok 1회 — 리셋됐으니 resolve 안 됨
+    await (monitor as any).checkAlerts(highQueryMetrics);
+    await (monitor as any).checkAlerts(okQueryMetrics);
+    expect(monitor.getActiveAlerts().filter(a => a.type === 'query')).toHaveLength(1);
+  });
+});

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -43,6 +43,7 @@ export interface AlertThresholds {
   cpuUsagePercent: number;         // CPU 사용률 임계값 (기본: 75%)
   databaseSizeMB: number;          // DB 크기 임계값 (기본: 100MB)
   queryTimeMs: number;             // 쿼리 시간 임계값 (기본: 1000ms)
+  queryResolveWindow: number;      // query auto-resolve에 필요한 연속 ok 횟수 (기본: 3)
 }
 
 export interface PerformanceAlert {
@@ -71,6 +72,8 @@ export class PerformanceMonitor {
   private onDemandMeasurementTime: number | null = null;
   private latestCpuSnapshot: NodeJS.CpuUsage = { user: 0, system: 0 };
   private lastCpuPercent: number = 0; // fallback; only updated by tick=true
+  // query sliding-window: 연속 ok 횟수. clearAlerts() 또는 스파이크 발생 시 리셋.
+  private queryConsecutiveOkCount: number = 0;
 
   constructor(thresholds?: Partial<AlertThresholds>) {
     this.thresholds = {
@@ -78,6 +81,7 @@ export class PerformanceMonitor {
       cpuUsagePercent: resolveValidatedNumber('PERF_CPU_WARN_PERCENT', 75, n => n >= 1 && n <= 100, '범위 1-100'),
       databaseSizeMB: 100,
       queryTimeMs: 1000,
+      queryResolveWindow: 3,
       ...thresholds
     };
   }
@@ -242,8 +246,15 @@ export class PerformanceMonitor {
       }
     }
 
-    // 데이터베이스 크기 검사 — DB 크기는 VACUUM 없이 자연히 감소하지 않으므로 auto-resolve를 지원하지 않는다.
+    // 데이터베이스 크기 검사
+    // memory/cpu와 달리 DB 크기는 VACUUM 같은 명시적 외부 작업 후에만 감소한다.
+    // 그러나 실제로 감소했다면 (예: VACUUM 완료) 즉시 resolve하는 것이 안전하다.
     const dbSizeMB = metrics.database.size / (1024 * 1024);
+    if (dbSizeMB <= this.thresholds.databaseSizeMB) {
+      const existing = Array.from(this.alerts.values())
+        .find(a => a.type === 'database' && !a.resolved);
+      if (existing) this.resolveAlert(existing.id);
+    }
     if (dbSizeMB > this.thresholds.databaseSizeMB) {
       const alertId = `database-${now.getTime()}`;
       const severity = dbSizeMB > this.thresholds.databaseSizeMB * 1.5 ? 'critical' : 'warning';
@@ -265,14 +276,28 @@ export class PerformanceMonitor {
       }
     }
 
-    // 쿼리 시간 검사 — 순간 측정값으로 감소를 신뢰할 수 없어 auto-resolve를 지원하지 않는다.
+    // 쿼리 시간 검사
+    // 순간 스파이크가 정상이므로 연속 N회(queryResolveWindow) 임계값 이하일 때만 auto-resolve.
+    // memory/cpu(즉시 해소)와 달리 sliding window를 써서 일시적 회복을 제외한다.
+    if (metrics.database.queryTime <= this.thresholds.queryTimeMs) {
+      const existingQueryAlert = Array.from(this.alerts.values())
+        .find(a => a.type === 'query' && !a.resolved);
+      if (existingQueryAlert) {
+        this.queryConsecutiveOkCount++;
+        if (this.queryConsecutiveOkCount >= this.thresholds.queryResolveWindow) {
+          this.resolveAlert(existingQueryAlert.id);
+          this.queryConsecutiveOkCount = 0;
+        }
+      }
+    }
     if (metrics.database.queryTime > this.thresholds.queryTimeMs) {
+      this.queryConsecutiveOkCount = 0; // 스파이크 발생 시 카운터 리셋
       const alertId = `query-${now.getTime()}`;
       const severity = metrics.database.queryTime > this.thresholds.queryTimeMs * 2 ? 'critical' : 'warning';
-      
+
       const existingQueryAlert = Array.from(this.alerts.values())
         .find(alert => alert.type === 'query' && !alert.resolved);
-      
+
       if (!existingQueryAlert) {
         alerts.push({
           id: alertId,
@@ -409,6 +434,7 @@ export class PerformanceMonitor {
    */
   clearAlerts(): void {
     this.alerts.clear();
+    this.queryConsecutiveOkCount = 0;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **database auto-resolve**: `checkAlerts()`에서 DB 크기가 임계값 이하로 내려오면 기존 활성 알림을 즉시 resolve. memory/cpu와 동일한 대칭 패턴. DB 크기는 VACUUM 없이 자연히 감소하지 않지만, 실제 감소가 감지되면 resolve하는 것이 안전하므로 이벤트 훅보다 관측 기반 접근법 채택.
- **query auto-resolve (sliding window)**: 순간 스파이크가 정상이므로 연속 N회(기본 `queryResolveWindow=3`) 임계값 이하일 때만 resolve. memory/cpu(즉시 1회)와 기준이 다른 이유를 설계 주석으로 명시.
- `AlertThresholds`에 `queryResolveWindow: number` 필드 추가 (기본 3, 생성자에서 재정의 가능).
- `clearAlerts()` 시 query window 카운터 리셋.

## 타입별 auto-resolve 기준 비교

| 타입 | resolve 방식 | 이유 |
|------|-------------|------|
| memory / cpu | 1회 측정 즉시 | 순시값, GC/스케줄러로 즉각 회복 가능 |
| database | 크기 감소 감지 시 즉시 | 외부 작업(VACUUM 등) 후 감소가 관측되면 신뢰 가능 |
| query | 연속 N회 확인 (sliding window) | 순간 스파이크 정상 — 지속 개선만 신뢰 |

## 제약 사항

`queryTime`은 `collectMetrics()`에서 항상 `0`으로 설정됨 (line ~154, "실제 쿼리 시간은 별도로 측정" 주석). 실제 쿼리 시간 측정 배선은 후속 이슈 범위.

## Test Plan

- [x] 신규 테스트 5개 추가 (`PerformanceMonitor database/query auto-resolve` describe 블록)
  - database: 알림 발생 후 크기 감소 시 auto-resolve
  - database: auto-resolve 후 재발생 시 새 알림 생성
  - query: 연속 3회 임계값 이하 시 auto-resolve
  - query: 스파이크 발생 시 카운터 리셋 후 N회 재충족 시 resolve
  - clearAlerts() 호출 시 query 연속 카운터 리셋
- [x] 모니터링 도메인 테스트: 377/377 통과
- [x] 전체 CI: 4591/4601 통과 (10 skipped — 기존)
- [x] TypeScript: 오류 없음

Closes #289

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)