### PR TITLE
fix(search): hybridSearch project_id/owner_id scope (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Changed
+- **VectorSearchRepository.hybridSearch**: `project_id` / `owner_id` 스코프가 vector·text CTE SQL에 반영되어 `search()`와 동작이 정렬됩니다. 텍스트 하이브리드 UNION의 `last_accessed`·ORDER BY SQL 오류도 함께 수정합니다 (#387).
 - **하이브리드·텍스트·벡터 검색**: `MemorySearchFilters`의 `project_id` / `owner_id`가 FTS·VEC SQL 및 임베딩 유사도(`searchBySimilarity`) fallback까지 전달되어, DB 단계에서 스코프가 적용됩니다. `memory_injection` / `buildKnowledgeContextBundle` 경로에서 좁은 스코프일 때 후보 부족을 줄이기 위해 검색 `limit` 배수를 키웁니다 (#232, PR #386 후속).
 
 ### Documentation

--- a/packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts
+++ b/packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts
@@ -400,6 +400,118 @@ describe('VectorSearchRepositoryImpl', () => {
     });
   });
 
+  describe('hybridSearch scope filters (issue #387)', () => {
+    const queryVector = new Array(512).fill(0.1);
+    const embeddingJson = JSON.stringify(queryVector);
+
+    async function seedScopedHybridMemories(): Promise<boolean> {
+      if (!repository.checkVecAvailability()) {
+        return false;
+      }
+
+      const insertItem = db.prepare(
+        `INSERT INTO memory_item (
+          id, type, content, importance, created_at, project_id, owner_id
+        ) VALUES (?, 'episodic', ?, 0.5, datetime('now'), ?, ?)`
+      );
+      const insertEmb = db.prepare(
+        `INSERT INTO memory_embedding (memory_id, embedding, dim, embedding_provider, dimensions)
+         VALUES (?, ?, ?, 'tfidf', ?)`
+      );
+
+      const rows = [
+        { id: 'mem_hybrid_scope_a', content: 'alpha scoped hybrid content', projectId: 'proj-a', ownerId: 'owner-a' },
+        { id: 'mem_hybrid_scope_b', content: 'beta scoped hybrid content', projectId: 'proj-b', ownerId: 'owner-b' },
+      ] as const;
+
+      for (const row of rows) {
+        insertItem.run(row.id, row.content, row.projectId, row.ownerId);
+        insertEmb.run(row.id, embeddingJson, 512, 512);
+
+        const embeddingId = db.prepare(
+          `SELECT id FROM memory_embedding WHERE memory_id = ?`
+        ).get(row.id) as { id: number } | undefined;
+
+        if (embeddingId) {
+          db.exec(`
+            INSERT INTO memory_item_vec_tfidf (rowid, embedding)
+            VALUES (${embeddingId.id}, '${embeddingJson}')
+          `);
+        }
+      }
+
+      return true;
+    }
+
+    it('project_id 스코프가 벡터 전용 hybridSearch 분기에 적용되어야 함', async () => {
+      if (!(await seedScopedHybridMemories())) {
+        return;
+      }
+
+      const query: VectorSearchQuery = {
+        queryVector,
+        provider: 'tfidf',
+        options: {
+          limit: 10,
+          threshold: 0,
+          project_id: 'proj-a',
+        },
+      };
+
+      const results = await repository.hybridSearch(query);
+      const memoryIds = results.map((result) => result.memory_id);
+
+      expect(memoryIds).toContain('mem_hybrid_scope_a');
+      expect(memoryIds).not.toContain('mem_hybrid_scope_b');
+    });
+
+    it('project_id·owner_id 스코프가 텍스트+벡터 hybridSearch CTE에 적용되어야 함', async () => {
+      if (!(await seedScopedHybridMemories())) {
+        return;
+      }
+
+      const query: VectorSearchQuery = {
+        queryVector,
+        textQuery: 'scoped hybrid',
+        provider: 'tfidf',
+        options: {
+          limit: 10,
+          threshold: 0,
+          project_id: 'proj-b',
+          owner_id: 'owner-b',
+        },
+      };
+
+      const results = await repository.hybridSearch(query);
+      const memoryIds = results.map((result) => result.memory_id);
+
+      expect(memoryIds).toContain('mem_hybrid_scope_b');
+      expect(memoryIds).not.toContain('mem_hybrid_scope_a');
+    });
+
+    it('owner_id 배열 스코프가 hybridSearch에 적용되어야 함', async () => {
+      if (!(await seedScopedHybridMemories())) {
+        return;
+      }
+
+      const query: VectorSearchQuery = {
+        queryVector,
+        provider: 'tfidf',
+        options: {
+          limit: 10,
+          threshold: 0,
+          owner_id: ['owner-a', 'owner-x'],
+        },
+      };
+
+      const results = await repository.hybridSearch(query);
+      const memoryIds = results.map((result) => result.memory_id);
+
+      expect(memoryIds).toContain('mem_hybrid_scope_a');
+      expect(memoryIds).not.toContain('mem_hybrid_scope_b');
+    });
+  });
+
   describe('getIndexStatus', () => {
     it('인덱스 상태를 반환해야 함', () => {
       // When: 인덱스 상태 확인

--- a/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
+++ b/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
@@ -339,7 +339,9 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       type,
       types,
       includeContent = true,
-      includeMetadata = false
+      includeMetadata = false,
+      project_id: scopeProjectId,
+      owner_id: scopeOwnerId,
     } = normalizedOptions;
 
     const runtimeContext = this.resolveRuntimeVectorContext(query.provider);
@@ -375,6 +377,51 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       ? types.filter(Boolean)
       : (type ? [type] : []);
 
+    const hasProjectScope = typeof scopeProjectId === 'string' && scopeProjectId.length > 0;
+    const hasOwnerStringScope = typeof scopeOwnerId === 'string' && scopeOwnerId.length > 0;
+    const ownerArrayScope = Array.isArray(scopeOwnerId) ? scopeOwnerId.filter(Boolean) : [];
+    const hasOwnerScope = hasOwnerStringScope || ownerArrayScope.length > 0;
+    const hasScopeFilter = hasProjectScope || hasOwnerScope;
+
+    const scopeParams: SqlParam[] = [];
+    if (hasProjectScope) {
+      scopeParams.push(scopeProjectId as string);
+    }
+    if (hasOwnerStringScope) {
+      scopeParams.push(scopeOwnerId as string);
+    } else if (ownerArrayScope.length > 0) {
+      scopeParams.push(...(ownerArrayScope as SqlParam[]));
+    }
+
+    const buildItemScopeClause = (): string => {
+      const parts: string[] = [];
+      if (hasProjectScope) {
+        parts.push('mi.project_id = ?');
+      }
+      if (hasOwnerStringScope) {
+        parts.push('mi.owner_id = ?');
+      } else if (ownerArrayScope.length > 0) {
+        parts.push(`mi.owner_id IN (${ownerArrayScope.map(() => '?').join(',')})`);
+      }
+      return parts.length > 0 ? `${parts.map(part => `AND ${part}`).join(' ')} ` : '';
+    };
+
+    const buildItemWhereSql = (): string => {
+      const whereParts: string[] = [];
+      if (typeFilters.length > 0) {
+        whereParts.push(`mi.type IN (${typeFilters.map(() => '?').join(',')})`);
+      }
+      if (hasProjectScope) {
+        whereParts.push('mi.project_id = ?');
+      }
+      if (hasOwnerStringScope) {
+        whereParts.push('mi.owner_id = ?');
+      } else if (ownerArrayScope.length > 0) {
+        whereParts.push(`mi.owner_id IN (${ownerArrayScope.map(() => '?').join(',')})`);
+      }
+      return whereParts.length > 0 ? `WHERE ${whereParts.join(' AND ')} ` : '';
+    };
+
     try {
       // textQuery가 없거나 빈 문자열이면 텍스트 검색을 건너뛰고 벡터 검색만 사용
       // FTS5는 빈 쿼리를 에러로 처리하므로 이를 방지
@@ -387,12 +434,11 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
         // 텍스트 검색과 벡터 검색 모두 사용
         // SQL Injection 방지: 화이트리스트 검증은 getTableName()에서 수행됨
         // 템플릿 리터럴 대신 문자열 연결 사용
-        const _vectorTypeClause = typeFilters.length > 0
-          ? `AND mi.type IN (${typeFilters.map(() => '?').join(',')})`
-          : '';
         const textTypeClause = typeFilters.length > 0
           ? `AND mi.type IN (${typeFilters.map(() => '?').join(',')})`
           : '';
+        const textScopeClause = buildItemScopeClause();
+        const vectorWhereSql = buildItemWhereSql().replace(/^WHERE /, '  WHERE ');
         hybridQuery =
           'WITH vector_search AS (' +
           '  SELECT ' +
@@ -420,7 +466,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           '  ) t ' +
           '  JOIN memory_embedding me ON t.rowid = me.id ' +
           '  JOIN memory_item mi ON mi.id = me.memory_id AND (COALESCE(mi.is_deleted, 0) = 0) ' +
-          (typeFilters.length > 0 ? `  WHERE mi.type IN (${typeFilters.map(() => '?').join(',')}) ` : '') +
+          vectorWhereSql +
           '), ' +
           'text_search AS (' +
           '  SELECT ' +
@@ -442,8 +488,10 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           '  FROM memory_item_fts fts ' +
           '  JOIN memory_item mi ON fts.rowid = mi.rowid AND (COALESCE(mi.is_deleted, 0) = 0) ' +
           '  WHERE memory_item_fts MATCH ? ' +
-          textTypeClause + ' ' +
+          textTypeClause +
+          textScopeClause +
           ') ' +
+          'SELECT * FROM (' +
           'SELECT ' +
           '  COALESCE(vs.memory_id, ts.memory_id) as memory_id, ' +
           '  COALESCE(1 - vs.vector_distance, 0) as vector_similarity, ' +
@@ -452,7 +500,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           '  COALESCE(vs.type, ts.type) as type, ' +
           '  COALESCE(vs.importance, ts.importance) as importance, ' +
           '  COALESCE(vs.created_at, ts.created_at) as created_at, ' +
-          '  COALESCE(vs.last_accessed_at, ts.last_accessed_at, vs.last_accessed, ts.last_accessed) as last_accessed_at, ' +
+          '  COALESCE(vs.last_accessed_at, ts.last_accessed_at) as last_accessed_at, ' +
           '  COALESCE(vs.pinned, ts.pinned) as pinned, ' +
           '  COALESCE(vs.tags, ts.tags) as tags, ' +
           '  COALESCE(vs.task_goal, ts.task_goal) as task_goal, ' +
@@ -473,7 +521,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           '  ts.type, ' +
           '  ts.importance, ' +
           '  ts.created_at, ' +
-          '  COALESCE(ts.last_accessed_at, ts.last_accessed) as last_accessed_at, ' +
+          '  ts.last_accessed_at as last_accessed_at, ' +
           '  ts.pinned, ' +
           '  ts.tags, ' +
           '  ts.task_goal, ' +
@@ -485,30 +533,31 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           'FROM text_search ts ' +
           'LEFT JOIN vector_search vs ON ts.memory_id = vs.memory_id ' +
           'WHERE vs.memory_id IS NULL ' +
+          ') hybrid_ranked ' +
           'ORDER BY (vector_similarity * 0.6 + text_similarity * 0.4) DESC ' +
           'LIMIT ?';
 
         // sqlite-vec의 vec0_knn은 MATCH 다음에 바로 LIMIT이 와야 함
         // 서브쿼리에서 LIMIT을 적용하기 위해 prefetchLimit 사용
-        const prefetchLimit = typeFilters.length > 0 ? limit * 5 : limit;
+        const prefetchLimit = typeFilters.length > 0 || hasScopeFilter ? limit * 5 : limit;
         params = [
           JSON.stringify(effectiveQueryVector),
           prefetchLimit,
           ...typeFilters,
+          ...scopeParams,
           textQuery.trim(),
           ...typeFilters,
+          ...scopeParams,
           limit
         ];
       } else {
         // 텍스트 검색 없이 벡터 검색만 사용
         // SQL Injection 방지: 화이트리스트 검증은 getTableName()에서 수행됨
         // 템플릿 리터럴 대신 문자열 연결 사용
-        const _typeClause = typeFilters.length > 0
-          ? `AND mi.type IN (${typeFilters.map(() => '?').join(',')})`
-          : '';
+        const outerWhereSql = buildItemWhereSql();
         // sqlite-vec의 vec0_knn은 MATCH 다음에 바로 LIMIT이 와야 함
         // 서브쿼리로 먼저 벡터 검색을 수행하고 LIMIT을 적용한 후 JOIN
-        const prefetchLimit = typeFilters.length > 0 ? limit * 5 : limit;
+        const prefetchLimit = typeFilters.length > 0 || hasScopeFilter ? limit * 5 : limit;
         hybridQuery =
           'SELECT ' +
           '  me.memory_id as memory_id, ' +
@@ -536,7 +585,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           ') t ' +
           'JOIN memory_embedding me ON t.rowid = me.id ' +
           'JOIN memory_item mi ON mi.id = me.memory_id AND (COALESCE(mi.is_deleted, 0) = 0) ' +
-          (typeFilters.length > 0 ? `WHERE mi.type IN (${typeFilters.map(() => '?').join(',')}) ` : '') +
+          outerWhereSql +
           'ORDER BY t.distance ASC ' +
           'LIMIT ?';
 
@@ -544,6 +593,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
           JSON.stringify(effectiveQueryVector),
           prefetchLimit,
           ...typeFilters,
+          ...scopeParams,
           limit
         ];
       }

--- a/specs/026-hybrid-search-scope/plan.md
+++ b/specs/026-hybrid-search-scope/plan.md
@@ -1,0 +1,11 @@
+# Implementation Plan: Issue #387
+
+**Branch**: `026-hybrid-search-scope`
+
+## Changes
+
+- `packages/memento-core/src/domains/search/repositories/vector-search.repository.ts`
+  - `hybridSearch`: `search()`의 `whereParts` / `scopeParams` 패턴을 vector·text CTE 및 벡터 전용 분기에 적용
+- `packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts`
+  - project_id / owner_id 스코프 `hybridSearch` 테스트
+- `CHANGELOG.md` (Unreleased 한 줄)

--- a/specs/026-hybrid-search-scope/spec.md
+++ b/specs/026-hybrid-search-scope/spec.md
@@ -1,0 +1,17 @@
+# Feature Specification: VectorSearchRepository.hybridSearch Scope Filters
+
+**Feature Branch**: `026-hybrid-search-scope`  
+**Created**: 2026-06-18  
+**Issue**: [#387](https://github.com/jee1/memento/issues/387)
+
+## Requirements
+
+- FR-001: `VectorSearchOptions.project_id` / `owner_id`를 `hybridSearch` SQL(vector CTE·text CTE·벡터 전용 분기)에 `search()`와 동일 규칙으로 반영한다.
+- FR-002: 빈 문자열·빈 배열 owner_id는 스코프 미적용(`search()`와 동일).
+- FR-003: 스코프 필터가 있을 때 prefetch limit 배수는 `search()`와 동일하게 `limit * 5`를 사용한다.
+- FR-004: `vector-search.repository.spec.ts`에 스코프가 적용된 `hybridSearch` 회귀 테스트를 추가한다.
+
+## Success Criteria
+
+- `hybridSearch`가 project_id/owner_id로 결과를 필터링한다.
+- lint, type-check, test pass.

--- a/specs/026-hybrid-search-scope/tasks.md
+++ b/specs/026-hybrid-search-scope/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Issue #387
+
+- [x] T001 spec/plan/tasks 작성
+- [x] T002 hybridSearch SQL에 project_id/owner_id 스코프 적용
+- [x] T003 회귀 테스트 추가
+- [x] T004 lint · test · CHANGELOG
+- [ ] T005 PR 등록


### PR DESCRIPTION
## Summary

- `VectorSearchRepository.hybridSearch`에 `search()`와 동일한 `project_id` / `owner_id` 스코프 필터를 vector CTE·text CTE·벡터 전용 분기 SQL에 적용합니다 (#387).
- 텍스트 하이브리드 경로에서 발견된 `last_accessed` 컬럼 참조·UNION ORDER BY SQL 오류를 함께 수정합니다.
- Spec Kit `026-hybrid-search-scope` spec/plan/tasks 및 회귀 테스트 3건을 추가합니다.

## Test plan

- [x] `npm test -- packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts`
- [ ] CI green 확인

Closes #387

Made with [Cursor](https://cursor.com)