### PR TITLE
fix(anchor-map): 임베딩 없는 앵커 노드 시각적 표시

### DIFF
--- a/packages/memento-server/src/server/handlers/anchor-map.handler.ts
+++ b/packages/memento-server/src/server/handlers/anchor-map.handler.ts
@@ -21,6 +21,7 @@ export interface AnchorMapNode {
   similarity?: number;
   importance?: number;
   created_at?: string;
+  embedding_missing?: boolean;
 }
 
 /**
@@ -186,6 +187,8 @@ async function buildNetworkNodesAndLinks(
             slot: anchor.slot,
             anchorMemoryId: anchor.memory_id
           });
+          const anchorNode = nodes.find(n => n.id === anchor.memory_id);
+          if (anchorNode) anchorNode.embedding_missing = true;
         } else {
           logger.error('Anchor search failed', {
             slot: anchor.slot,

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -276,7 +276,8 @@ function renderMap() {
       return palette.memoryStroke;
     })
     .attr('stroke-width', d => d.type === 'anchor' ? 3 : 2)
-    .attr('opacity', 1.0)
+    .attr('stroke-dasharray', d => d.embedding_missing ? '5,3' : null)
+    .attr('opacity', d => d.embedding_missing ? 0.6 : 1.0)
     .call(drag(simulation))
     .on('click', (event, d) => {
       event.stopPropagation();
@@ -306,7 +307,8 @@ function renderMap() {
   node.append('title')
     .text(d => {
       if (d.type === 'anchor') {
-        return `Anchor ${d.slot}\n${d.content}`;
+        const warning = d.embedding_missing ? '\n⚠ 임베딩 없음 — 연결 메모리 검색 불가' : '';
+        return `Anchor ${d.slot}\n${d.content}${warning}`;
       }
       return `Memory\n${d.content}\nHop: ${d.hop_distance || 'N/A'}`;
     });


### PR DESCRIPTION
## Summary

- `AnchorMapNode`에 `embedding_missing?: boolean` 필드 추가
- `EmbeddingNotFoundError` catch 시 해당 앵커 노드에 `embedding_missing: true` 플래그 설정
- `anchor-map.js`에서 임베딩 없는 앵커를 점선 테두리(`stroke-dasharray: 5,3`) + 반투명(`opacity: 0.6`) + tooltip 경고로 표시

## Root Cause

앵커 메모리에 임베딩이 없으면 `searchLocal()`이 `EmbeddingNotFoundError`를 throw하고 catch되어 연결 메모리 없이 앵커만 고립 표시됨. 사용자는 왜 연결이 없는지 알 수 없었음.

## Test plan

- [ ] 임베딩 없는 메모리를 SLOT A/B에 앵커로 설정 후 앵커 대시보드 확인 — 점선 테두리로 표시되는지 검증
- [ ] tooltip hover 시 "⚠ 임베딩 없음 — 연결 메모리 검색 불가" 메시지 표시 확인
- [ ] 임베딩 있는 SLOT C는 기존과 동일하게 solid 테두리로 표시되는지 확인
- [ ] `anchor-map-search-highlight.spec.ts` 3개 테스트 통과 확인

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)