### PR TITLE
fix(remember): load existing memories without memory_item.embedding (Closes #544)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-06-15)
+# Graph Report - .  (2026-06-18)
 
 ## Corpus Check
-- 1138 files · ~1,519,487 words
+- 1139 files · ~1,508,961 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5685 nodes · 7013 edges · 1130 communities detected
+- 5690 nodes · 7020 edges · 1131 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1140,6 +1140,7 @@
 - [[_COMMUNITY_Community 1127|Community 1127]]
 - [[_COMMUNITY_Community 1128|Community 1128]]
 - [[_COMMUNITY_Community 1129|Community 1129]]
+- [[_COMMUNITY_Community 1130|Community 1130]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 43 edges
@@ -1620,60 +1621,60 @@ Cohesion: 0.26
 Nodes (1): MigrationMonitorService
 
 ### Community 113 - "Community 113"
+Cohesion: 0.32
+Nodes (11): buildQuarantinePath(), extractPragmaMessages(), findRecentQuarantineSnapshot(), formatTimestamp(), isOkResult(), looksLikeCorruption(), maskError(), quarantineDatabaseFile() (+3 more)
+
+### Community 114 - "Community 114"
 Cohesion: 0.27
 Nodes (1): RelationEngineSchemaMigration
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.2
 Nodes (2): SqliteCoreMemoryAdapter, SqliteCoreMemoryPreparedStatement
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.26
 Nodes (1): SpacedRepetitionAlgorithm
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.2
 Nodes (3): AdaptiveRecallProbabilityCalculator, DefaultRecallProbabilityCalculator, EnhancedRecallProbabilityCalculator
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.29
 Nodes (1): ConvertEpisodicToSemanticTool
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.27
 Nodes (1): PinTool
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (8): buildScoreBreakdown(), computeStaleDays(), isMemoryRowActive(), isNonEmptyDeletedAt(), isTruthyFlag(), parseSqliteInstant(), passesEligibility(), resolveStaleAnchor()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.32
 Nodes (11): aggregateJudgeResults(), assertJudgeResults(), createManifest(), graphRrfStatus(), main(), parseCli(), readJsonLines(), runLongMemEvalValidation() (+3 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.35
 Nodes (10): batchProcessingExample(), benchmarkExample(), cachingExample(), compressedSearchExample(), memoryOptimizationExample(), parallelSearchExample(), processPageData(), realTimeMonitoringExample() (+2 more)
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.31
 Nodes (7): cleanup(), getHttpAuthMissingAdminKeyWarning(), getHttpAuthTrustModelNotice(), initializeServer(), registerCleanupHandlers(), startServer(), writeRuntimeDiagnosticsEvent()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.22
 Nodes (5): buildEmbeddingMapResponse(), distSq(), EmbeddingMapBuildError, getCacheKey(), kMeans()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.31
 Nodes (2): CaptureRuntime, TimeoutError
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.18
 Nodes (5): AuthenticationError, ConnectionError, MementoError, NotFoundError, ValidationError
-
-### Community 126 - "Community 126"
-Cohesion: 0.35
-Nodes (10): buildQuarantinePath(), extractPragmaMessages(), formatTimestamp(), isOkResult(), looksLikeCorruption(), maskError(), quarantineDatabaseFile(), runCheck() (+2 more)
 
 ### Community 127 - "Community 127"
 Cohesion: 0.31
@@ -1788,140 +1789,140 @@ Cohesion: 0.24
 Nodes (1): WriteCoalescingManager
 
 ### Community 155 - "Community 155"
+Cohesion: 0.31
+Nodes (6): buildLogMessage(), formatTime(), logToStderr(), logWithMCPLogger(), normalizeMetaErrors(), safeStringify()
+
+### Community 156 - "Community 156"
 Cohesion: 0.22
 Nodes (1): VectorSearchContainer
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.29
 Nodes (1): RememberTool
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.22
 Nodes (1): ConsolidationRepository
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.29
 Nodes (1): PredicateCanonicalizer
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.24
 Nodes (2): scopeSearchFilters(), SqliteHybridAgentContextSource
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (2): escapeHtml(), QualityReporter
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.31
 Nodes (6): countMagicNumbers(), findMagicNumbers(), getAllTsFiles(), isCoreModule(), isExcluded(), main()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.36
 Nodes (9): checkSqlInjection(), findFiles(), findSqlInjectionPatterns(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.36
 Nodes (9): countAnyTypes(), findAnyTypes(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.36
 Nodes (8): cursorKey(), findLastNewlineBefore(), readDockerLogs(), readIncrementalJsonlLines(), readJsonlFiles(), readStreamLines(), resolveDockerLogsRef(), runDocker()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.22
 Nodes (1): MementoAssistant
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.39
 Nodes (8): findSubcommandWithIndex(), main(), parseCli(), parseGlobalFlags(), stripGlobalArgvForAgentDetection(), subcommandArgvFrom(), writeStderr(), writeStdout()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.28
 Nodes (4): registerHandlers(), runHeavyInit(), Semaphore, startServer()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.44
 Nodes (8): applySizePolicy(), buildBatch(), cloneEvent(), reducibleText(), removeOptionalFields(), truncateToFit(), utf8Size(), validateBatch()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.47
 Nodes (6): hasOnlyKeys(), isRecord(), validateAgentEvent(), validatePayload(), validIdentifier(), validJsonValue()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.44
 Nodes (7): defaultGit(), detectClaudeCodeScope(), detectCodexScope(), explicit(), normalizeRemote(), processFromBranch(), value()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.36
 Nodes (1): TripleExtractionLogger
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.31
 Nodes (1): MigrationRunner
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.25
 Nodes (1): BackupManager
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (1): AnchorTableMigration
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.36
 Nodes (1): FactMetadataFieldsMigration
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.39
 Nodes (1): MemoryItemIsConsolidatedMigration
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.39
 Nodes (1): TripleExtractionFieldsMigration
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.42
 Nodes (1): FeedbackEventAttributionMigration
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.33
 Nodes (1): ProceduralVersionIndexesMigration
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.36
 Nodes (1): MemoryItemAttributionMigration
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.36
 Nodes (1): KgTripleTableMigration
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.39
 Nodes (1): SoftDeleteFieldsMigration
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.36
 Nodes (1): MemoryItemOwnerIdMigration
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.25
 Nodes (1): RetryManager
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.36
 Nodes (1): FileLogger
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.28
 Nodes (3): convertMemoryRowToItem(), isMemoryType(), isPrivacyScope()
 
-### Community 187 - "Community 187"
-Cohesion: 0.31
-Nodes (1): LoggingRateLimiter
-
 ### Community 188 - "Community 188"
 Cohesion: 0.31
-Nodes (4): buildLogMessage(), formatTime(), logToStderr(), safeStringify()
+Nodes (1): LoggingRateLimiter
 
 ### Community 189 - "Community 189"
 Cohesion: 0.36
@@ -5687,6 +5688,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 1130 - "Community 1130"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `TimeoutError`, `FeedbackRepository`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -5908,929 +5913,931 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 667`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 668`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 669`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 670`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 671`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 672`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 673`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 674`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 675`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 676`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 677`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 678`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 679`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 680`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 681`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 682`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 683`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
+- **Thin community `Community 684`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
+- **Thin community `Community 685`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 686`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 687`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 688`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 689`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 690`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 691`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 692`** (2 nodes): `remember-tool-relation-load.spec.ts`, `initializeProductionLikeSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 693`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 694`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 695`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 696`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 697`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 698`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 699`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 700`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 701`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 702`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 703`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 704`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 705`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 706`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 707`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 708`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 709`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 710`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 711`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 712`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 713`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 714`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
+- **Thin community `Community 715`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
+- **Thin community `Community 716`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 717`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 718`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 719`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 720`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 721`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 722`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 723`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 724`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 725`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 726`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 727`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 728`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 729`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 730`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 731`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 732`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 733`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 734`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 735`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 736`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 737`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 738`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 739`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 740`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 741`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 742`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
+- **Thin community `Community 743`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 744`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 745`** (2 nodes): `readStaticFile()`, `static-design-contracts.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 746`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 747`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 748`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `test-docker.js`, `testDockerServer()`
+- **Thin community `Community 749`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 750`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 751`** (2 nodes): `test-docker.js`, `testDockerServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 752`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 753`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 754`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 755`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 756`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 757`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 758`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 759`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 760`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 761`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 762`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 763`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 764`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 765`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 766`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 767`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 768`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 769`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 770`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 771`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 772`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 773`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 774`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 775`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 776`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (1 nodes): `types.ts`
+- **Thin community `Community 777`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 778`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (1 nodes): `index.ts`
+- **Thin community `Community 779`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 780`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 781`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 782`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 783`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 784`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 785`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (1 nodes): `transport.ts`
+- **Thin community `Community 786`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (1 nodes): `index.ts`
+- **Thin community `Community 787`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 788`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 790`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 791`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 792`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 793`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 794`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 795`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 796`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 797`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 798`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 799`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 800`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 801`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 802`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 803`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 804`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 805`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 806`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 807`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 808`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 809`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 810`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 811`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 812`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 813`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 814`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 815`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (1 nodes): `context.ts`
+- **Thin community `Community 816`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 817`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (1 nodes): `mcp-tool-call-error.spec.ts`
+- **Thin community `Community 818`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 819`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 820`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 821`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (1 nodes): `index.ts`
+- **Thin community `Community 822`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 823`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 824`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 825`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 826`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (1 nodes): `types.ts`
+- **Thin community `Community 827`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 828`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 829`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 830`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 831`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 832`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 833`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 834`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 835`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 836`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 837`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 838`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 839`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 840`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (1 nodes): `types.ts`
+- **Thin community `Community 841`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 842`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (1 nodes): `index.ts`
+- **Thin community `Community 843`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 844`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 845`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (1 nodes): `types.ts`
+- **Thin community `Community 846`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 847`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 848`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 849`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (1 nodes): `types.ts`
+- **Thin community `Community 850`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 851`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 852`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (1 nodes): `index.ts`
+- **Thin community `Community 853`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 854`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 855`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 856`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 857`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 858`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 859`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 860`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 861`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 862`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 863`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (1 nodes): `types.ts`
+- **Thin community `Community 864`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 865`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 866`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 867`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 868`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 869`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 870`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 871`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 872`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 873`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 874`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 875`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 876`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 877`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 878`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
+- **Thin community `Community 879`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 880`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 881`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 882`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 883`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 884`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 885`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 886`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 887`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 888`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 889`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 890`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 891`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 892`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 893`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (1 nodes): `pii-masker-api-key.spec.ts`
+- **Thin community `Community 894`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 895`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 896`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 897`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 898`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 899`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 900`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 901`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 902`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 903`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 904`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 905`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 906`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 907`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 908`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 909`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 910`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 911`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 912`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 913`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 914`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 915`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (1 nodes): `error-types.ts`
+- **Thin community `Community 916`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 917`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 918`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (1 nodes): `search.types.ts`
+- **Thin community `Community 919`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 920`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 921`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (1 nodes): `constants.ts`
+- **Thin community `Community 922`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 923`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 924`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 925`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 926`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 927`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 928`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 929`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 930`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 931`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 932`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 933`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 934`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 935`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 936`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 937`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 938`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 939`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 940`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 941`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 942`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 943`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 944`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 945`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 946`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 947`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 948`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 949`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 950`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 951`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 952`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 953`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 954`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 955`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 956`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 957`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 958`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 959`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 960`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 961`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (1 nodes): `index.ts`
+- **Thin community `Community 962`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 963`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `database-types.ts`
+- **Thin community `Community 964`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 965`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 966`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 967`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `types.ts`
+- **Thin community `Community 968`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `index.ts`
+- **Thin community `Community 969`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `spec.ts`
+- **Thin community `Community 970`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 971`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 972`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 973`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 974`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 975`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 976`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 977`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 978`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 979`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `vector-search.repository.spec.ts`
+- **Thin community `Community 980`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 981`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 982`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 983`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 984`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 985`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 986`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 987`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 988`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 989`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `index.ts`
+- **Thin community `Community 990`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 991`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 992`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `index.ts`
+- **Thin community `Community 993`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 994`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 995`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 996`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 997`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 998`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `context-port.ts`
+- **Thin community `Community 999`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 1000`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 1001`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 1002`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1003`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1004`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1005`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 1006`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 1007`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `core-memory-repository.ts`
+- **Thin community `Community 1008`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `kg-triple-repository.ts`
+- **Thin community `Community 1009`** (1 nodes): `core-memory-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `process-attribute-repository.ts`
+- **Thin community `Community 1010`** (1 nodes): `kg-triple-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 1011`** (1 nodes): `process-attribute-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 1012`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `feedback-repository.interface.ts`
+- **Thin community `Community 1013`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 1014`** (1 nodes): `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 1015`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `knowledge-vault-repository.ts`
+- **Thin community `Community 1016`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 1017`** (1 nodes): `knowledge-vault-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 1018`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 1019`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 1020`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 1021`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1027`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1028`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1029`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1031`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1032`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1033`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1035`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1036`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1037`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1038`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1039`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1041`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `index.ts`
+- **Thin community `Community 1042`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1043`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1044`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1045`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1046`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1047`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1048`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1049`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1050`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1051`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1052`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1053`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1054`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1055`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1056`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1057`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1058`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1059`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1060`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1061`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 1062`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 1063`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `types.ts`
+- **Thin community `Community 1064`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1065`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1066`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1067`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1068`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1069`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1070`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1071`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1072`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `embedding-service.spec.ts`
+- **Thin community `Community 1073`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1074`** (1 nodes): `embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1075`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1076`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1077`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1078`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1079`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1080`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1081`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1082`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1083`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `types.ts`
+- **Thin community `Community 1084`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1085`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1086`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1087`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1088`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1089`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1090`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1091`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1092`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1093`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1094`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1095`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1096`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `agent-sessions.e2e.ts`
+- **Thin community `Community 1097`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1098`** (1 nodes): `agent-sessions.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1099`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1100`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1101`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1102`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `longmemeval-validation.spec.ts`
+- **Thin community `Community 1103`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `acquire-longmemeval.spec.ts`
+- **Thin community `Community 1104`** (1 nodes): `longmemeval-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1105`** (1 nodes): `acquire-longmemeval.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1106`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1107`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1108`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1109`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1110`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1111`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1112`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1113`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1114`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `types.ts`
+- **Thin community `Community 1115`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1116`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1117`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1118`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1119`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1120`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1121`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1122`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1123`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1124`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1125`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1126`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1127`** (1 nodes): `entrypoint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1128`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1129`** (1 nodes): `memory-evolution-demo-shell-render.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1130`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "playwright.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "vitest.config.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "assistant.spec.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "types.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "types.spec.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "assistant.ts",
@@ -57,7 +57,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_ts",
-      "community": 165
+      "community": 166
     },
     {
       "label": "MementoAssistant",
@@ -65,7 +65,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L21",
       "id": "assistant_mementoassistant",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".constructor()",
@@ -73,7 +73,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L34",
       "id": "assistant_mementoassistant_constructor",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".fromEnv()",
@@ -81,7 +81,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L46",
       "id": "assistant_mementoassistant_fromenv",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".beforeUserTurn()",
@@ -89,7 +89,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L61",
       "id": "assistant_mementoassistant_beforeuserturn",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".afterAssistantTurn()",
@@ -97,7 +97,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L67",
       "id": "assistant_mementoassistant_afterassistantturn",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".recall()",
@@ -105,7 +105,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L75",
       "id": "assistant_mementoassistant_recall",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".remember()",
@@ -113,7 +113,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L78",
       "id": "assistant_mementoassistant_remember",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".close()",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L81",
       "id": "assistant_mementoassistant_close",
-      "community": 165
+      "community": 166
     },
     {
       "label": "index.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "after-assistant-turn.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "auto-remember-policy.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "channel-scope.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "http-transport.ts",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "mock-transport.spec.ts",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "transport.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "index.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "http-transport.spec.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "factory.ts",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "mock-transport.ts",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "retry-queue.spec.ts",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "retry-queue.ts",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "http.integration.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "start-http-server.ts",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 800
+      "community": 802
     },
     {
       "label": "test-integration.js",
@@ -1113,7 +1113,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_performance_examples_ts",
-      "community": 121
+      "community": 122
     },
     {
       "label": "batchProcessingExample()",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L25",
       "id": "performance_examples_batchprocessingexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "parallelSearchExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L54",
       "id": "performance_examples_parallelsearchexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "cachingExample()",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L87",
       "id": "performance_examples_cachingexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "streamingSearchExample()",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L118",
       "id": "performance_examples_streamingsearchexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "compressedSearchExample()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L152",
       "id": "performance_examples_compressedsearchexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "benchmarkExample()",
@@ -1161,7 +1161,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L183",
       "id": "performance_examples_benchmarkexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "memoryOptimizationExample()",
@@ -1169,7 +1169,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L209",
       "id": "performance_examples_memoryoptimizationexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "realTimeMonitoringExample()",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L285",
       "id": "performance_examples_realtimemonitoringexample",
-      "community": 121
+      "community": 122
     },
     {
       "label": "processPageData()",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L367",
       "id": "performance_examples_processpagedata",
-      "community": 121
+      "community": 122
     },
     {
       "label": "runPerformanceExamples()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L373",
       "id": "performance_examples_runperformanceexamples",
-      "community": 121
+      "community": 122
     },
     {
       "label": "advanced-usage.ts",
@@ -1617,7 +1617,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_ts",
-      "community": 166
+      "community": 167
     },
     {
       "label": "writeStdout()",
@@ -1625,7 +1625,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L7",
       "id": "cli_writestdout",
-      "community": 166
+      "community": 167
     },
     {
       "label": "writeStderr()",
@@ -1633,7 +1633,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L19",
       "id": "cli_writestderr",
-      "community": 166
+      "community": 167
     },
     {
       "label": "stripGlobalArgvForAgentDetection()",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L45",
       "id": "cli_stripglobalargvforagentdetection",
-      "community": 166
+      "community": 167
     },
     {
       "label": "parseGlobalFlags()",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L59",
       "id": "cli_parseglobalflags",
-      "community": 166
+      "community": 167
     },
     {
       "label": "findSubcommandWithIndex()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L75",
       "id": "cli_findsubcommandwithindex",
-      "community": 166
+      "community": 167
     },
     {
       "label": "subcommandArgvFrom()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L91",
       "id": "cli_subcommandargvfrom",
-      "community": 166
+      "community": 167
     },
     {
       "label": "parseCli()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L106",
       "id": "cli_parsecli",
-      "community": 166
+      "community": 167
     },
     {
       "label": "main()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L150",
       "id": "cli_main",
-      "community": 166
+      "community": 167
     },
     {
       "label": "check-migration-status.ts",
@@ -1769,7 +1769,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1777,7 +1777,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1785,7 +1785,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -2089,7 +2089,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "context.spec.ts",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "server-factory.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "server-state.spec.ts",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2425,7 +2425,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_ts",
-      "community": 167
+      "community": 168
     },
     {
       "label": "Semaphore",
@@ -2433,7 +2433,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L52",
       "id": "index_semaphore",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".constructor()",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L55",
       "id": "index_semaphore_constructor",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".acquire()",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L56",
       "id": "index_semaphore_acquire",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".release()",
@@ -2457,7 +2457,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L60",
       "id": "index_semaphore_release",
-      "community": 167
+      "community": 168
     },
     {
       "label": "runHeavyInit()",
@@ -2465,7 +2465,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L87",
       "id": "index_runheavyinit",
-      "community": 167
+      "community": 168
     },
     {
       "label": "registerHandlers()",
@@ -2473,7 +2473,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L106",
       "id": "index_registerhandlers",
-      "community": 167
+      "community": 168
     },
     {
       "label": "startServer()",
@@ -2481,7 +2481,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L135",
       "id": "index_startserver",
-      "community": 167
+      "community": 168
     },
     {
       "label": "cleanup()",
@@ -2489,7 +2489,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L173",
       "id": "index_cleanup",
-      "community": 167
+      "community": 168
     },
     {
       "label": "server-info.spec.ts",
@@ -2497,7 +2497,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "bootstrap.ts",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2729,7 +2729,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "sse-server-impl.ts",
@@ -2769,7 +2769,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_ts",
-      "community": 122
+      "community": 123
     },
     {
       "label": "setTestDependencies()",
@@ -2777,7 +2777,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L79",
       "id": "http_server_settestdependencies",
-      "community": 122
+      "community": 123
     },
     {
       "label": "writeRuntimeDiagnosticsEvent()",
@@ -2785,7 +2785,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L96",
       "id": "http_server_writeruntimediagnosticsevent",
-      "community": 122
+      "community": 123
     },
     {
       "label": "resolveStaticRoot()",
@@ -2793,7 +2793,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L120",
       "id": "http_server_resolvestaticroot",
-      "community": 122
+      "community": 123
     },
     {
       "label": "isProtectedMcpProgrammaticPath()",
@@ -2801,7 +2801,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L213",
       "id": "http_server_isprotectedmcpprogrammaticpath",
-      "community": 122
+      "community": 123
     },
     {
       "label": "getHttpAuthTrustModelNotice()",
@@ -2809,7 +2809,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L217",
       "id": "http_server_gethttpauthtrustmodelnotice",
-      "community": 122
+      "community": 123
     },
     {
       "label": "getHttpAuthMissingAdminKeyWarning()",
@@ -2817,7 +2817,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L221",
       "id": "http_server_gethttpauthmissingadminkeywarning",
-      "community": 122
+      "community": 123
     },
     {
       "label": "initializeServer()",
@@ -2825,7 +2825,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L256",
       "id": "http_server_initializeserver",
-      "community": 122
+      "community": 123
     },
     {
       "label": "cleanup()",
@@ -2833,7 +2833,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L405",
       "id": "http_server_cleanup",
-      "community": 122
+      "community": 123
     },
     {
       "label": "registerCleanupHandlers()",
@@ -2841,7 +2841,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L477",
       "id": "http_server_registercleanuphandlers",
-      "community": 122
+      "community": 123
     },
     {
       "label": "startServer()",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/http-server.ts",
       "source_location": "L659",
       "id": "http_server_startserver",
-      "community": 122
+      "community": 123
     },
     {
       "label": "context.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "batch-run-history.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "mcp-tool-call-error.spec.ts",
@@ -3073,7 +3073,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "mcp-tool-call-error.ts",
@@ -3119,7 +3119,7 @@
       "label": "buildNetworkLinks()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L201",
+      "source_location": "L209",
       "id": "anchor_map_handler_buildnetworklinks",
       "community": 287
     },
@@ -3127,7 +3127,7 @@
       "label": "broadcastToSubscribers()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L249",
+      "source_location": "L257",
       "id": "anchor_map_handler_broadcasttosubscribers",
       "community": 287
     },
@@ -3135,7 +3135,7 @@
       "label": "broadcastAnchorMapUpdate()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L272",
+      "source_location": "L280",
       "id": "anchor_map_handler_broadcastanchormapupdate",
       "community": 287
     },
@@ -3145,7 +3145,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3153,7 +3153,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3161,7 +3161,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "session-store.ts",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "agent.routes.spec.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_response_ts",
-      "community": 123
+      "community": 124
     },
     {
       "label": "EmbeddingMapBuildError",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L55",
       "id": "admin_embedding_map_response_embeddingmapbuilderror",
-      "community": 123
+      "community": 124
     },
     {
       "label": ".constructor()",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L56",
       "id": "admin_embedding_map_response_embeddingmapbuilderror_constructor",
-      "community": 123
+      "community": 124
     },
     {
       "label": "clearEmbeddingMapCacheForTests()",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L66",
       "id": "admin_embedding_map_response_clearembeddingmapcachefortests",
-      "community": 123
+      "community": 124
     },
     {
       "label": "getCacheKey()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L75",
       "id": "admin_embedding_map_response_getcachekey",
-      "community": 123
+      "community": 124
     },
     {
       "label": "distSq()",
@@ -4721,7 +4721,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L79",
       "id": "admin_embedding_map_response_distsq",
-      "community": 123
+      "community": 124
     },
     {
       "label": "hash32()",
@@ -4729,7 +4729,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L89",
       "id": "admin_embedding_map_response_hash32",
-      "community": 123
+      "community": 124
     },
     {
       "label": "mulberry32()",
@@ -4737,7 +4737,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L99",
       "id": "admin_embedding_map_response_mulberry32",
-      "community": 123
+      "community": 124
     },
     {
       "label": "kMeans()",
@@ -4745,7 +4745,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L112",
       "id": "admin_embedding_map_response_kmeans",
-      "community": 123
+      "community": 124
     },
     {
       "label": "parseTags()",
@@ -4753,7 +4753,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L198",
       "id": "admin_embedding_map_response_parsetags",
-      "community": 123
+      "community": 124
     },
     {
       "label": "buildEmbeddingMapResponse()",
@@ -4761,7 +4761,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L207",
       "id": "admin_embedding_map_response_buildembeddingmapresponse",
-      "community": 123
+      "community": 124
     },
     {
       "label": "claude-code-hook.ts",
@@ -4865,7 +4865,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "env-loader.ts",
@@ -4897,7 +4897,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "codex-hook.ts",
@@ -5497,7 +5497,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "test-http-server-v2.ts",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "brave-search-provider.ts",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "llm-provider.ts",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "claude-provider.spec.ts",
@@ -6001,7 +6001,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "types.ts",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "vitest.config.ts",
@@ -6033,7 +6033,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "injection-contract.spec.ts",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -6065,7 +6065,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "injection-contract.ts",
@@ -6193,7 +6193,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "runtime.ts",
@@ -6201,7 +6201,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_runtime_ts",
-      "community": 124
+      "community": 125
     },
     {
       "label": "TimeoutError",
@@ -6209,7 +6209,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L37",
       "id": "runtime_timeouterror",
-      "community": 124
+      "community": 125
     },
     {
       "label": "CaptureRuntime",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L39",
       "id": "runtime_captureruntime",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".constructor()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L48",
       "id": "runtime_captureruntime_constructor",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".capture()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L58",
       "id": "runtime_captureruntime_capture",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".drain()",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L125",
       "id": "runtime_captureruntime_drain",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".captureResult()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L169",
       "id": "runtime_captureruntime_captureresult",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".dispatchTelemetry()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L185",
       "id": "runtime_captureruntime_dispatchtelemetry",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".emit()",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L197",
       "id": "runtime_captureruntime_emit",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".sendWithTimeout()",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L205",
       "id": "runtime_captureruntime_sendwithtimeout",
-      "community": 124
+      "community": 125
     },
     {
       "label": ".delay()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L226",
       "id": "runtime_captureruntime_delay",
-      "community": 124
+      "community": 125
     },
     {
       "label": "test-fixtures.ts",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "normalize.ts",
@@ -6345,7 +6345,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "priority-queue.ts",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_size_policy_ts",
-      "community": 168
+      "community": 169
     },
     {
       "label": "utf8Size()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L12",
       "id": "size_policy_utf8size",
-      "community": 168
+      "community": 169
     },
     {
       "label": "cloneEvent()",
@@ -6425,7 +6425,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L16",
       "id": "size_policy_cloneevent",
-      "community": 168
+      "community": 169
     },
     {
       "label": "removeOptionalFields()",
@@ -6433,7 +6433,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L20",
       "id": "size_policy_removeoptionalfields",
-      "community": 168
+      "community": 169
     },
     {
       "label": "reducibleText()",
@@ -6441,7 +6441,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L49",
       "id": "size_policy_reducibletext",
-      "community": 168
+      "community": 169
     },
     {
       "label": "truncateToFit()",
@@ -6449,7 +6449,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L89",
       "id": "size_policy_truncatetofit",
-      "community": 168
+      "community": 169
     },
     {
       "label": "applySizePolicy()",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L110",
       "id": "size_policy_applysizepolicy",
-      "community": 168
+      "community": 169
     },
     {
       "label": "buildBatch()",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L128",
       "id": "size_policy_buildbatch",
-      "community": 168
+      "community": 169
     },
     {
       "label": "validateBatch()",
@@ -6473,7 +6473,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L150",
       "id": "size_policy_validatebatch",
-      "community": 168
+      "community": 169
     },
     {
       "label": "schema.ts",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_ts",
-      "community": 169
+      "community": 170
     },
     {
       "label": "isRecord()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L50",
       "id": "schema_isrecord",
-      "community": 169
+      "community": 170
     },
     {
       "label": "hasOnlyKeys()",
@@ -6497,7 +6497,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L54",
       "id": "schema_hasonlykeys",
-      "community": 169
+      "community": 170
     },
     {
       "label": "validIdentifier()",
@@ -6505,7 +6505,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L58",
       "id": "schema_valididentifier",
-      "community": 169
+      "community": 170
     },
     {
       "label": "validJsonValue()",
@@ -6513,7 +6513,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L68",
       "id": "schema_validjsonvalue",
-      "community": 169
+      "community": 170
     },
     {
       "label": "validatePayload()",
@@ -6521,7 +6521,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L94",
       "id": "schema_validatepayload",
-      "community": 169
+      "community": 170
     },
     {
       "label": "validateAgentEvent()",
@@ -6529,7 +6529,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L125",
       "id": "schema_validateagentevent",
-      "community": 169
+      "community": 170
     },
     {
       "label": "eventSchema()",
@@ -6537,7 +6537,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L177",
       "id": "schema_eventschema",
-      "community": 169
+      "community": 170
     },
     {
       "label": "asAgentEvent()",
@@ -6545,7 +6545,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L277",
       "id": "schema_asagentevent",
-      "community": 169
+      "community": 170
     },
     {
       "label": "scope.spec.ts",
@@ -6569,7 +6569,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "adapter.ts",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "types.ts",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "scope.ts",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_ts",
-      "community": 170
+      "community": 171
     },
     {
       "label": "value()",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L7",
       "id": "scope_value",
-      "community": 170
+      "community": 171
     },
     {
       "label": "defaultGit()",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L12",
       "id": "scope_defaultgit",
-      "community": 170
+      "community": 171
     },
     {
       "label": "normalizeRemote()",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L25",
       "id": "scope_normalizeremote",
-      "community": 170
+      "community": 171
     },
     {
       "label": "processFromBranch()",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L38",
       "id": "scope_processfrombranch",
-      "community": 170
+      "community": 171
     },
     {
       "label": "detectCodexScope()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L44",
       "id": "scope_detectcodexscope",
-      "community": 170
+      "community": 171
     },
     {
       "label": "diagnostics.spec.ts",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "diagnostics.ts",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "adapter.ts",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "types.ts",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "scope.ts",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_ts",
-      "community": 170
+      "community": 171
     },
     {
       "label": "explicit()",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L7",
       "id": "scope_explicit",
-      "community": 170
+      "community": 171
     },
     {
       "label": "detectClaudeCodeScope()",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L44",
       "id": "scope_detectclaudecodescope",
-      "community": 170
+      "community": 171
     },
     {
       "label": "diagnostics.spec.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "diagnostics.ts",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "utils.spec.ts",
@@ -7241,7 +7241,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_types_ts",
-      "community": 125
+      "community": 126
     },
     {
       "label": "MementoError",
@@ -7249,7 +7249,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L299",
       "id": "types_mementoerror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -7257,7 +7257,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L300",
       "id": "types_mementoerror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "ConnectionError",
@@ -7265,7 +7265,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L311",
       "id": "types_connectionerror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -7273,7 +7273,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L312",
       "id": "types_connectionerror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "AuthenticationError",
@@ -7281,7 +7281,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L318",
       "id": "types_authenticationerror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L319",
       "id": "types_authenticationerror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "ValidationError",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L325",
       "id": "types_validationerror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L326",
       "id": "types_validationerror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "NotFoundError",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L332",
       "id": "types_notfounderror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L333",
       "id": "types_notfounderror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "memory-manager.ts",
@@ -8001,7 +8001,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "agent-api.spec.ts",
@@ -8009,7 +8009,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "logger.ts",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_ts",
-      "community": 171
+      "community": 172
     },
     {
       "label": "TripleExtractionLogger",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L61",
       "id": "triple_extraction_logger_tripleextractionlogger",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".constructor()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L65",
       "id": "triple_extraction_logger_tripleextractionlogger_constructor",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".logExtraction()",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L91",
       "id": "triple_extraction_logger_tripleextractionlogger_logextraction",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".createLogEntry()",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L128",
       "id": "triple_extraction_logger_tripleextractionlogger_createlogentry",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".ensureLogDirectory()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L191",
       "id": "triple_extraction_logger_tripleextractionlogger_ensurelogdirectory",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".getLogFilePath()",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L207",
       "id": "triple_extraction_logger_tripleextractionlogger_getlogfilepath",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".listLogFiles()",
@@ -9273,7 +9273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L233",
       "id": "triple_extraction_logger_tripleextractionlogger_listlogfiles",
-      "community": 171
+      "community": 172
     },
     {
       "label": ".deleteOldLogs()",
@@ -9281,7 +9281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L266",
       "id": "triple_extraction_logger_tripleextractionlogger_deleteoldlogs",
-      "community": 171
+      "community": 172
     },
     {
       "label": "database-optimize-tool.ts",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -10025,7 +10025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -10033,7 +10033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
-      "community": 126
+      "community": 113
     },
     {
       "label": "shouldSkipPreflight()",
@@ -10041,7 +10041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L16",
       "id": "db_integrity_preflight_shouldskippreflight",
-      "community": 126
+      "community": 113
     },
     {
       "label": "extractPragmaMessages()",
@@ -10049,7 +10049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L20",
       "id": "db_integrity_preflight_extractpragmamessages",
-      "community": 126
+      "community": 113
     },
     {
       "label": "runCheck()",
@@ -10057,7 +10057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L26",
       "id": "db_integrity_preflight_runcheck",
-      "community": 126
+      "community": 113
     },
     {
       "label": "formatTimestamp()",
@@ -10065,7 +10065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L31",
       "id": "db_integrity_preflight_formattimestamp",
-      "community": 126
+      "community": 113
     },
     {
       "label": "buildQuarantinePath()",
@@ -10073,47 +10073,55 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
       "source_location": "L35",
       "id": "db_integrity_preflight_buildquarantinepath",
-      "community": 126
+      "community": 113
+    },
+    {
+      "label": "findRecentQuarantineSnapshot()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
+      "source_location": "L45",
+      "id": "db_integrity_preflight_findrecentquarantinesnapshot",
+      "community": 113
     },
     {
       "label": "quarantineDatabaseFile()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L43",
+      "source_location": "L84",
       "id": "db_integrity_preflight_quarantinedatabasefile",
-      "community": 126
+      "community": 113
     },
     {
       "label": "maskError()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L50",
+      "source_location": "L95",
       "id": "db_integrity_preflight_maskerror",
-      "community": 126
+      "community": 113
     },
     {
       "label": "isOkResult()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L56",
+      "source_location": "L101",
       "id": "db_integrity_preflight_isokresult",
-      "community": 126
+      "community": 113
     },
     {
       "label": "looksLikeCorruption()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L60",
+      "source_location": "L105",
       "id": "db_integrity_preflight_lookslikecorruption",
-      "community": 126
+      "community": 113
     },
     {
       "label": "runDatabaseIntegrityPreflight()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L65",
+      "source_location": "L110",
       "id": "db_integrity_preflight_rundatabaseintegritypreflight",
-      "community": 126
+      "community": 113
     },
     {
       "label": "init.spec.ts",
@@ -10121,7 +10129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "init.ts",
@@ -10257,7 +10265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "migrate.ts",
@@ -10289,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "migration-runner.ts",
@@ -10297,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_ts",
-      "community": 172
+      "community": 173
     },
     {
       "label": "MigrationRunner",
@@ -10305,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L19",
       "id": "migration_runner_migrationrunner",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".constructor()",
@@ -10313,7 +10321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L24",
       "id": "migration_runner_migrationrunner_constructor",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".runMigration()",
@@ -10321,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L33",
       "id": "migration_runner_migrationrunner_runmigration",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".rollbackMigration()",
@@ -10329,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L174",
       "id": "migration_runner_migrationrunner_rollbackmigration",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".runMigrations()",
@@ -10337,7 +10345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L199",
       "id": "migration_runner_migrationrunner_runmigrations",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".calculateChecksum()",
@@ -10345,7 +10353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L222",
       "id": "migration_runner_migrationrunner_calculatechecksum",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".getBackupManager()",
@@ -10353,7 +10361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L231",
       "id": "migration_runner_migrationrunner_getbackupmanager",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".getVersionManager()",
@@ -10361,7 +10369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L238",
       "id": "migration_runner_migrationrunner_getversionmanager",
-      "community": 172
+      "community": 173
     },
     {
       "label": "migration-runner.integration.spec.ts",
@@ -10385,7 +10393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "migration-detector.ts",
@@ -10577,7 +10585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "migration-detector.spec.ts",
@@ -10585,7 +10593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "backup-manager.ts",
@@ -10593,7 +10601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_ts",
-      "community": 173
+      "community": 174
     },
     {
       "label": "BackupManager",
@@ -10601,7 +10609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L37",
       "id": "backup_manager_backupmanager",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".constructor()",
@@ -10609,7 +10617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L40",
       "id": "backup_manager_backupmanager_constructor",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".ensureBackupsDirectory()",
@@ -10617,7 +10625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L50",
       "id": "backup_manager_backupmanager_ensurebackupsdirectory",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".createBackup()",
@@ -10625,7 +10633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L68",
       "id": "backup_manager_backupmanager_createbackup",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".restoreBackup()",
@@ -10633,7 +10641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L132",
       "id": "backup_manager_backupmanager_restorebackup",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".cleanupOldBackups()",
@@ -10641,7 +10649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L165",
       "id": "backup_manager_backupmanager_cleanupoldbackups",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".findLatestBackup()",
@@ -10649,7 +10657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L210",
       "id": "backup_manager_backupmanager_findlatestbackup",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".getBackupsDirectory()",
@@ -10657,7 +10665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.ts",
       "source_location": "L244",
       "id": "backup_manager_backupmanager_getbackupsdirectory",
-      "community": 173
+      "community": 174
     },
     {
       "label": "backup-manager.spec.ts",
@@ -10665,7 +10673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "dependency-validator.ts",
@@ -10769,7 +10777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "schema-version-manager.ts",
@@ -10857,7 +10865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -10985,7 +10993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_ts",
-      "community": 174
+      "community": 175
     },
     {
       "label": "AnchorTableMigration",
@@ -10993,7 +11001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L20",
       "id": "004_anchor_table_anchortablemigration",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".executeSQL()",
@@ -11001,7 +11009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L29",
       "id": "004_anchor_table_anchortablemigration_executesql",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".tableExists()",
@@ -11009,7 +11017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L54",
       "id": "004_anchor_table_anchortablemigration_tableexists",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".indexExists()",
@@ -11017,7 +11025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L65",
       "id": "004_anchor_table_anchortablemigration_indexexists",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".validateBefore()",
@@ -11025,7 +11033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L76",
       "id": "004_anchor_table_anchortablemigration_validatebefore",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".up()",
@@ -11033,7 +11041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L102",
       "id": "004_anchor_table_anchortablemigration_up",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".down()",
@@ -11041,7 +11049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L136",
       "id": "004_anchor_table_anchortablemigration_down",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".validateAfter()",
@@ -11049,7 +11057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L158",
       "id": "004_anchor_table_anchortablemigration_validateafter",
-      "community": 174
+      "community": 175
     },
     {
       "label": "020-process-attribute-table.ts",
@@ -11121,7 +11129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_ts",
-      "community": 175
+      "community": 176
     },
     {
       "label": "FactMetadataFieldsMigration",
@@ -11129,7 +11137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L18",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".tableExists()",
@@ -11137,7 +11145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L23",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_tableexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".columnExists()",
@@ -11145,7 +11153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L30",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_columnexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".indexExists()",
@@ -11153,7 +11161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L35",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_indexexists",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".validateBefore()",
@@ -11161,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L42",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validatebefore",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".up()",
@@ -11169,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L59",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_up",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".down()",
@@ -11177,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L68",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_down",
-      "community": 175
+      "community": 176
     },
     {
       "label": ".validateAfter()",
@@ -11185,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L96",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validateafter",
-      "community": 175
+      "community": 176
     },
     {
       "label": "032-add-project-id.ts",
@@ -11297,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_025_memory_item_is_consolidated_ts",
-      "community": 176
+      "community": 177
     },
     {
       "label": "MemoryItemIsConsolidatedMigration",
@@ -11305,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L9",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".tableExists()",
@@ -11313,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L14",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_tableexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".columnExists()",
@@ -11321,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L21",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_columnexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".indexExists()",
@@ -11329,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L26",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_indexexists",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".validateBefore()",
@@ -11337,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L33",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validatebefore",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".up()",
@@ -11345,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L35",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_up",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".down()",
@@ -11353,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L49",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_down",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".validateAfter()",
@@ -11361,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L58",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validateafter",
-      "community": 176
+      "community": 177
     },
     {
       "label": "030-triple-extraction-fields.spec.ts",
@@ -12329,7 +12337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_ts",
-      "community": 177
+      "community": 178
     },
     {
       "label": "TripleExtractionFieldsMigration",
@@ -12337,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".tableExists()",
@@ -12345,7 +12353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L15",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_tableexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".columnExists()",
@@ -12353,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L22",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_columnexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".indexExists()",
@@ -12361,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L27",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_indexexists",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".validateBefore()",
@@ -12369,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L34",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validatebefore",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".up()",
@@ -12377,7 +12385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L36",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_up",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".down()",
@@ -12385,7 +12393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L61",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_down",
-      "community": 177
+      "community": 178
     },
     {
       "label": ".validateAfter()",
@@ -12393,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L69",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validateafter",
-      "community": 177
+      "community": 178
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -12401,7 +12409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_021_feedback_event_attribution_ts",
-      "community": 178
+      "community": 179
     },
     {
       "label": "FeedbackEventAttributionMigration",
@@ -12409,7 +12417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L9",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".tableExists()",
@@ -12417,7 +12425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L14",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_tableexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".columnExists()",
@@ -12425,7 +12433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L21",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_columnexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".indexExists()",
@@ -12433,7 +12441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L26",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_indexexists",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".validateBefore()",
@@ -12441,7 +12449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L33",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validatebefore",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".up()",
@@ -12449,7 +12457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L57",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_up",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".down()",
@@ -12457,7 +12465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L89",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_down",
-      "community": 178
+      "community": 179
     },
     {
       "label": ".validateAfter()",
@@ -12465,7 +12473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L107",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validateafter",
-      "community": 178
+      "community": 179
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -12841,7 +12849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_ts",
-      "community": 179
+      "community": 180
     },
     {
       "label": "ProceduralVersionIndexesMigration",
@@ -12849,7 +12857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L18",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".columnExists()",
@@ -12857,7 +12865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L23",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_columnexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".tableExists()",
@@ -12865,7 +12873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L28",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_tableexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".indexExists()",
@@ -12873,7 +12881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L35",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_indexexists",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".validateBefore()",
@@ -12881,7 +12889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L42",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validatebefore",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".up()",
@@ -12889,7 +12897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L62",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_up",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".down()",
@@ -12897,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L73",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_down",
-      "community": 179
+      "community": 180
     },
     {
       "label": ".validateAfter()",
@@ -12905,7 +12913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L81",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validateafter",
-      "community": 179
+      "community": 180
     },
     {
       "label": "002-mirix-schema-expansion.spec.ts",
@@ -12929,7 +12937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_ts",
-      "community": 113
+      "community": 114
     },
     {
       "label": "RelationEngineSchemaMigration",
@@ -12937,7 +12945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L29",
       "id": "005_relation_engine_schema_relationengineschemamigration",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".loadSQLFile()",
@@ -12945,7 +12953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L37",
       "id": "005_relation_engine_schema_relationengineschemamigration_loadsqlfile",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".executeSQL()",
@@ -12953,7 +12961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L46",
       "id": "005_relation_engine_schema_relationengineschemamigration_executesql",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".tableExists()",
@@ -12961,7 +12969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L71",
       "id": "005_relation_engine_schema_relationengineschemamigration_tableexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".indexExists()",
@@ -12969,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L82",
       "id": "005_relation_engine_schema_relationengineschemamigration_indexexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".columnExists()",
@@ -12977,7 +12985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L93",
       "id": "005_relation_engine_schema_relationengineschemamigration_columnexists",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".mapRelationType()",
@@ -12985,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L101",
       "id": "005_relation_engine_schema_relationengineschemamigration_maprelationtype",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".validateBefore()",
@@ -12993,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L114",
       "id": "005_relation_engine_schema_relationengineschemamigration_validatebefore",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".up()",
@@ -13001,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L145",
       "id": "005_relation_engine_schema_relationengineschemamigration_up",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".down()",
@@ -13009,7 +13017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L214",
       "id": "005_relation_engine_schema_relationengineschemamigration_down",
-      "community": 113
+      "community": 114
     },
     {
       "label": ".validateAfter()",
@@ -13017,7 +13025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts",
       "source_location": "L241",
       "id": "005_relation_engine_schema_relationengineschemamigration_validateafter",
-      "community": 113
+      "community": 114
     },
     {
       "label": "019-backfill-kg-triple-from-memory-item.spec.ts",
@@ -13089,7 +13097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_ts",
-      "community": 180
+      "community": 181
     },
     {
       "label": "MemoryItemAttributionMigration",
@@ -13097,7 +13105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L18",
       "id": "016_memory_item_attribution_memoryitemattributionmigration",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".tableExists()",
@@ -13105,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L23",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_tableexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".columnExists()",
@@ -13113,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L30",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_columnexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".indexExists()",
@@ -13121,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L35",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_indexexists",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".validateBefore()",
@@ -13129,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L42",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validatebefore",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".up()",
@@ -13137,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L62",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_up",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".down()",
@@ -13145,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L69",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_down",
-      "community": 180
+      "community": 181
     },
     {
       "label": ".validateAfter()",
@@ -13153,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L87",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validateafter",
-      "community": 180
+      "community": 181
     },
     {
       "label": "036-agent-memory-promotion-schema.ts",
@@ -13369,7 +13377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_ts",
-      "community": 181
+      "community": 182
     },
     {
       "label": "KgTripleTableMigration",
@@ -13377,7 +13385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L17",
       "id": "018_kg_triple_table_kgtripletablemigration",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".tableExists()",
@@ -13385,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L22",
       "id": "018_kg_triple_table_kgtripletablemigration_tableexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".columnExists()",
@@ -13393,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L29",
       "id": "018_kg_triple_table_kgtripletablemigration_columnexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".indexExists()",
@@ -13401,7 +13409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L34",
       "id": "018_kg_triple_table_kgtripletablemigration_indexexists",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".validateBefore()",
@@ -13409,7 +13417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L41",
       "id": "018_kg_triple_table_kgtripletablemigration_validatebefore",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".up()",
@@ -13417,7 +13425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L58",
       "id": "018_kg_triple_table_kgtripletablemigration_up",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".down()",
@@ -13425,7 +13433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L80",
       "id": "018_kg_triple_table_kgtripletablemigration_down",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".validateAfter()",
@@ -13433,7 +13441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L91",
       "id": "018_kg_triple_table_kgtripletablemigration_validateafter",
-      "community": 181
+      "community": 182
     },
     {
       "label": "035-agent-integration-schema.contract.spec.ts",
@@ -13441,7 +13449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -13673,7 +13681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -13761,7 +13769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_ts",
-      "community": 182
+      "community": 183
     },
     {
       "label": "SoftDeleteFieldsMigration",
@@ -13769,7 +13777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_softdeletefieldsmigration",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".tableExists()",
@@ -13777,7 +13785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L14",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_tableexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".columnExists()",
@@ -13785,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L21",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_columnexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".indexExists()",
@@ -13793,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L26",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_indexexists",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".validateBefore()",
@@ -13801,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L33",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validatebefore",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".up()",
@@ -13809,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_up",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".down()",
@@ -13817,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L52",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_down",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".validateAfter()",
@@ -13825,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L59",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validateafter",
-      "community": 182
+      "community": 183
     },
     {
       "label": "006-fts5-reflection-notes.spec.ts",
@@ -13921,7 +13929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_ts",
-      "community": 183
+      "community": 184
     },
     {
       "label": "MemoryItemOwnerIdMigration",
@@ -13929,7 +13937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L17",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".tableExists()",
@@ -13937,7 +13945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L22",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_tableexists",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".columnExists()",
@@ -13945,7 +13953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L29",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_columnexists",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".indexExists()",
@@ -13953,7 +13961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L34",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_indexexists",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".validateBefore()",
@@ -13961,7 +13969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L41",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validatebefore",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".up()",
@@ -13969,7 +13977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L58",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_up",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".down()",
@@ -13977,7 +13985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L63",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_down",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".validateAfter()",
@@ -13985,7 +13993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L75",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validateafter",
-      "community": 183
+      "community": 184
     },
     {
       "label": "003-consolidation-score-fields.spec.ts",
@@ -14121,7 +14129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_sqlite_core_memory_adapter_ts",
-      "community": 114
+      "community": 115
     },
     {
       "label": "SqliteCoreMemoryPreparedStatement",
@@ -14129,7 +14137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L15",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".constructor()",
@@ -14137,7 +14145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L18",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_constructor",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".all()",
@@ -14145,7 +14153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L25",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_all",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".get()",
@@ -14153,7 +14161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L36",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_get",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".run()",
@@ -14161,7 +14169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L47",
       "id": "sqlite_core_memory_adapter_sqlitecorememorypreparedstatement_run",
-      "community": 114
+      "community": 115
     },
     {
       "label": "SqliteCoreMemoryAdapter",
@@ -14169,7 +14177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L64",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".constructor()",
@@ -14177,7 +14185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L67",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_constructor",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".prepare()",
@@ -14185,7 +14193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L74",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_prepare",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".exec()",
@@ -14193,7 +14201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L86",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_exec",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".close()",
@@ -14201,7 +14209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L98",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_close",
-      "community": 114
+      "community": 115
     },
     {
       "label": ".isOpen()",
@@ -14209,7 +14217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts",
       "source_location": "L110",
       "id": "sqlite_core_memory_adapter_sqlitecorememoryadapter_isopen",
-      "community": 114
+      "community": 115
     },
     {
       "label": "sqlite-core-memory-adapter.spec.ts",
@@ -14217,7 +14225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -14993,7 +15001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "cache-service.ts",
@@ -15321,7 +15329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "batch-scheduler.ts",
@@ -15889,7 +15897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -15913,7 +15921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_retry_manager_ts",
-      "community": 184
+      "community": 185
     },
     {
       "label": "RetryManager",
@@ -15921,7 +15929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L103",
       "id": "retry_manager_retrymanager",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".constructor()",
@@ -15929,7 +15937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L107",
       "id": "retry_manager_retrymanager_constructor",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".shouldRetry()",
@@ -15937,7 +15945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L119",
       "id": "retry_manager_retrymanager_shouldretry",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".resetErrorCount()",
@@ -15945,7 +15953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L158",
       "id": "retry_manager_retrymanager_reseterrorcount",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".incrementErrorCount()",
@@ -15953,7 +15961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L168",
       "id": "retry_manager_retrymanager_incrementerrorcount",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".getErrorCount()",
@@ -15961,7 +15969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L181",
       "id": "retry_manager_retrymanager_geterrorcount",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".clearAllErrorCounts()",
@@ -15969,7 +15977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L188",
       "id": "retry_manager_retrymanager_clearallerrorcounts",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".retry()",
@@ -15977,7 +15985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L218",
       "id": "retry_manager_retrymanager_retry",
-      "community": 184
+      "community": 185
     },
     {
       "label": "batch-job-execution-coordinator.ts",
@@ -16049,7 +16057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_file_logger_ts",
-      "community": 185
+      "community": 186
     },
     {
       "label": "FileLogger",
@@ -16057,7 +16065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L38",
       "id": "file_logger_filelogger",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".constructor()",
@@ -16065,7 +16073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L42",
       "id": "file_logger_filelogger_constructor",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".log()",
@@ -16073,7 +16081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L81",
       "id": "file_logger_filelogger_log",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".logWarn()",
@@ -16081,7 +16089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L128",
       "id": "file_logger_filelogger_logwarn",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".logError()",
@@ -16089,7 +16097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L160",
       "id": "file_logger_filelogger_logerror",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".sanitizeData()",
@@ -16097,7 +16105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L194",
       "id": "file_logger_filelogger_sanitizedata",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".getLogFilePath()",
@@ -16105,7 +16113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L211",
       "id": "file_logger_filelogger_getlogfilepath",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".setEnabled()",
@@ -16113,7 +16121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L220",
       "id": "file_logger_filelogger_setenabled",
-      "community": 185
+      "community": 186
     },
     {
       "label": "batch-job-timeout-resolver.ts",
@@ -16457,7 +16465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -16585,7 +16593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "batch-job-execution-coordinator.spec.ts",
@@ -16673,7 +16681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "retry-manager.spec.ts",
@@ -16753,7 +16761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "batch-job-timeout-resolver.spec.ts",
@@ -16761,7 +16769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_timeout_resolver_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -16873,7 +16881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -16913,7 +16921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -17049,7 +17057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "jsonl-rotation.ts",
@@ -17073,7 +17081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "type-guards.ts",
@@ -17081,7 +17089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_guards_ts",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isMemoryRow()",
@@ -17089,7 +17097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L32",
       "id": "type_guards_ismemoryrow",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isMemoryType()",
@@ -17097,7 +17105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L53",
       "id": "type_guards_ismemorytype",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isPrivacyScope()",
@@ -17105,7 +17113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L63",
       "id": "type_guards_isprivacyscope",
-      "community": 186
+      "community": 187
     },
     {
       "label": "convertMemoryRowToItem()",
@@ -17113,7 +17121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L74",
       "id": "type_guards_convertmemoryrowtoitem",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isRelationRow()",
@@ -17121,7 +17129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L144",
       "id": "type_guards_isrelationrow",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isExistingRelationRow()",
@@ -17129,7 +17137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L176",
       "id": "type_guards_isexistingrelationrow",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isMetadataRow()",
@@ -17137,7 +17145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L201",
       "id": "type_guards_ismetadatarow",
-      "community": 186
+      "community": 187
     },
     {
       "label": "isSqlParam()",
@@ -17145,7 +17153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L216",
       "id": "type_guards_issqlparam",
-      "community": 186
+      "community": 187
     },
     {
       "label": "procedural-memory-extractor.ts",
@@ -17329,7 +17337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -17337,7 +17345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -17513,7 +17521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_rate_limiter_ts",
-      "community": 187
+      "community": 188
     },
     {
       "label": "LoggingRateLimiter",
@@ -17521,7 +17529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L31",
       "id": "logging_rate_limiter_loggingratelimiter",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".constructor()",
@@ -17529,7 +17537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L38",
       "id": "logging_rate_limiter_loggingratelimiter_constructor",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".canSend()",
@@ -17537,7 +17545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L52",
       "id": "logging_rate_limiter_loggingratelimiter_cansend",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".consume()",
@@ -17545,7 +17553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L61",
       "id": "logging_rate_limiter_loggingratelimiter_consume",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".refill()",
@@ -17553,7 +17561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L76",
       "id": "logging_rate_limiter_loggingratelimiter_refill",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".getDroppedCount()",
@@ -17561,7 +17569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L88",
       "id": "logging_rate_limiter_loggingratelimiter_getdroppedcount",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".resetDroppedCount()",
@@ -17569,7 +17577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L95",
       "id": "logging_rate_limiter_loggingratelimiter_resetdroppedcount",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".getAvailableTokens()",
@@ -17577,7 +17585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L102",
       "id": "logging_rate_limiter_loggingratelimiter_getavailabletokens",
-      "community": 187
+      "community": 188
     },
     {
       "label": "type-param-validator.ts",
@@ -17633,7 +17641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "relation-visualizer.ts",
@@ -18057,7 +18065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "cache-key-generator.ts",
@@ -18249,7 +18257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "path-validator.ts",
@@ -18345,7 +18353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -18353,7 +18361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -18481,7 +18489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_ts",
-      "community": 188
+      "community": 155
     },
     {
       "label": "validateLogMetadata()",
@@ -18489,7 +18497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L54",
       "id": "logger_validatelogmetadata",
-      "community": 188
+      "community": 155
     },
     {
       "label": "isMCPMode()",
@@ -18497,7 +18505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L160",
       "id": "logger_ismcpmode",
-      "community": 188
+      "community": 155
     },
     {
       "label": "safeStringify()",
@@ -18505,47 +18513,55 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
       "source_location": "L173",
       "id": "logger_safestringify",
-      "community": 188
+      "community": 155
+    },
+    {
+      "label": "normalizeMetaErrors()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/shared/utils/logger.ts",
+      "source_location": "L181",
+      "id": "logger_normalizemetaerrors",
+      "community": 155
     },
     {
       "label": "formatTime()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L181",
+      "source_location": "L193",
       "id": "logger_formattime",
-      "community": 188
+      "community": 155
     },
     {
       "label": "buildLogMessage()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L191",
+      "source_location": "L203",
       "id": "logger_buildlogmessage",
-      "community": 188
+      "community": 155
     },
     {
       "label": "logToStderr()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L209",
+      "source_location": "L221",
       "id": "logger_logtostderr",
-      "community": 188
+      "community": 155
     },
     {
       "label": "logWithMCPLogger()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L240",
+      "source_location": "L253",
       "id": "logger_logwithmcplogger",
-      "community": 188
+      "community": 155
     },
     {
       "label": "isCliQuiet()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L294",
+      "source_location": "L308",
       "id": "logger_iscliquiet",
-      "community": 188
+      "community": 155
     },
     {
       "label": "ensure-meta-memory-stats-schema.ts",
@@ -18713,7 +18729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "pii-masker.ts",
@@ -18825,7 +18841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -18833,7 +18849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "pii-masker-api-key.spec.ts",
@@ -18841,7 +18857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "path-validator.spec.ts",
@@ -18849,7 +18865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "triple-cache.spec.ts",
@@ -18857,7 +18873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -18865,7 +18881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -18873,7 +18889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -18881,7 +18897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -18889,7 +18905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "logger-schema.spec.ts",
@@ -18897,7 +18913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -18905,7 +18921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -18929,7 +18945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -18937,7 +18953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "benchmark.types.ts",
@@ -18961,7 +18977,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "consolidation-score.types.ts",
@@ -18969,7 +18985,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "consolidation.types.ts",
@@ -18977,7 +18993,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "vector-search.types.ts",
@@ -18985,7 +19001,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -18993,7 +19009,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "procedural-versioning.ts",
@@ -19001,7 +19017,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "triple-extraction.ts",
@@ -19009,7 +19025,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "feedback.types.ts",
@@ -19017,7 +19033,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "embedding.types.ts",
@@ -19025,7 +19041,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "relation-graph.ts",
@@ -19033,7 +19049,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "failure-event.ts",
@@ -19041,7 +19057,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "index.ts",
@@ -19073,7 +19089,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "ranking.types.ts",
@@ -19081,7 +19097,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "alerts.types.ts",
@@ -19089,7 +19105,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "relation.ts",
@@ -19129,7 +19145,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "index.spec.ts",
@@ -19137,7 +19153,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -19145,7 +19161,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "constants.ts",
@@ -19153,7 +19169,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "environment.ts",
@@ -19297,7 +19313,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "retry-options-loader.ts",
@@ -19457,7 +19473,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "constants.spec.ts",
@@ -19465,7 +19481,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -19473,7 +19489,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "config-validation.spec.ts",
@@ -19481,7 +19497,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -19489,7 +19505,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "environment-paths.spec.ts",
@@ -19497,7 +19513,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -19505,7 +19521,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "relation-constants.ts",
@@ -19513,7 +19529,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "introspection-constants.ts",
@@ -19521,7 +19537,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -19529,7 +19545,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "http-bind-policy.ts",
@@ -19609,7 +19625,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "retry-manager.interface.ts",
@@ -19617,7 +19633,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "cache.interface.ts",
@@ -19625,7 +19641,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -19633,7 +19649,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "error-logging.interface.ts",
@@ -19641,7 +19657,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -19649,7 +19665,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -19657,7 +19673,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "database.interface.ts",
@@ -19665,7 +19681,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -19673,7 +19689,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -19681,7 +19697,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "llm-client-initializer.ts",
@@ -19889,7 +19905,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "openai-client.spec.ts",
@@ -19897,7 +19913,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -19905,7 +19921,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -19913,7 +19929,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -19921,7 +19937,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -19929,7 +19945,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -19937,7 +19953,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "environment-priority.spec.ts",
@@ -19945,7 +19961,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -19953,7 +19969,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "gemini-client.spec.ts",
@@ -19961,7 +19977,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "search-local-tool.ts",
@@ -20281,7 +20297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 954
+      "community": 956
     },
     {
       "label": "query-filter-strategy.ts",
@@ -20329,7 +20345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -20337,7 +20353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "local-search-service.ts",
@@ -20409,7 +20425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -20417,7 +20433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "anchor-interfaces.ts",
@@ -20545,7 +20561,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 959
+      "community": 961
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -20569,7 +20585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 960
+      "community": 962
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -20577,7 +20593,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 961
+      "community": 963
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -20825,7 +20841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "fallback-strategy.ts",
@@ -21009,7 +21025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 963
+      "community": 965
     },
     {
       "label": "anchor-cache-service.ts",
@@ -21257,7 +21273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 964
+      "community": 966
     },
     {
       "label": "local-search-service.spec.ts",
@@ -21265,7 +21281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -21273,7 +21289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -21281,7 +21297,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 967
+      "community": 969
     },
     {
       "label": "store.ts",
@@ -21321,7 +21337,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 968
+      "community": 970
     },
     {
       "label": "index.ts",
@@ -21329,7 +21345,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "getters.ts",
@@ -21377,7 +21393,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 970
+      "community": 972
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -21385,7 +21401,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -21393,7 +21409,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 972
+      "community": 974
     },
     {
       "label": "vector-search.factory.ts",
@@ -21537,7 +21553,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 973
+      "community": 975
     },
     {
       "label": "search-result-combiner.ts",
@@ -22769,7 +22785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "search-ranking.spec.ts",
@@ -22777,7 +22793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -22881,7 +22897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -22889,7 +22905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "search-engine.spec.ts",
@@ -22929,7 +22945,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "vector-search.repository.ts",
@@ -22983,7 +22999,7 @@
       "label": ".getIndexStatus()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L607",
+      "source_location": "L657",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_getindexstatus",
       "community": 48
     },
@@ -22991,7 +23007,7 @@
       "label": ".rebuildIndex()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L665",
+      "source_location": "L715",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_rebuildindex",
       "community": 48
     },
@@ -22999,7 +23015,7 @@
       "label": ".getTableName()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L686",
+      "source_location": "L736",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_gettablename",
       "community": 48
     },
@@ -23007,7 +23023,7 @@
       "label": ".checkAvailability()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L693",
+      "source_location": "L743",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_checkavailability",
       "community": 48
     },
@@ -23015,7 +23031,7 @@
       "label": ".isVecTableRegistered()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L701",
+      "source_location": "L751",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_isvectableregistered",
       "community": 48
     },
@@ -23023,7 +23039,7 @@
       "label": ".shouldUseDominantStoredDimensionsForTable()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L725",
+      "source_location": "L775",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_shouldusedominantstoreddimensionsfortable",
       "community": 48
     },
@@ -23031,7 +23047,7 @@
       "label": ".getVecTableSchemaDimensions()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L733",
+      "source_location": "L783",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_getvectableschemadimensions",
       "community": 48
     },
@@ -23039,7 +23055,7 @@
       "label": ".resolveRuntimeVectorContext()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L745",
+      "source_location": "L795",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "community": 48
     },
@@ -23047,7 +23063,7 @@
       "label": ".getDominantStoredDimensions()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L804",
+      "source_location": "L854",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_getdominantstoreddimensions",
       "community": 48
     },
@@ -23055,7 +23071,7 @@
       "label": ".alignQueryVectorToStoredDimensions()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L827",
+      "source_location": "L877",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_alignqueryvectortostoreddimensions",
       "community": 48
     },
@@ -23063,7 +23079,7 @@
       "label": ".getExpectedDimensions()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L864",
+      "source_location": "L914",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_getexpecteddimensions",
       "community": 48
     },
@@ -23071,7 +23087,7 @@
       "label": ".safeParseTags()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L872",
+      "source_location": "L922",
       "id": "vector_search_repository_vectorsearchrepositoryimpl_safeparsetags",
       "community": 48
     },
@@ -23129,7 +23145,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -23137,7 +23153,15 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 980
+      "community": 668
+    },
+    {
+      "label": "seedScopedHybridMemories()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
+      "source_location": "L407",
+      "id": "vector_search_repository_spec_seedscopedhybridmemories",
+      "community": 668
     },
     {
       "label": "vector-search.service.ts",
@@ -23233,7 +23257,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -23241,7 +23265,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 668
+      "community": 669
     },
     {
       "label": "vector-performance-tester.ts",
@@ -23305,7 +23329,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "createMockRepository()",
@@ -23313,7 +23337,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 669
+      "community": 670
     },
     {
       "label": "vector-index-manager.ts",
@@ -23497,7 +23521,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_container_ts",
-      "community": 155
+      "community": 156
     },
     {
       "label": "VectorSearchContainer",
@@ -23505,7 +23529,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L11",
       "id": "vector_search_container_vectorsearchcontainer",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".constructor()",
@@ -23513,7 +23537,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L16",
       "id": "vector_search_container_vectorsearchcontainer_constructor",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".getInstance()",
@@ -23521,7 +23545,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L21",
       "id": "vector_search_container_vectorsearchcontainer_getinstance",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".setDatabase()",
@@ -23529,7 +23553,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L31",
       "id": "vector_search_container_vectorsearchcontainer_setdatabase",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".getFacade()",
@@ -23537,7 +23561,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L39",
       "id": "vector_search_container_vectorsearchcontainer_getfacade",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".createFacade()",
@@ -23545,7 +23569,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L52",
       "id": "vector_search_container_vectorsearchcontainer_createfacade",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".reset()",
@@ -23553,7 +23577,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L70",
       "id": "vector_search_container_vectorsearchcontainer_reset",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".isConnected()",
@@ -23561,7 +23585,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L78",
       "id": "vector_search_container_vectorsearchcontainer_isconnected",
-      "community": 155
+      "community": 156
     },
     {
       "label": ".isFacadeReady()",
@@ -23569,7 +23593,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-container.ts",
       "source_location": "L85",
       "id": "vector_search_container_vectorsearchcontainer_isfacadeready",
-      "community": 155
+      "community": 156
     },
     {
       "label": "vector-search-result-normalizer.ts",
@@ -23617,7 +23641,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "createMockRepositories()",
@@ -23625,7 +23649,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 670
+      "community": 671
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -23633,7 +23657,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 981
+      "community": 982
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -23641,7 +23665,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "createMockIndexRepository()",
@@ -23649,7 +23673,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 671
+      "community": 672
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -23825,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 982
+      "community": 983
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -23833,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 983
+      "community": 984
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -23841,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 984
+      "community": 985
     },
     {
       "label": "spaced-repetition.ts",
@@ -23849,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_ts",
-      "community": 115
+      "community": 116
     },
     {
       "label": "SpacedRepetitionAlgorithm",
@@ -23857,7 +23881,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L29",
       "id": "spaced_repetition_spacedrepetitionalgorithm",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".constructor()",
@@ -23865,7 +23889,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L33",
       "id": "spaced_repetition_spacedrepetitionalgorithm_constructor",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".calculateNextInterval()",
@@ -23873,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L47",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculatenextinterval",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".calculateRecallProbability()",
@@ -23881,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L66",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculaterecallprobability",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".needsReview()",
@@ -23889,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L77",
       "id": "spaced_repetition_spacedrepetitionalgorithm_needsreview",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".createReviewSchedule()",
@@ -23897,7 +23921,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L90",
       "id": "spaced_repetition_spacedrepetitionalgorithm_createreviewschedule",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".createBatchReviewSchedules()",
@@ -23905,7 +23929,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L116",
       "id": "spaced_repetition_spacedrepetitionalgorithm_createbatchreviewschedules",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".calculateReviewPriority()",
@@ -23913,7 +23937,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L148",
       "id": "spaced_repetition_spacedrepetitionalgorithm_calculatereviewpriority",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".analyzeReviewPerformance()",
@@ -23921,7 +23945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L160",
       "id": "spaced_repetition_spacedrepetitionalgorithm_analyzereviewperformance",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".recommendOptimalInterval()",
@@ -23929,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L210",
       "id": "spaced_repetition_spacedrepetitionalgorithm_recommendoptimalinterval",
-      "community": 115
+      "community": 116
     },
     {
       "label": ".getDaysSince()",
@@ -23937,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.ts",
       "source_location": "L238",
       "id": "spaced_repetition_spacedrepetitionalgorithm_getdayssince",
-      "community": 115
+      "community": 116
     },
     {
       "label": "spaced-repetition-refactored.ts",
@@ -24169,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 985
+      "community": 986
     },
     {
       "label": "forgetting-stats-tool.ts",
@@ -24209,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 986
+      "community": 987
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -24345,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 987
+      "community": 988
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -24353,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 988
+      "community": 989
     },
     {
       "label": "priority-calculation.service.ts",
@@ -25233,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 989
+      "community": 990
     },
     {
       "label": "recall-probability.service.ts",
@@ -25241,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_recall_probability_service_ts",
-      "community": 116
+      "community": 117
     },
     {
       "label": "DefaultRecallProbabilityCalculator",
@@ -25249,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L12",
       "id": "recall_probability_service_defaultrecallprobabilitycalculator",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".calculateRecallProbability()",
@@ -25257,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L13",
       "id": "recall_probability_service_defaultrecallprobabilitycalculator_calculaterecallprobability",
-      "community": 116
+      "community": 117
     },
     {
       "label": "EnhancedRecallProbabilityCalculator",
@@ -25265,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L28",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".constructor()",
@@ -25273,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L29",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_constructor",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".calculateRecallProbability()",
@@ -25281,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L34",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_calculaterecallprobability",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".updateLearningEfficiency()",
@@ -25289,7 +25313,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L46",
       "id": "recall_probability_service_enhancedrecallprobabilitycalculator_updatelearningefficiency",
-      "community": 116
+      "community": 117
     },
     {
       "label": "AdaptiveRecallProbabilityCalculator",
@@ -25297,7 +25321,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L58",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".calculateRecallProbability()",
@@ -25305,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L61",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_calculaterecallprobability",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".calculatePersonalizedProbability()",
@@ -25313,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L81",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_calculatepersonalizedprobability",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".updateForgettingCurve()",
@@ -25321,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L98",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_updateforgettingcurve",
-      "community": 116
+      "community": 117
     },
     {
       "label": ".estimateForgettingCurve()",
@@ -25329,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/recall-probability.service.ts",
       "source_location": "L104",
       "id": "recall_probability_service_adaptiverecallprobabilitycalculator_estimateforgettingcurve",
-      "community": 116
+      "community": 117
     },
     {
       "label": "index.ts",
@@ -25337,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 990
+      "community": 991
     },
     {
       "label": "telemetry.types.ts",
@@ -25345,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 991
+      "community": 992
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -25353,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "openTelemetryDb()",
@@ -25361,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 672
+      "community": 673
     },
     {
       "label": "telemetry-repository.ts",
@@ -25593,7 +25617,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 992
+      "community": 993
     },
     {
       "label": "telemetry-service.ts",
@@ -25721,7 +25745,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 993
+      "community": 994
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -25729,7 +25753,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 994
+      "community": 995
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -25737,7 +25761,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 995
+      "community": 996
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -25745,7 +25769,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -25753,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 673
+      "community": 674
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -25825,7 +25849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 996
+      "community": 997
     },
     {
       "label": "llm-port.ts",
@@ -25833,7 +25857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 997
+      "community": 998
     },
     {
       "label": "persistence-port.ts",
@@ -25841,7 +25865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 998
+      "community": 999
     },
     {
       "label": "context-port.ts",
@@ -25849,7 +25873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 999
+      "community": 1000
     },
     {
       "label": "agent-types.ts",
@@ -25857,7 +25881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 1000
+      "community": 1001
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -25889,7 +25913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 1001
+      "community": 1002
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -25897,7 +25921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 1002
+      "community": 1003
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -25977,7 +26001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 1003
+      "community": 1004
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -26129,7 +26153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 1004
+      "community": 1005
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -26137,7 +26161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 1005
+      "community": 1006
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -26145,7 +26169,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 1006
+      "community": 1007
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -26153,7 +26177,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "baseCandidate()",
@@ -26161,7 +26185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 674
+      "community": 675
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -26209,7 +26233,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 1007
+      "community": 1008
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -26217,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "makeDeps()",
@@ -26225,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 675
+      "community": 676
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -26273,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -26281,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 676
+      "community": 677
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -26289,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -26297,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 677
+      "community": 678
     },
     {
       "label": "core-memory-repository.ts",
@@ -26305,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_ts",
-      "community": 1008
+      "community": 1009
     },
     {
       "label": "kg-triple-repository.ts",
@@ -26313,7 +26337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_ts",
-      "community": 1009
+      "community": 1010
     },
     {
       "label": "process-attribute-repository.ts",
@@ -26321,7 +26345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_ts",
-      "community": 1010
+      "community": 1011
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -26329,7 +26353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 1011
+      "community": 1012
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -26337,7 +26361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 1012
+      "community": 1013
     },
     {
       "label": "feedback-repository.ts",
@@ -26369,7 +26393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 1013
+      "community": 1014
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -26377,7 +26401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 1014
+      "community": 1015
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -26385,7 +26409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 1015
+      "community": 1016
     },
     {
       "label": "knowledge-vault-repository.ts",
@@ -26393,7 +26417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_ts",
-      "community": 1016
+      "community": 1017
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -26401,7 +26425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 1017
+      "community": 1018
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -26409,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "createKgTripleTable()",
@@ -26417,7 +26441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 678
+      "community": 679
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -26425,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "createProcessAttributeTable()",
@@ -26433,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 679
+      "community": 680
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -26441,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -26449,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 680
+      "community": 681
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -26457,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 1018
+      "community": 1019
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -26465,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "createCoreMemoryTable()",
@@ -26473,7 +26497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 681
+      "community": 682
     },
     {
       "label": "recall-tool-host.ts",
@@ -26481,7 +26505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 1019
+      "community": 1020
     },
     {
       "label": "recall-tool-definition.ts",
@@ -26489,7 +26513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 1020
+      "community": 1021
     },
     {
       "label": "remember-tool.ts",
@@ -26497,79 +26521,79 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
-      "community": 156
+      "community": 157
     },
     {
       "label": "RememberTool",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L135",
+      "source_location": "L134",
       "id": "remember_tool_remembertool",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L136",
+      "source_location": "L135",
       "id": "remember_tool_remembertool_constructor",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".validateReflectionNotesJson()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L249",
+      "source_location": "L248",
       "id": "remember_tool_remembertool_validatereflectionnotesjson",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".getExistingReflectionNotes()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L265",
+      "source_location": "L264",
       "id": "remember_tool_remembertool_getexistingreflectionnotes",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".parseReflectionNotes()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L319",
+      "source_location": "L318",
       "id": "remember_tool_remembertool_parsereflectionnotes",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".handle()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L369",
+      "source_location": "L368",
       "id": "remember_tool_remembertool_handle",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".findExistingProceduralMemory()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1536",
+      "source_location": "L1535",
       "id": "remember_tool_remembertool_findexistingproceduralmemory",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".getExistingMemoriesForRelationExtraction()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1609",
+      "source_location": "L1608",
       "id": "remember_tool_remembertool_getexistingmemoriesforrelationextraction",
-      "community": 156
+      "community": 157
     },
     {
       "label": ".getMemoryById()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1657",
+      "source_location": "L1655",
       "id": "remember_tool_remembertool_getmemorybyid",
-      "community": 156
+      "community": 157
     },
     {
       "label": "recall-tool-validation.ts",
@@ -26601,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "normalizeProviderFilter()",
@@ -26609,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 682
+      "community": 683
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -26825,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_convert_episodic_to_semantic_tool_ts",
-      "community": 117
+      "community": 118
     },
     {
       "label": "ConvertEpisodicToSemanticTool",
@@ -26833,7 +26857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L46",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".constructor()",
@@ -26841,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L47",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_constructor",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".handle()",
@@ -26849,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L86",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handle",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".resolveMemories()",
@@ -26857,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L158",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_resolvememories",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".fetchAlreadyConverted()",
@@ -26865,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L171",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchalreadyconverted",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".fetchSingleMemory()",
@@ -26873,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L186",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchsinglememory",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".convertSingleMemory()",
@@ -26881,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L231",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_convertsinglememory",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".handleConversionError()",
@@ -26889,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L252",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handleconversionerror",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".handleConversionSuccess()",
@@ -26897,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L298",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handleconversionsuccess",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".handleNoTriples()",
@@ -26905,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L380",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_handlenotriples",
-      "community": 117
+      "community": 118
     },
     {
       "label": ".fetchBatchMemories()",
@@ -26913,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/convert-episodic-to-semantic-tool.ts",
       "source_location": "L431",
       "id": "convert_episodic_to_semantic_tool_convertepisodictosemantictool_fetchbatchmemories",
-      "community": 117
+      "community": 118
     },
     {
       "label": "recall-tool-search-execution.ts",
@@ -26921,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -26929,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 683
+      "community": 684
     },
     {
       "label": "pin-tool.ts",
@@ -26937,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_pin_tool_ts",
-      "community": 118
+      "community": 119
     },
     {
       "label": "PinTool",
@@ -26945,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L23",
       "id": "pin_tool_pintool",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".constructor()",
@@ -26953,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L24",
       "id": "pin_tool_pintool_constructor",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".handle()",
@@ -26961,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L63",
       "id": "pin_tool_pintool_handle",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".handleSinglePin()",
@@ -26969,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L84",
       "id": "pin_tool_pintool_handlesinglepin",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".handleBatchPin()",
@@ -26977,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L144",
       "id": "pin_tool_pintool_handlebatchpin",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".getMemoryById()",
@@ -26985,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L192",
       "id": "pin_tool_pintool_getmemorybyid",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".getMemoriesByIds()",
@@ -26993,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L203",
       "id": "pin_tool_pintool_getmemoriesbyids",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".logPinAction()",
@@ -27001,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L217",
       "id": "pin_tool_pintool_logpinaction",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".handleDatabaseLock()",
@@ -27009,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L241",
       "id": "pin_tool_pintool_handledatabaselock",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".getPinnedMemories()",
@@ -27017,7 +27041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L256",
       "id": "pin_tool_pintool_getpinnedmemories",
-      "community": 118
+      "community": 119
     },
     {
       "label": ".getPinStats()",
@@ -27025,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/pin-tool.ts",
       "source_location": "L273",
       "id": "pin_tool_pintool_getpinstats",
-      "community": 118
+      "community": 119
     },
     {
       "label": "recall-tool-post-search.ts",
@@ -27097,7 +27121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_neighbors_fetch_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -27105,7 +27129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L16",
       "id": "recall_tool_neighbors_fetch_handleincludeneighbors",
-      "community": 684
+      "community": 685
     },
     {
       "label": "recall-tool-anchor-rotation.ts",
@@ -27113,7 +27137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_anchor_rotation_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -27121,7 +27145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L12",
       "id": "recall_tool_anchor_rotation_handleautosetanchor",
-      "community": 685
+      "community": 686
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -27425,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -27433,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L11",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 686
+      "community": 687
     },
     {
       "label": "recall-tool.ts",
@@ -27481,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 1021
+      "community": 1022
     },
     {
       "label": "forget-tool.ts",
@@ -27625,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "createSchema()",
@@ -27633,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 687
+      "community": 688
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -27641,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 1022
+      "community": 1023
     },
     {
       "label": "remember-tool.spec.ts",
@@ -27673,7 +27697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 1023
+      "community": 1024
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -27681,7 +27705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "createSchema()",
@@ -27689,7 +27713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 688
+      "community": 689
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -27729,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 1024
+      "community": 1025
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -27737,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 1025
+      "community": 1026
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -27745,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "initializeTestDatabase()",
@@ -27753,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 689
+      "community": 690
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -27761,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "parseData()",
@@ -27769,7 +27793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 690
+      "community": 691
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -27777,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 1026
+      "community": 1027
     },
     {
       "label": "recall-tool.spec.ts",
@@ -27809,7 +27833,23 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1027
+      "community": 1028
+    },
+    {
+      "label": "remember-tool-relation-load.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
+      "community": 692
+    },
+    {
+      "label": "initializeProductionLikeSchema()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
+      "source_location": "L10",
+      "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
+      "community": 692
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -27817,7 +27857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1028
+      "community": 1029
     },
     {
       "label": "pin-tool.spec.ts",
@@ -27825,7 +27865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1029
+      "community": 1030
     },
     {
       "label": "meta-memory-service.ts",
@@ -28073,7 +28113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "createBaseSchema()",
@@ -28081,7 +28121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L24",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 691
+      "community": 693
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -28161,7 +28201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "baseRow()",
@@ -28169,7 +28209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 692
+      "community": 694
     },
     {
       "label": "procedural-versioning.ts",
@@ -28385,7 +28425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1030
+      "community": 1031
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -28393,7 +28433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -28401,7 +28441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 693
+      "community": 695
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -28409,7 +28449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "openDb()",
@@ -28417,7 +28457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 694
+      "community": 696
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -28609,7 +28649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_ts",
-      "community": 119
+      "community": 120
     },
     {
       "label": "parseSqliteInstant()",
@@ -28617,7 +28657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L12",
       "id": "memory_review_candidate_selection_scoring_parsesqliteinstant",
-      "community": 119
+      "community": 120
     },
     {
       "label": "resolveStaleAnchor()",
@@ -28625,7 +28665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L30",
       "id": "memory_review_candidate_selection_scoring_resolvestaleanchor",
-      "community": 119
+      "community": 120
     },
     {
       "label": "computeStaleDays()",
@@ -28633,7 +28673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L45",
       "id": "memory_review_candidate_selection_scoring_computestaledays",
-      "community": 119
+      "community": 120
     },
     {
       "label": "computeStaleRatio()",
@@ -28641,7 +28681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L50",
       "id": "memory_review_candidate_selection_scoring_computestaleratio",
-      "community": 119
+      "community": 120
     },
     {
       "label": "computePriority()",
@@ -28649,7 +28689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L55",
       "id": "memory_review_candidate_selection_scoring_computepriority",
-      "community": 119
+      "community": 120
     },
     {
       "label": "isTruthyFlag()",
@@ -28657,7 +28697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L59",
       "id": "memory_review_candidate_selection_scoring_istruthyflag",
-      "community": 119
+      "community": 120
     },
     {
       "label": "isNonEmptyDeletedAt()",
@@ -28665,7 +28705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L63",
       "id": "memory_review_candidate_selection_scoring_isnonemptydeletedat",
-      "community": 119
+      "community": 120
     },
     {
       "label": "isMemoryRowActive()",
@@ -28673,7 +28713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L68",
       "id": "memory_review_candidate_selection_scoring_ismemoryrowactive",
-      "community": 119
+      "community": 120
     },
     {
       "label": "passesEligibility()",
@@ -28681,7 +28721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L75",
       "id": "memory_review_candidate_selection_scoring_passeseligibility",
-      "community": 119
+      "community": 120
     },
     {
       "label": "buildScoreBreakdown()",
@@ -28689,7 +28729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L89",
       "id": "memory_review_candidate_selection_scoring_buildscorebreakdown",
-      "community": 119
+      "community": 120
     },
     {
       "label": "buildReason()",
@@ -28697,7 +28737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.ts",
       "source_location": "L106",
       "id": "memory_review_candidate_selection_scoring_buildreason",
-      "community": 119
+      "community": 120
     },
     {
       "label": "memory-review-candidate-persistence-service.ts",
@@ -29049,7 +29089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -29057,7 +29097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 695
+      "community": 697
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -29321,7 +29361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1031
+      "community": 1032
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -29353,7 +29393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1032
+      "community": 1033
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -29361,7 +29401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1033
+      "community": 1034
     },
     {
       "label": "core-memory-service.ts",
@@ -29521,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "createBaseSchema()",
@@ -29529,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 696
+      "community": 698
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -29537,7 +29577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -29545,7 +29585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 697
+      "community": 699
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -29625,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1034
+      "community": 1035
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -29633,7 +29673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1035
+      "community": 1036
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -29641,7 +29681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "createSchema()",
@@ -29649,7 +29689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 698
+      "community": 700
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -29657,7 +29697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1036
+      "community": 1037
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -29665,7 +29705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "createSchema()",
@@ -29673,7 +29713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 699
+      "community": 701
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -29681,7 +29721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1037
+      "community": 1038
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -29689,7 +29729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "createBaseSchema()",
@@ -29697,7 +29737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 700
+      "community": 702
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -29705,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1038
+      "community": 1039
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -29713,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "createSchema()",
@@ -29721,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 701
+      "community": 703
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -29729,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1039
+      "community": 1040
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -29737,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1040
+      "community": 1041
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -29857,7 +29897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1041
+      "community": 1042
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -30121,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1042
+      "community": 1043
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -30129,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -30137,7 +30177,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 702
+      "community": 704
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -30145,7 +30185,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1043
+      "community": 1044
     },
     {
       "label": "consolidation-repository.ts",
@@ -30153,7 +30193,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_ts",
-      "community": 157
+      "community": 158
     },
     {
       "label": "ConsolidationRepository",
@@ -30161,7 +30201,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L25",
       "id": "consolidation_repository_consolidationrepository",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".constructor()",
@@ -30169,7 +30209,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L26",
       "id": "consolidation_repository_consolidationrepository_constructor",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".getLookbackDays()",
@@ -30177,7 +30217,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L28",
       "id": "consolidation_repository_consolidationrepository_getlookbackdays",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".findEpisodicCandidates()",
@@ -30185,7 +30225,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L37",
       "id": "consolidation_repository_consolidationrepository_findepisodiccandidates",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".findSemanticsByOwner()",
@@ -30193,7 +30233,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L87",
       "id": "consolidation_repository_consolidationrepository_findsemanticsbyowner",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".updateSemanticMemory()",
@@ -30201,7 +30241,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L103",
       "id": "consolidation_repository_consolidationrepository_updatesemanticmemory",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".loadEmbeddingsMap()",
@@ -30209,7 +30249,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L118",
       "id": "consolidation_repository_consolidationrepository_loadembeddingsmap",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".insertSemanticMemory()",
@@ -30217,7 +30257,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L151",
       "id": "consolidation_repository_consolidationrepository_insertsemanticmemory",
-      "community": 157
+      "community": 158
     },
     {
       "label": ".markEpisodicsConsolidated()",
@@ -30225,7 +30265,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L177",
       "id": "consolidation_repository_consolidationrepository_markepisodicsconsolidated",
-      "community": 157
+      "community": 158
     },
     {
       "label": "sleep-consolidation-service.ts",
@@ -30377,7 +30417,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "row()",
@@ -30385,7 +30425,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 703
+      "community": 705
     },
     {
       "label": "summarization-service.ts",
@@ -30481,7 +30521,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "ep()",
@@ -30489,7 +30529,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 704
+      "community": 706
     },
     {
       "label": "relation-graph.port.ts",
@@ -30497,7 +30537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1044
+      "community": 1045
     },
     {
       "label": "get-relations-tool.ts",
@@ -30537,7 +30577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -30545,7 +30585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 705
+      "community": 707
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -30801,7 +30841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1045
+      "community": 1046
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -31641,7 +31681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1046
+      "community": 1047
     },
     {
       "label": "relation-graph.spec.ts",
@@ -31673,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "createTestMemory()",
@@ -31681,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L67",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 706
+      "community": 708
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -31721,7 +31761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "createTestMemory()",
@@ -31729,7 +31769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 707
+      "community": 709
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -31793,7 +31833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1047
+      "community": 1048
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -31801,7 +31841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1048
+      "community": 1049
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -31833,7 +31873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1049
+      "community": 1050
     },
     {
       "label": "provider-openai.spec.ts",
@@ -31841,7 +31881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1050
+      "community": 1051
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -31849,7 +31889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1051
+      "community": 1052
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -31857,7 +31897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1052
+      "community": 1053
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -32177,7 +32217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "extract()",
@@ -32185,7 +32225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 708
+      "community": 710
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -32217,7 +32257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1053
+      "community": 1054
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -32401,7 +32441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1054
+      "community": 1055
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -32409,7 +32449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1055
+      "community": 1056
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -32417,7 +32457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1056
+      "community": 1057
     },
     {
       "label": "triple-extractor.ts",
@@ -32593,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1057
+      "community": 1058
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -32633,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1058
+      "community": 1059
     },
     {
       "label": "triple-parser.ts",
@@ -32681,7 +32721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "splitTextIntoChunks()",
@@ -32689,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 709
+      "community": 711
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -32697,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -32705,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 710
+      "community": 712
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -32713,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_ts",
-      "community": 158
+      "community": 159
     },
     {
       "label": "PredicateCanonicalizer",
@@ -32721,7 +32761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L95",
       "id": "predicate_canonicalizer_predicatecanonicalizer",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".constructor()",
@@ -32729,7 +32769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L99",
       "id": "predicate_canonicalizer_predicatecanonicalizer_constructor",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".buildReverseIndex()",
@@ -32737,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L107",
       "id": "predicate_canonicalizer_predicatecanonicalizer_buildreverseindex",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".normalizeKey()",
@@ -32745,7 +32785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L125",
       "id": "predicate_canonicalizer_predicatecanonicalizer_normalizekey",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".canonicalize()",
@@ -32753,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L135",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalize",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".canonicalizeBatch()",
@@ -32761,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L177",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalizebatch",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".addPredicate()",
@@ -32769,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L187",
       "id": "predicate_canonicalizer_predicatecanonicalizer_addpredicate",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".getDictionary()",
@@ -32777,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L206",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getdictionary",
-      "community": 158
+      "community": 159
     },
     {
       "label": ".getCanonicalPredicates()",
@@ -32785,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L213",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getcanonicalpredicates",
-      "community": 158
+      "community": 159
     },
     {
       "label": "entity-linker.spec.ts",
@@ -32793,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1059
+      "community": 1060
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -32801,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1060
+      "community": 1061
     },
     {
       "label": "interfaces.spec.ts",
@@ -32809,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1061
+      "community": 1062
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -32817,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1062
+      "community": 1063
     },
     {
       "label": "triple-parser.spec.ts",
@@ -32825,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1063
+      "community": 1064
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -32833,7 +32873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -32841,7 +32881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 711
+      "community": 713
     },
     {
       "label": "extract-relations-openai.ts",
@@ -32849,7 +32889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -32857,7 +32897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 712
+      "community": 714
     },
     {
       "label": "types.ts",
@@ -32865,7 +32905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1064
+      "community": 1065
     },
     {
       "label": "ollama-chat-support.ts",
@@ -32905,7 +32945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -32913,7 +32953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 713
+      "community": 715
     },
     {
       "label": "provider-selection.ts",
@@ -32945,7 +32985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -32953,7 +32993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 714
+      "community": 716
     },
     {
       "label": "llm-response-parse.ts",
@@ -33001,7 +33041,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1065
+      "community": 1066
     },
     {
       "label": "agent-integration-repository.ts",
@@ -33009,7 +33049,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1066
+      "community": 1067
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -33041,7 +33081,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1067
+      "community": 1068
     },
     {
       "label": "agent-integration-error.ts",
@@ -33073,7 +33113,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1068
+      "community": 1069
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -33561,7 +33601,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_provenance_graph_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "buildProvenanceTrace()",
@@ -33569,7 +33609,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L10",
       "id": "agent_provenance_graph_buildprovenancetrace",
-      "community": 715
+      "community": 717
     },
     {
       "label": "agent-context-injection-service.spec.ts",
@@ -33577,7 +33617,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1069
+      "community": 1070
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -33585,7 +33625,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_ts",
-      "community": 159
+      "community": 160
     },
     {
       "label": "SqliteHybridAgentContextSource",
@@ -33593,7 +33633,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L20",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".constructor()",
@@ -33601,7 +33641,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L25",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_constructor",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".recall()",
@@ -33609,7 +33649,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L30",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_recall",
-      "community": 159
+      "community": 160
     },
     {
       "label": ".loadMemoryRows()",
@@ -33617,7 +33657,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L94",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_loadmemoryrows",
-      "community": 159
+      "community": 160
     },
     {
       "label": "scopeSearchFilters()",
@@ -33625,7 +33665,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L125",
       "id": "sqlite_hybrid_agent_context_source_scopesearchfilters",
-      "community": 159
+      "community": 160
     },
     {
       "label": "asMemoryType()",
@@ -33633,7 +33673,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L151",
       "id": "sqlite_hybrid_agent_context_source_asmemorytype",
-      "community": 159
+      "community": 160
     },
     {
       "label": "asPrivacyScope()",
@@ -33641,7 +33681,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L160",
       "id": "sqlite_hybrid_agent_context_source_asprivacyscope",
-      "community": 159
+      "community": 160
     },
     {
       "label": "clampConfidence()",
@@ -33649,7 +33689,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L166",
       "id": "sqlite_hybrid_agent_context_source_clampconfidence",
-      "community": 159
+      "community": 160
     },
     {
       "label": "parseTags()",
@@ -33657,7 +33697,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L173",
       "id": "sqlite_hybrid_agent_context_source_parsetags",
-      "community": 159
+      "community": 160
     },
     {
       "label": "agent-memory-promotion-service.spec.ts",
@@ -33689,7 +33729,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_capture_transaction_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "executeAgentCaptureTransaction()",
@@ -33697,7 +33737,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L21",
       "id": "agent_capture_transaction_executeagentcapturetransaction",
-      "community": 716
+      "community": 718
     },
     {
       "label": "agent-lifecycle-service.ts",
@@ -34105,7 +34145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1070
+      "community": 1071
     },
     {
       "label": "embedding-service.ts",
@@ -35217,7 +35257,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1071
+      "community": 1072
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -35225,7 +35265,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1072
+      "community": 1073
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -35257,7 +35297,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_service_spec_ts",
-      "community": 1073
+      "community": 1074
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -35265,7 +35305,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1074
+      "community": 1075
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -35273,7 +35313,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1075
+      "community": 1076
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -35393,7 +35433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "executeResolveError()",
@@ -35401,7 +35441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 717
+      "community": 719
     },
     {
       "label": "error-stats.ts",
@@ -35409,7 +35449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "executeErrorStats()",
@@ -35417,7 +35457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 718
+      "community": 720
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -35425,7 +35465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1076
+      "community": 1077
     },
     {
       "label": "resolve-error.spec.ts",
@@ -35433,7 +35473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1077
+      "community": 1078
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -35441,7 +35481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "createBaseSchema()",
@@ -35449,7 +35489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 719
+      "community": 721
     },
     {
       "label": "error-stats.spec.ts",
@@ -35457,7 +35497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1078
+      "community": 1079
     },
     {
       "label": "performance-monitor.ts",
@@ -35471,7 +35511,7 @@
       "label": "PerformanceMonitor",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L59",
+      "source_location": "L60",
       "id": "performance_monitor_performancemonitor",
       "community": 3
     },
@@ -35479,7 +35519,7 @@
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L75",
+      "source_location": "L78",
       "id": "performance_monitor_performancemonitor_constructor",
       "community": 3
     },
@@ -35487,7 +35527,7 @@
       "label": ".getMemoryPressureDenominatorBytes()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L90",
+      "source_location": "L94",
       "id": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
       "community": 3
     },
@@ -35495,7 +35535,7 @@
       "label": ".memoryRatioToPercent()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L105",
+      "source_location": "L109",
       "id": "performance_monitor_performancemonitor_memoryratiotopercent",
       "community": 3
     },
@@ -35503,7 +35543,7 @@
       "label": ".initialize()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L116",
+      "source_location": "L120",
       "id": "performance_monitor_performancemonitor_initialize",
       "community": 3
     },
@@ -35511,7 +35551,7 @@
       "label": ".setDatabase()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L132",
+      "source_location": "L136",
       "id": "performance_monitor_performancemonitor_setdatabase",
       "community": 3
     },
@@ -35519,7 +35559,7 @@
       "label": ".collectMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L142",
+      "source_location": "L146",
       "id": "performance_monitor_performancemonitor_collectmetrics",
       "community": 3
     },
@@ -35527,7 +35567,7 @@
       "label": ".checkAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L209",
+      "source_location": "L213",
       "id": "performance_monitor_performancemonitor_checkalerts",
       "community": 3
     },
@@ -35535,7 +35575,7 @@
       "label": ".addToHistory()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L350",
+      "source_location": "L375",
       "id": "performance_monitor_performancemonitor_addtohistory",
       "community": 3
     },
@@ -35543,7 +35583,7 @@
       "label": ".resolveAlert()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L363",
+      "source_location": "L388",
       "id": "performance_monitor_performancemonitor_resolvealert",
       "community": 3
     },
@@ -35551,7 +35591,7 @@
       "label": ".getMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L377",
+      "source_location": "L402",
       "id": "performance_monitor_performancemonitor_getmetrics",
       "community": 3
     },
@@ -35559,7 +35599,7 @@
       "label": ".getMetricsHistory()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L384",
+      "source_location": "L409",
       "id": "performance_monitor_performancemonitor_getmetricshistory",
       "community": 3
     },
@@ -35567,7 +35607,7 @@
       "label": ".getAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L394",
+      "source_location": "L419",
       "id": "performance_monitor_performancemonitor_getalerts",
       "community": 3
     },
@@ -35575,7 +35615,7 @@
       "label": ".getActiveAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L398",
+      "source_location": "L423",
       "id": "performance_monitor_performancemonitor_getactivealerts",
       "community": 3
     },
@@ -35583,7 +35623,7 @@
       "label": ".getAllAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L402",
+      "source_location": "L427",
       "id": "performance_monitor_performancemonitor_getallalerts",
       "community": 3
     },
@@ -35591,7 +35631,7 @@
       "label": ".clearAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L410",
+      "source_location": "L435",
       "id": "performance_monitor_performancemonitor_clearalerts",
       "community": 3
     },
@@ -35599,7 +35639,7 @@
       "label": ".getPerformanceReport()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L417",
+      "source_location": "L443",
       "id": "performance_monitor_performancemonitor_getperformancereport",
       "community": 3
     },
@@ -35607,7 +35647,7 @@
       "label": ".generateRecommendations()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L451",
+      "source_location": "L477",
       "id": "performance_monitor_performancemonitor_generaterecommendations",
       "community": 3
     },
@@ -35615,7 +35655,7 @@
       "label": ".startMonitoring()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L480",
+      "source_location": "L506",
       "id": "performance_monitor_performancemonitor_startmonitoring",
       "community": 3
     },
@@ -35623,7 +35663,7 @@
       "label": ".stopMonitoring()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L497",
+      "source_location": "L523",
       "id": "performance_monitor_performancemonitor_stopmonitoring",
       "community": 3
     },
@@ -35631,7 +35671,7 @@
       "label": ".isMonitoring()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L507",
+      "source_location": "L533",
       "id": "performance_monitor_performancemonitor_ismonitoring",
       "community": 3
     },
@@ -35639,7 +35679,7 @@
       "label": ".recordSearch()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L514",
+      "source_location": "L540",
       "id": "performance_monitor_performancemonitor_recordsearch",
       "community": 3
     },
@@ -35647,7 +35687,7 @@
       "label": ".getSearchMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L547",
+      "source_location": "L573",
       "id": "performance_monitor_performancemonitor_getsearchmetrics",
       "community": 3
     },
@@ -35655,7 +35695,7 @@
       "label": ".getMemoryMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L585",
+      "source_location": "L611",
       "id": "performance_monitor_performancemonitor_getmemorymetrics",
       "community": 3
     },
@@ -35663,7 +35703,7 @@
       "label": ".getSystemMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L619",
+      "source_location": "L645",
       "id": "performance_monitor_performancemonitor_getsystemmetrics",
       "community": 3
     },
@@ -35671,7 +35711,7 @@
       "label": ".getDatabaseMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L638",
+      "source_location": "L664",
       "id": "performance_monitor_performancemonitor_getdatabasemetrics",
       "community": 3
     },
@@ -35679,7 +35719,7 @@
       "label": ".resetStats()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L694",
+      "source_location": "L720",
       "id": "performance_monitor_performancemonitor_resetstats",
       "community": 3
     },
@@ -35687,7 +35727,7 @@
       "label": ".isHealthy()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L709",
+      "source_location": "L735",
       "id": "performance_monitor_performancemonitor_ishealthy",
       "community": 3
     },
@@ -35695,7 +35735,7 @@
       "label": ".exportMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L721",
+      "source_location": "L747",
       "id": "performance_monitor_performancemonitor_exportmetrics",
       "community": 3
     },
@@ -35703,7 +35743,7 @@
       "label": ".importMetrics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L740",
+      "source_location": "L766",
       "id": "performance_monitor_performancemonitor_importmetrics",
       "community": 3
     },
@@ -35711,7 +35751,7 @@
       "label": ".getPerformanceSummary()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L792",
+      "source_location": "L818",
       "id": "performance_monitor_performancemonitor_getperformancesummary",
       "community": 3
     },
@@ -35719,7 +35759,7 @@
       "label": ".getMetricsAnalytics()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L822",
+      "source_location": "L848",
       "id": "performance_monitor_performancemonitor_getmetricsanalytics",
       "community": 3
     },
@@ -35727,7 +35767,7 @@
       "label": ".analyzeTrend()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L928",
+      "source_location": "L954",
       "id": "performance_monitor_performancemonitor_analyzetrend",
       "community": 3
     },
@@ -35735,7 +35775,7 @@
       "label": ".updateThresholds()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L946",
+      "source_location": "L972",
       "id": "performance_monitor_performancemonitor_updatethresholds",
       "community": 3
     },
@@ -35743,7 +35783,7 @@
       "label": ".formatBytes()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L954",
+      "source_location": "L980",
       "id": "performance_monitor_performancemonitor_formatbytes",
       "community": 3
     },
@@ -35751,7 +35791,7 @@
       "label": ".calculateCpuUsage()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L972",
+      "source_location": "L998",
       "id": "performance_monitor_performancemonitor_calculatecpuusage",
       "community": 3
     },
@@ -35759,7 +35799,7 @@
       "label": ".handleCriticalAlert()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1014",
+      "source_location": "L1040",
       "id": "performance_monitor_performancemonitor_handlecriticalalert",
       "community": 3
     },
@@ -35767,7 +35807,7 @@
       "label": ".optimizeDatabase()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1053",
+      "source_location": "L1079",
       "id": "performance_monitor_performancemonitor_optimizedatabase",
       "community": 3
     },
@@ -35775,7 +35815,7 @@
       "label": ".getAlertStats()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1078",
+      "source_location": "L1104",
       "id": "performance_monitor_performancemonitor_getalertstats",
       "community": 3
     },
@@ -35783,7 +35823,7 @@
       "label": ".cleanupOldAlerts()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1117",
+      "source_location": "L1143",
       "id": "performance_monitor_performancemonitor_cleanupoldalerts",
       "community": 3
     },
@@ -35791,7 +35831,7 @@
       "label": ".recordMetric()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1136",
+      "source_location": "L1162",
       "id": "performance_monitor_performancemonitor_recordmetric",
       "community": 3
     },
@@ -35799,7 +35839,7 @@
       "label": ".incrementCounter()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1145",
+      "source_location": "L1171",
       "id": "performance_monitor_performancemonitor_incrementcounter",
       "community": 3
     },
@@ -35807,7 +35847,7 @@
       "label": ".log()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1154",
+      "source_location": "L1180",
       "id": "performance_monitor_performancemonitor_log",
       "community": 3
     },
@@ -35815,7 +35855,7 @@
       "label": "getPerformanceMonitor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1162",
+      "source_location": "L1188",
       "id": "performance_monitor_getperformancemonitor",
       "community": 3
     },
@@ -35823,7 +35863,7 @@
       "label": "createPerformanceMonitor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1169",
+      "source_location": "L1195",
       "id": "performance_monitor_createperformancemonitor",
       "community": 3
     },
@@ -36359,7 +36399,7 @@
       "label": ".cleanup()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
-      "source_location": "L387",
+      "source_location": "L392",
       "id": "error_logging_service_errorloggingservice_cleanup",
       "community": 87
     },
@@ -36369,7 +36409,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1079
+      "community": 1080
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -36377,7 +36417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1080
+      "community": 1081
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -36385,7 +36425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1081
+      "community": 1082
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -36393,7 +36433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1082
+      "community": 1083
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -36441,7 +36481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "restoreEnvValue()",
@@ -36449,7 +36489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 720
+      "community": 722
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -36553,7 +36593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -36561,7 +36601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 721
+      "community": 723
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -36641,7 +36681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -36649,7 +36689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 722
+      "community": 724
     },
     {
       "label": "quality-reporter.ts",
@@ -36657,7 +36697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_ts",
-      "community": 160
+      "community": 161
     },
     {
       "label": "escapeHtml()",
@@ -36665,7 +36705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L24",
       "id": "quality_reporter_escapehtml",
-      "community": 160
+      "community": 161
     },
     {
       "label": "QualityReporter",
@@ -36673,7 +36713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L175",
       "id": "quality_reporter_qualityreporter",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".constructor()",
@@ -36681,7 +36721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L179",
       "id": "quality_reporter_qualityreporter_constructor",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".collectReportData()",
@@ -36689,7 +36729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L193",
       "id": "quality_reporter_qualityreporter_collectreportdata",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".generateMarkdownReport()",
@@ -36697,7 +36737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L354",
       "id": "quality_reporter_qualityreporter_generatemarkdownreport",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".generateJsonReport()",
@@ -36705,7 +36745,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L435",
       "id": "quality_reporter_qualityreporter_generatejsonreport",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".generateHtmlReport()",
@@ -36713,7 +36753,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L445",
       "id": "quality_reporter_qualityreporter_generatehtmlreport",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".generateReport()",
@@ -36721,7 +36761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L731",
       "id": "quality_reporter_qualityreporter_generatereport",
-      "community": 160
+      "community": 161
     },
     {
       "label": ".saveReportToFile()",
@@ -36729,7 +36769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L765",
       "id": "quality_reporter_qualityreporter_savereporttofile",
-      "community": 160
+      "community": 161
     },
     {
       "label": "quality-reporter.spec.ts",
@@ -36769,7 +36809,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1083
+      "community": 1084
     },
     {
       "label": "quality-assurance-service.ts",
@@ -37265,7 +37305,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1084
+      "community": 1085
     },
     {
       "label": "base-tool.ts",
@@ -37561,7 +37601,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 723
+      "community": 725
     },
     {
       "label": "testBootstrapIntegration()",
@@ -37569,7 +37609,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 723
+      "community": 725
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -37577,7 +37617,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "measureRecall()",
@@ -37585,7 +37625,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 724
+      "community": 726
     },
     {
       "label": "test-embedding.ts",
@@ -37593,7 +37633,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -37601,7 +37641,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 725
+      "community": 727
     },
     {
       "label": "test-tool-consistency.ts",
@@ -37697,7 +37737,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "testSearchFunctionality()",
@@ -37705,7 +37745,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 726
+      "community": 728
     },
     {
       "label": "test-forgetting.ts",
@@ -37713,7 +37753,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "testForgettingFunctionality()",
@@ -37721,7 +37761,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 727
+      "community": 729
     },
     {
       "label": "mock-database.spec.ts",
@@ -37729,7 +37769,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1085
+      "community": 1086
     },
     {
       "label": "test-m1-completion.ts",
@@ -37737,7 +37777,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "testM1Completion()",
@@ -37745,7 +37785,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 728
+      "community": 730
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -37753,7 +37793,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -37761,7 +37801,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 729
+      "community": 731
     },
     {
       "label": "vitest.setup.ts",
@@ -37769,7 +37809,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1086
+      "community": 1087
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -37777,7 +37817,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "parseItems()",
@@ -37785,7 +37825,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 730
+      "community": 732
     },
     {
       "label": "test-memory-resource.ts",
@@ -37817,7 +37857,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "testRegression()",
@@ -37825,7 +37865,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 731
+      "community": 733
     },
     {
       "label": "test-anchor-system.ts",
@@ -37889,7 +37929,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1087
+      "community": 1088
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -37961,7 +38001,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 732
+      "community": 734
     },
     {
       "label": "testSingleProviderRegression()",
@@ -37969,7 +38009,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 732
+      "community": 734
     },
     {
       "label": "visualize-recency.ts",
@@ -38033,7 +38073,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1088
+      "community": 1089
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -38097,7 +38137,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "constructor()",
@@ -38105,7 +38145,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 733
+      "community": 735
     },
     {
       "label": "mock-database.ts",
@@ -38337,7 +38377,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1089
+      "community": 1090
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -38377,7 +38417,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "createTestMemories()",
@@ -38385,7 +38425,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L291",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 734
+      "community": 736
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -38393,7 +38433,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -38401,7 +38441,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 735
+      "community": 737
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -38409,7 +38449,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1090
+      "community": 1091
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -38417,7 +38457,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "seedCluster()",
@@ -38425,7 +38465,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 736
+      "community": 738
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -38489,7 +38529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "writeFixtureDir()",
@@ -38497,7 +38537,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 737
+      "community": 739
     },
     {
       "label": "search-quality-metrics.ts",
@@ -38593,7 +38633,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1091
+      "community": 1092
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -38689,7 +38729,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1092
+      "community": 1093
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -38697,7 +38737,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1093
+      "community": 1094
     },
     {
       "label": "test-database.ts",
@@ -38729,7 +38769,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "mergeCandidateIds()",
@@ -38737,7 +38777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 738
+      "community": 740
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -38769,7 +38809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1094
+      "community": 1095
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -38777,7 +38817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1095
+      "community": 1096
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -38977,7 +39017,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1096
+      "community": 1097
     },
     {
       "label": "query-counter.ts",
@@ -39377,7 +39417,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 739
+      "community": 741
     },
     {
       "label": "copyDir()",
@@ -39385,7 +39425,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 739
+      "community": 741
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -39393,7 +39433,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "readRootPackageJson()",
@@ -39401,7 +39441,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 740
+      "community": 742
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -39409,7 +39449,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "readJson()",
@@ -39417,7 +39457,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 741
+      "community": 743
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -39425,7 +39465,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "readWorkflow()",
@@ -39433,7 +39473,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 742
+      "community": 744
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -39497,7 +39537,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "readStaticFile()",
@@ -39505,7 +39545,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 743
+      "community": 745
     },
     {
       "label": "agent-sessions.e2e.ts",
@@ -39513,7 +39553,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_e2e_ts",
-      "community": 1097
+      "community": 1098
     },
     {
       "label": "agent-sessions.fixtures.ts",
@@ -39577,7 +39617,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "extractFencedBlocks()",
@@ -39585,7 +39625,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 744
+      "community": 746
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -39689,7 +39729,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L1",
       "id": "scripts_check_magic_numbers_ts",
-      "community": 161
+      "community": 162
     },
     {
       "label": "isCoreModule()",
@@ -39697,7 +39737,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L73",
       "id": "check_magic_numbers_iscoremodule",
-      "community": 161
+      "community": 162
     },
     {
       "label": "isExcluded()",
@@ -39705,7 +39745,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L77",
       "id": "check_magic_numbers_isexcluded",
-      "community": 161
+      "community": 162
     },
     {
       "label": "findMagicNumbers()",
@@ -39713,7 +39753,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L82",
       "id": "check_magic_numbers_findmagicnumbers",
-      "community": 161
+      "community": 162
     },
     {
       "label": "getAllTsFiles()",
@@ -39721,7 +39761,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L130",
       "id": "check_magic_numbers_getalltsfiles",
-      "community": 161
+      "community": 162
     },
     {
       "label": "countMagicNumbers()",
@@ -39729,7 +39769,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L161",
       "id": "check_magic_numbers_countmagicnumbers",
-      "community": 161
+      "community": 162
     },
     {
       "label": "printResultsJSON()",
@@ -39737,7 +39777,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L195",
       "id": "check_magic_numbers_printresultsjson",
-      "community": 161
+      "community": 162
     },
     {
       "label": "printResultsCSV()",
@@ -39745,7 +39785,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L214",
       "id": "check_magic_numbers_printresultscsv",
-      "community": 161
+      "community": 162
     },
     {
       "label": "printResultsText()",
@@ -39753,7 +39793,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L222",
       "id": "check_magic_numbers_printresultstext",
-      "community": 161
+      "community": 162
     },
     {
       "label": "main()",
@@ -39761,7 +39801,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L233",
       "id": "check_magic_numbers_main",
-      "community": 161
+      "community": 162
     },
     {
       "label": "prepack-bundle-core.js",
@@ -39769,7 +39809,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 745
+      "community": 747
     },
     {
       "label": "shouldInclude()",
@@ -39777,7 +39817,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 745
+      "community": 747
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -39865,7 +39905,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 746
+      "community": 748
     },
     {
       "label": "fixMigration()",
@@ -39873,7 +39913,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 746
+      "community": 748
     },
     {
       "label": "sync-root-server-dist.js",
@@ -39881,7 +39921,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1098
+      "community": 1099
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -40673,7 +40713,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 747
+      "community": 749
     },
     {
       "label": "updateEmbeddings()",
@@ -40681,7 +40721,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 747
+      "community": 749
     },
     {
       "label": "agent-smoke-matrix.spec.ts",
@@ -40873,7 +40913,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "analyzeEmbeddings()",
@@ -40881,7 +40921,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 748
+      "community": 750
     },
     {
       "label": "test-docker.js",
@@ -40889,7 +40929,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 749
+      "community": 751
     },
     {
       "label": "testDockerServer()",
@@ -40897,7 +40937,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L8",
       "id": "test_docker_testdockerserver",
-      "community": 749
+      "community": 751
     },
     {
       "label": "pack-with-restore.js",
@@ -40905,7 +40945,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1099
+      "community": 1100
     },
     {
       "label": "run-migration.js",
@@ -40913,7 +40953,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 750
+      "community": 752
     },
     {
       "label": "runMigration()",
@@ -40921,7 +40961,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 750
+      "community": 752
     },
     {
       "label": "safe-migration.js",
@@ -40929,7 +40969,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 751
+      "community": 753
     },
     {
       "label": "safeMigration()",
@@ -40937,7 +40977,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 751
+      "community": 753
     },
     {
       "label": "generate-ground-truth.ts",
@@ -41001,7 +41041,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "saveWorkMemory()",
@@ -41009,7 +41049,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 752
+      "community": 754
     },
     {
       "label": "check-file-sizes.ts",
@@ -41249,7 +41289,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1100
+      "community": 1101
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -41257,7 +41297,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "main()",
@@ -41265,7 +41305,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 753
+      "community": 755
     },
     {
       "label": "agent-integration-release-gate.spec.ts",
@@ -41337,7 +41377,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1101
+      "community": 1102
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -41345,7 +41385,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1102
+      "community": 1103
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -41393,7 +41433,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 754
+      "community": 756
     },
     {
       "label": "analyzeEmbeddings()",
@@ -41401,7 +41441,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 754
+      "community": 756
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -41409,7 +41449,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 755
+      "community": 757
     },
     {
       "label": "fixVectorDimensions()",
@@ -41417,7 +41457,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 755
+      "community": 757
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -41481,7 +41521,7 @@
       "source_file": "scripts/longmemeval-validation.spec.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_spec_ts",
-      "community": 1103
+      "community": 1104
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -41489,7 +41529,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "runUpdateMigration()",
@@ -41497,7 +41537,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 756
+      "community": 758
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -41529,7 +41569,7 @@
       "source_file": "scripts/acquire-longmemeval.spec.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_spec_ts",
-      "community": 1104
+      "community": 1105
     },
     {
       "label": "regenerate-embeddings.js",
@@ -41537,7 +41577,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 757
+      "community": 759
     },
     {
       "label": "regenerateEmbeddings()",
@@ -41545,7 +41585,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 757
+      "community": 759
     },
     {
       "label": "generate-relation-report.ts",
@@ -41617,7 +41657,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L1",
       "id": "scripts_check_sql_injection_ts",
-      "community": 162
+      "community": 163
     },
     {
       "label": "parseArgs()",
@@ -41625,7 +41665,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L56",
       "id": "check_sql_injection_parseargs",
-      "community": 162
+      "community": 163
     },
     {
       "label": "printHelp()",
@@ -41633,7 +41673,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L87",
       "id": "check_sql_injection_printhelp",
-      "community": 162
+      "community": 163
     },
     {
       "label": "matchesPattern()",
@@ -41641,7 +41681,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L110",
       "id": "check_sql_injection_matchespattern",
-      "community": 162
+      "community": 163
     },
     {
       "label": "shouldExclude()",
@@ -41649,7 +41689,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L129",
       "id": "check_sql_injection_shouldexclude",
-      "community": 162
+      "community": 163
     },
     {
       "label": "findFiles()",
@@ -41657,7 +41697,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L141",
       "id": "check_sql_injection_findfiles",
-      "community": 162
+      "community": 163
     },
     {
       "label": "findSqlInjectionPatterns()",
@@ -41665,7 +41705,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L179",
       "id": "check_sql_injection_findsqlinjectionpatterns",
-      "community": 162
+      "community": 163
     },
     {
       "label": "checkSqlInjection()",
@@ -41673,7 +41713,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L453",
       "id": "check_sql_injection_checksqlinjection",
-      "community": 162
+      "community": 163
     },
     {
       "label": "printResults()",
@@ -41681,7 +41721,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L483",
       "id": "check_sql_injection_printresults",
-      "community": 162
+      "community": 163
     },
     {
       "label": "main()",
@@ -41689,7 +41729,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L542",
       "id": "check_sql_injection_main",
-      "community": 162
+      "community": 163
     },
     {
       "label": "quality-benchmark-category-report.spec.ts",
@@ -41697,7 +41737,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "sampleReport()",
@@ -41705,7 +41745,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 758
+      "community": 760
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -41713,7 +41753,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1105
+      "community": 1106
     },
     {
       "label": "debug-embeddings.js",
@@ -41721,7 +41761,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 759
+      "community": 761
     },
     {
       "label": "debugEmbeddings()",
@@ -41729,7 +41769,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 759
+      "community": 761
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -41737,7 +41777,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1106
+      "community": 1107
     },
     {
       "label": "longmemeval-validation.ts",
@@ -41745,7 +41785,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_ts",
-      "community": 120
+      "community": 121
     },
     {
       "label": "aggregateJudgeResults()",
@@ -41753,7 +41793,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L41",
       "id": "longmemeval_validation_aggregatejudgeresults",
-      "community": 120
+      "community": 121
     },
     {
       "label": "runLongMemEvalValidation()",
@@ -41761,7 +41801,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L73",
       "id": "longmemeval_validation_runlongmemevalvalidation",
-      "community": 120
+      "community": 121
     },
     {
       "label": "assertJudgeResults()",
@@ -41769,7 +41809,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L152",
       "id": "longmemeval_validation_assertjudgeresults",
-      "community": 120
+      "community": 121
     },
     {
       "label": "createManifest()",
@@ -41777,7 +41817,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L186",
       "id": "longmemeval_validation_createmanifest",
-      "community": 120
+      "community": 121
     },
     {
       "label": "graphRrfStatus()",
@@ -41785,7 +41825,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L216",
       "id": "longmemeval_validation_graphrrfstatus",
-      "community": 120
+      "community": 121
     },
     {
       "label": "writeArtifacts()",
@@ -41793,7 +41833,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L223",
       "id": "longmemeval_validation_writeartifacts",
-      "community": 120
+      "community": 121
     },
     {
       "label": "readJsonLines()",
@@ -41801,7 +41841,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L255",
       "id": "longmemeval_validation_readjsonlines",
-      "community": 120
+      "community": 121
     },
     {
       "label": "writeJson()",
@@ -41809,7 +41849,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L263",
       "id": "longmemeval_validation_writejson",
-      "community": 120
+      "community": 121
     },
     {
       "label": "sha256()",
@@ -41817,7 +41857,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L267",
       "id": "longmemeval_validation_sha256",
-      "community": 120
+      "community": 121
     },
     {
       "label": "parseCli()",
@@ -41825,7 +41865,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L271",
       "id": "longmemeval_validation_parsecli",
-      "community": 120
+      "community": 121
     },
     {
       "label": "main()",
@@ -41833,7 +41873,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L292",
       "id": "longmemeval_validation_main",
-      "community": 120
+      "community": 121
     },
     {
       "label": "tune-weights.ts",
@@ -42361,7 +42401,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 760
+      "community": 762
     },
     {
       "label": "backupEmbeddings()",
@@ -42369,7 +42409,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 760
+      "community": 762
     },
     {
       "label": "count-any-types.ts",
@@ -42377,7 +42417,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L1",
       "id": "scripts_count_any_types_ts",
-      "community": 163
+      "community": 164
     },
     {
       "label": "parseArgs()",
@@ -42385,7 +42425,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L56",
       "id": "count_any_types_parseargs",
-      "community": 163
+      "community": 164
     },
     {
       "label": "printHelp()",
@@ -42393,7 +42433,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L92",
       "id": "count_any_types_printhelp",
-      "community": 163
+      "community": 164
     },
     {
       "label": "matchesPattern()",
@@ -42401,7 +42441,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L118",
       "id": "count_any_types_matchespattern",
-      "community": 163
+      "community": 164
     },
     {
       "label": "shouldExclude()",
@@ -42409,7 +42449,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L137",
       "id": "count_any_types_shouldexclude",
-      "community": 163
+      "community": 164
     },
     {
       "label": "findFiles()",
@@ -42417,7 +42457,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L149",
       "id": "count_any_types_findfiles",
-      "community": 163
+      "community": 164
     },
     {
       "label": "findAnyTypes()",
@@ -42425,7 +42465,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L186",
       "id": "count_any_types_findanytypes",
-      "community": 163
+      "community": 164
     },
     {
       "label": "countAnyTypes()",
@@ -42433,7 +42473,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L251",
       "id": "count_any_types_countanytypes",
-      "community": 163
+      "community": 164
     },
     {
       "label": "printResults()",
@@ -42441,7 +42481,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L278",
       "id": "count_any_types_printresults",
-      "community": 163
+      "community": 164
     },
     {
       "label": "main()",
@@ -42449,7 +42489,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L318",
       "id": "count_any_types_main",
-      "community": 163
+      "community": 164
     },
     {
       "label": "count-console-logs.ts",
@@ -42585,7 +42625,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "makeRng()",
@@ -42593,7 +42633,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 761
+      "community": 763
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -42601,7 +42641,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1107
+      "community": 1108
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -42609,7 +42649,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1108
+      "community": 1109
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -42617,7 +42657,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1109
+      "community": 1110
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -42625,7 +42665,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "jsonEmbedding()",
@@ -42633,7 +42673,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 762
+      "community": 764
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -42641,7 +42681,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1110
+      "community": 1111
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -42649,7 +42689,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1111
+      "community": 1112
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -42657,7 +42697,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1112
+      "community": 1113
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -42665,7 +42705,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -42673,7 +42713,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 763
+      "community": 765
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -42681,7 +42721,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1113
+      "community": 1114
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -42689,7 +42729,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "jsonEmbedding()",
@@ -42697,7 +42737,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 764
+      "community": 766
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -42705,7 +42745,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "main()",
@@ -42713,7 +42753,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 765
+      "community": 767
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -42721,7 +42761,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -42729,7 +42769,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 766
+      "community": 768
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -42761,7 +42801,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1114
+      "community": 1115
     },
     {
       "label": "check-retry-usage.ts",
@@ -42881,7 +42921,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -42889,7 +42929,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 767
+      "community": 769
     },
     {
       "label": "check-no-console-violations.ts",
@@ -42985,7 +43025,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "fixVecTableDimensions()",
@@ -42993,7 +43033,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 768
+      "community": 770
     },
     {
       "label": "sources.ts",
@@ -43001,7 +43041,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 164
+      "community": 165
     },
     {
       "label": "splitJsonlLines()",
@@ -43009,7 +43049,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L17",
       "id": "sources_splitjsonllines",
-      "community": 164
+      "community": 165
     },
     {
       "label": "cursorKey()",
@@ -43017,7 +43057,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L32",
       "id": "sources_cursorkey",
-      "community": 164
+      "community": 165
     },
     {
       "label": "findLastNewlineBefore()",
@@ -43025,7 +43065,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L36",
       "id": "sources_findlastnewlinebefore",
-      "community": 164
+      "community": 165
     },
     {
       "label": "readStreamLines()",
@@ -43033,7 +43073,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L56",
       "id": "sources_readstreamlines",
-      "community": 164
+      "community": 165
     },
     {
       "label": "readIncrementalJsonlLines()",
@@ -43041,7 +43081,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L113",
       "id": "sources_readincrementaljsonllines",
-      "community": 164
+      "community": 165
     },
     {
       "label": "runDocker()",
@@ -43049,7 +43089,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L148",
       "id": "sources_rundocker",
-      "community": 164
+      "community": 165
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -43057,7 +43097,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L168",
       "id": "sources_resolvedockerlogsref",
-      "community": 164
+      "community": 165
     },
     {
       "label": "readDockerLogs()",
@@ -43065,7 +43105,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L215",
       "id": "sources_readdockerlogs",
-      "community": 164
+      "community": 165
     },
     {
       "label": "readJsonlFiles()",
@@ -43073,7 +43113,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L244",
       "id": "sources_readjsonlfiles",
-      "community": 164
+      "community": 165
     },
     {
       "label": "types.ts",
@@ -43081,7 +43121,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1115
+      "community": 1116
     },
     {
       "label": "issue-body.ts",
@@ -43233,7 +43273,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -43241,7 +43281,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 769
+      "community": 771
     },
     {
       "label": "state-store.ts",
@@ -43521,7 +43561,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1116
+      "community": 1117
     },
     {
       "label": "issue-body.spec.ts",
@@ -43529,7 +43569,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1117
+      "community": 1118
     },
     {
       "label": "github-client.spec.ts",
@@ -43537,7 +43577,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1118
+      "community": 1119
     },
     {
       "label": "config.spec.ts",
@@ -43545,7 +43585,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1119
+      "community": 1120
     },
     {
       "label": "detectors.spec.ts",
@@ -43553,7 +43593,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1120
+      "community": 1121
     },
     {
       "label": "sources.spec.ts",
@@ -43561,7 +43601,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1121
+      "community": 1122
     },
     {
       "label": "parsers.spec.ts",
@@ -43569,7 +43609,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1122
+      "community": 1123
     },
     {
       "label": "monitor.spec.ts",
@@ -43577,7 +43617,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "config()",
@@ -43585,7 +43625,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 770
+      "community": 772
     },
     {
       "label": "fingerprint.spec.ts",
@@ -43593,7 +43633,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1123
+      "community": 1124
     },
     {
       "label": "state-store.spec.ts",
@@ -43601,7 +43641,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1124
+      "community": 1125
     },
     {
       "label": "sanitizer.spec.ts",
@@ -43609,7 +43649,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1125
+      "community": 1126
     },
     {
       "label": "entrypoint.spec.ts",
@@ -43617,7 +43657,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1126
+      "community": 1127
     },
     {
       "label": "index.ts",
@@ -43657,7 +43697,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1127
+      "community": 1128
     },
     {
       "label": "memento-admin-fetch.js",
@@ -43713,7 +43753,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1128
+      "community": 1129
     },
     {
       "label": "dashboard-auth.js",
@@ -44225,7 +44265,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 771
+      "community": 773
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -44233,7 +44273,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 771
+      "community": 773
     },
     {
       "label": "graph.js",
@@ -44625,7 +44665,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1129
+      "community": 1130
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -44809,7 +44849,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 772
+      "community": 774
     },
     {
       "label": "init()",
@@ -44817,7 +44857,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 772
+      "community": 774
     },
     {
       "label": "review-candidates-panel-bulk.js",
@@ -50589,7 +50629,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L201",
+      "source_location": "L209",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
       "_tgt": "anchor_map_handler_buildnetworklinks",
@@ -50601,7 +50641,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L249",
+      "source_location": "L257",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
       "_tgt": "anchor_map_handler_broadcasttosubscribers",
@@ -50613,7 +50653,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L272",
+      "source_location": "L280",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
       "_tgt": "anchor_map_handler_broadcastanchormapupdate",
@@ -50637,7 +50677,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L288",
+      "source_location": "L296",
       "weight": 1.0,
       "_src": "anchor_map_handler_broadcastanchormapupdate",
       "_tgt": "anchor_map_handler_buildanchormapdata",
@@ -50649,7 +50689,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L192",
+      "source_location": "L200",
       "weight": 1.0,
       "_src": "anchor_map_handler_buildnetworknodesandlinks",
       "_tgt": "anchor_map_handler_buildnetworklinks",
@@ -50661,7 +50701,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L292",
+      "source_location": "L300",
       "weight": 1.0,
       "_src": "anchor_map_handler_broadcastanchormapupdate",
       "_tgt": "anchor_map_handler_broadcasttosubscribers",
@@ -63249,7 +63289,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L43",
+      "source_location": "L45",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
+      "_tgt": "db_integrity_preflight_findrecentquarantinesnapshot",
+      "source": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
+      "target": "db_integrity_preflight_findrecentquarantinesnapshot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
+      "source_location": "L84",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
       "_tgt": "db_integrity_preflight_quarantinedatabasefile",
@@ -63261,7 +63313,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L50",
+      "source_location": "L95",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
       "_tgt": "db_integrity_preflight_maskerror",
@@ -63273,7 +63325,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L56",
+      "source_location": "L101",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
       "_tgt": "db_integrity_preflight_isokresult",
@@ -63285,7 +63337,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L60",
+      "source_location": "L105",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
       "_tgt": "db_integrity_preflight_lookslikecorruption",
@@ -63297,7 +63349,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L65",
+      "source_location": "L110",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_ts",
       "_tgt": "db_integrity_preflight_rundatabaseintegritypreflight",
@@ -63309,7 +63361,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L66",
+      "source_location": "L111",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_shouldskippreflight",
@@ -63333,7 +63385,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L78",
+      "source_location": "L123",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_runcheck",
@@ -63357,7 +63409,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L44",
+      "source_location": "L89",
       "weight": 1.0,
       "_src": "db_integrity_preflight_quarantinedatabasefile",
       "_tgt": "db_integrity_preflight_buildquarantinepath",
@@ -63369,7 +63421,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L122",
+      "source_location": "L85",
+      "weight": 1.0,
+      "_src": "db_integrity_preflight_quarantinedatabasefile",
+      "_tgt": "db_integrity_preflight_findrecentquarantinesnapshot",
+      "source": "db_integrity_preflight_findrecentquarantinesnapshot",
+      "target": "db_integrity_preflight_quarantinedatabasefile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
+      "source_location": "L167",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_quarantinedatabasefile",
@@ -63381,7 +63445,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L83",
+      "source_location": "L128",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_maskerror",
@@ -63393,7 +63457,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L88",
+      "source_location": "L133",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_isokresult",
@@ -63405,7 +63469,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.ts",
-      "source_location": "L108",
+      "source_location": "L153",
       "weight": 1.0,
       "_src": "db_integrity_preflight_rundatabaseintegritypreflight",
       "_tgt": "db_integrity_preflight_lookslikecorruption",
@@ -79320,6 +79384,18 @@
       "source_location": "L181",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_utils_logger_ts",
+      "_tgt": "logger_normalizemetaerrors",
+      "source": "packages_memento_core_src_shared_utils_logger_ts",
+      "target": "logger_normalizemetaerrors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/utils/logger.ts",
+      "source_location": "L193",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_shared_utils_logger_ts",
       "_tgt": "logger_formattime",
       "source": "packages_memento_core_src_shared_utils_logger_ts",
       "target": "logger_formattime",
@@ -79329,7 +79405,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L191",
+      "source_location": "L203",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_utils_logger_ts",
       "_tgt": "logger_buildlogmessage",
@@ -79341,7 +79417,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L209",
+      "source_location": "L221",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_utils_logger_ts",
       "_tgt": "logger_logtostderr",
@@ -79353,7 +79429,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L240",
+      "source_location": "L253",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_utils_logger_ts",
       "_tgt": "logger_logwithmcplogger",
@@ -79365,7 +79441,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L294",
+      "source_location": "L308",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_utils_logger_ts",
       "_tgt": "logger_iscliquiet",
@@ -79377,7 +79453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L199",
+      "source_location": "L211",
       "weight": 1.0,
       "_src": "logger_buildlogmessage",
       "_tgt": "logger_safestringify",
@@ -79389,7 +79465,31 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L195",
+      "source_location": "L223",
+      "weight": 1.0,
+      "_src": "logger_logtostderr",
+      "_tgt": "logger_normalizemetaerrors",
+      "source": "logger_normalizemetaerrors",
+      "target": "logger_logtostderr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/utils/logger.ts",
+      "source_location": "L266",
+      "weight": 1.0,
+      "_src": "logger_logwithmcplogger",
+      "_tgt": "logger_normalizemetaerrors",
+      "source": "logger_normalizemetaerrors",
+      "target": "logger_logwithmcplogger",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/shared/utils/logger.ts",
+      "source_location": "L207",
       "weight": 1.0,
       "_src": "logger_buildlogmessage",
       "_tgt": "logger_formattime",
@@ -79401,7 +79501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/utils/logger.ts",
-      "source_location": "L212",
+      "source_location": "L225",
       "weight": 1.0,
       "_src": "logger_logtostderr",
       "_tgt": "logger_buildlogmessage",
@@ -86265,7 +86365,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L607",
+      "source_location": "L657",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getindexstatus",
@@ -86277,7 +86377,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L665",
+      "source_location": "L715",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_rebuildindex",
@@ -86289,7 +86389,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L686",
+      "source_location": "L736",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_gettablename",
@@ -86301,7 +86401,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L693",
+      "source_location": "L743",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_checkavailability",
@@ -86313,7 +86413,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L701",
+      "source_location": "L751",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_isvectableregistered",
@@ -86325,7 +86425,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L725",
+      "source_location": "L775",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_shouldusedominantstoreddimensionsfortable",
@@ -86337,7 +86437,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L733",
+      "source_location": "L783",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getvectableschemadimensions",
@@ -86349,7 +86449,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L745",
+      "source_location": "L795",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
@@ -86361,7 +86461,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L804",
+      "source_location": "L854",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getdominantstoreddimensions",
@@ -86373,7 +86473,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L827",
+      "source_location": "L877",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_alignqueryvectortostoreddimensions",
@@ -86385,7 +86485,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L864",
+      "source_location": "L914",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getexpecteddimensions",
@@ -86397,7 +86497,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L872",
+      "source_location": "L922",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_safeparsetags",
@@ -86445,7 +86545,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L694",
+      "source_location": "L744",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_checkavailability",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_checkvecavailability",
@@ -86481,7 +86581,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L345",
+      "source_location": "L347",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_hybridsearch",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
@@ -86493,7 +86593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L354",
+      "source_location": "L356",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_hybridsearch",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_alignqueryvectortostoreddimensions",
@@ -86505,7 +86605,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L626",
+      "source_location": "L676",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_getindexstatus",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_gettablename",
@@ -86517,7 +86617,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L779",
+      "source_location": "L829",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_gettablename",
@@ -86529,7 +86629,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L757",
+      "source_location": "L807",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_shouldusedominantstoreddimensionsfortable",
@@ -86541,7 +86641,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L780",
+      "source_location": "L830",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getvectableschemadimensions",
@@ -86553,7 +86653,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L753",
+      "source_location": "L803",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getexpecteddimensions",
@@ -86565,7 +86665,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search.repository.ts",
-      "source_location": "L758",
+      "source_location": "L808",
       "weight": 1.0,
       "_src": "vector_search_repository_vectorsearchrepositoryimpl_resolveruntimevectorcontext",
       "_tgt": "vector_search_repository_vectorsearchrepositoryimpl_getdominantstoreddimensions",
@@ -86655,6 +86755,18 @@
       "_tgt": "vector_performance_repository_vectorperformancerepositoryimpl_executesearch",
       "source": "vector_performance_repository_vectorperformancerepositoryimpl_runperformancetest",
       "target": "vector_performance_repository_vectorperformancerepositoryimpl_executesearch",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
+      "source_location": "L407",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
+      "_tgt": "vector_search_repository_spec_seedscopedhybridmemories",
+      "source": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
+      "target": "vector_search_repository_spec_seedscopedhybridmemories",
       "confidence_score": 1.0
     },
     {
@@ -92121,7 +92233,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L135",
+      "source_location": "L134",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
       "_tgt": "remember_tool_remembertool",
@@ -92133,7 +92245,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L136",
+      "source_location": "L135",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_constructor",
@@ -92145,7 +92257,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L249",
+      "source_location": "L248",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_validatereflectionnotesjson",
@@ -92157,7 +92269,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L265",
+      "source_location": "L264",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_getexistingreflectionnotes",
@@ -92169,7 +92281,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L319",
+      "source_location": "L318",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_parsereflectionnotes",
@@ -92181,7 +92293,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L369",
+      "source_location": "L368",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_handle",
@@ -92193,7 +92305,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1536",
+      "source_location": "L1535",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_findexistingproceduralmemory",
@@ -92205,7 +92317,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1609",
+      "source_location": "L1608",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_getexistingmemoriesforrelationextraction",
@@ -92217,7 +92329,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L1657",
+      "source_location": "L1655",
       "weight": 1.0,
       "_src": "remember_tool_remembertool",
       "_tgt": "remember_tool_remembertool_getmemorybyid",
@@ -92229,7 +92341,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L432",
+      "source_location": "L431",
       "weight": 1.0,
       "_src": "remember_tool_remembertool_handle",
       "_tgt": "remember_tool_remembertool_validatereflectionnotesjson",
@@ -92241,7 +92353,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L299",
+      "source_location": "L298",
       "weight": 1.0,
       "_src": "remember_tool_remembertool_getexistingreflectionnotes",
       "_tgt": "remember_tool_remembertool_parsereflectionnotes",
@@ -92253,7 +92365,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L595",
+      "source_location": "L594",
       "weight": 1.0,
       "_src": "remember_tool_remembertool_handle",
       "_tgt": "remember_tool_remembertool_getexistingreflectionnotes",
@@ -92265,7 +92377,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
-      "source_location": "L662",
+      "source_location": "L661",
       "weight": 1.0,
       "_src": "remember_tool_remembertool_handle",
       "_tgt": "remember_tool_remembertool_findexistingproceduralmemory",
@@ -94191,6 +94303,18 @@
       "_tgt": "recall_tool_spec_createvalidreflectionnote",
       "source": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
       "target": "recall_tool_spec_createvalidreflectionnote",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
+      "_tgt": "remember_tool_relation_load_spec_initializeproductionlikeschema",
+      "source": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
+      "target": "remember_tool_relation_load_spec_initializeproductionlikeschema",
       "confidence_score": 1.0
     },
     {
@@ -108561,7 +108685,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L59",
+      "source_location": "L60",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_monitoring_services_performance_monitor_ts",
       "_tgt": "performance_monitor_performancemonitor",
@@ -108573,7 +108697,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1162",
+      "source_location": "L1188",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_monitoring_services_performance_monitor_ts",
       "_tgt": "performance_monitor_getperformancemonitor",
@@ -108585,7 +108709,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1169",
+      "source_location": "L1195",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_monitoring_services_performance_monitor_ts",
       "_tgt": "performance_monitor_createperformancemonitor",
@@ -108597,7 +108721,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L75",
+      "source_location": "L78",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_constructor",
@@ -108609,7 +108733,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L90",
+      "source_location": "L94",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
@@ -108621,7 +108745,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L105",
+      "source_location": "L109",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_memoryratiotopercent",
@@ -108633,7 +108757,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L116",
+      "source_location": "L120",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_initialize",
@@ -108645,7 +108769,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L132",
+      "source_location": "L136",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_setdatabase",
@@ -108657,7 +108781,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L142",
+      "source_location": "L146",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_collectmetrics",
@@ -108669,7 +108793,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L209",
+      "source_location": "L213",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_checkalerts",
@@ -108681,7 +108805,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L350",
+      "source_location": "L375",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_addtohistory",
@@ -108693,7 +108817,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L363",
+      "source_location": "L388",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_resolvealert",
@@ -108705,7 +108829,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L377",
+      "source_location": "L402",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getmetrics",
@@ -108717,7 +108841,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L384",
+      "source_location": "L409",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getmetricshistory",
@@ -108729,7 +108853,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L394",
+      "source_location": "L419",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getalerts",
@@ -108741,7 +108865,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L398",
+      "source_location": "L423",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getactivealerts",
@@ -108753,7 +108877,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L402",
+      "source_location": "L427",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getallalerts",
@@ -108765,7 +108889,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L410",
+      "source_location": "L435",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_clearalerts",
@@ -108777,7 +108901,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L417",
+      "source_location": "L443",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getperformancereport",
@@ -108789,7 +108913,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L451",
+      "source_location": "L477",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_generaterecommendations",
@@ -108801,7 +108925,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L480",
+      "source_location": "L506",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_startmonitoring",
@@ -108813,7 +108937,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L497",
+      "source_location": "L523",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_stopmonitoring",
@@ -108825,7 +108949,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L507",
+      "source_location": "L533",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_ismonitoring",
@@ -108837,7 +108961,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L514",
+      "source_location": "L540",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_recordsearch",
@@ -108849,7 +108973,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L547",
+      "source_location": "L573",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getsearchmetrics",
@@ -108861,7 +108985,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L585",
+      "source_location": "L611",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getmemorymetrics",
@@ -108873,7 +108997,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L619",
+      "source_location": "L645",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getsystemmetrics",
@@ -108885,7 +109009,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L638",
+      "source_location": "L664",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getdatabasemetrics",
@@ -108897,7 +109021,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L694",
+      "source_location": "L720",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_resetstats",
@@ -108909,7 +109033,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L709",
+      "source_location": "L735",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_ishealthy",
@@ -108921,7 +109045,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L721",
+      "source_location": "L747",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_exportmetrics",
@@ -108933,7 +109057,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L740",
+      "source_location": "L766",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_importmetrics",
@@ -108945,7 +109069,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L792",
+      "source_location": "L818",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getperformancesummary",
@@ -108957,7 +109081,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L822",
+      "source_location": "L848",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getmetricsanalytics",
@@ -108969,7 +109093,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L928",
+      "source_location": "L954",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_analyzetrend",
@@ -108981,7 +109105,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L946",
+      "source_location": "L972",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_updatethresholds",
@@ -108993,7 +109117,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L954",
+      "source_location": "L980",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_formatbytes",
@@ -109005,7 +109129,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L972",
+      "source_location": "L998",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_calculatecpuusage",
@@ -109017,7 +109141,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1014",
+      "source_location": "L1040",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_handlecriticalalert",
@@ -109029,7 +109153,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1053",
+      "source_location": "L1079",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_optimizedatabase",
@@ -109041,7 +109165,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1078",
+      "source_location": "L1104",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_getalertstats",
@@ -109053,7 +109177,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1117",
+      "source_location": "L1143",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_cleanupoldalerts",
@@ -109065,7 +109189,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1136",
+      "source_location": "L1162",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_recordmetric",
@@ -109077,7 +109201,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1145",
+      "source_location": "L1171",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_incrementcounter",
@@ -109089,7 +109213,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1154",
+      "source_location": "L1180",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor",
       "_tgt": "performance_monitor_performancemonitor_log",
@@ -109101,7 +109225,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L163",
+      "source_location": "L167",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
@@ -109113,7 +109237,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L214",
+      "source_location": "L218",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_checkalerts",
       "_tgt": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
@@ -109125,7 +109249,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L600",
+      "source_location": "L626",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getmemorymetrics",
       "_tgt": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
@@ -109137,7 +109261,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1015",
+      "source_location": "L1041",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_handlecriticalalert",
       "_tgt": "performance_monitor_performancemonitor_getmemorypressuredenominatorbytes",
@@ -109149,7 +109273,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L164",
+      "source_location": "L168",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_memoryratiotopercent",
@@ -109161,7 +109285,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L601",
+      "source_location": "L627",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getmemorymetrics",
       "_tgt": "performance_monitor_performancemonitor_memoryratiotopercent",
@@ -109173,7 +109297,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1021",
+      "source_location": "L1047",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_handlecriticalalert",
       "_tgt": "performance_monitor_performancemonitor_memoryratiotopercent",
@@ -109185,7 +109309,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L150",
+      "source_location": "L154",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_getdatabasemetrics",
@@ -109197,7 +109321,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L158",
+      "source_location": "L162",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_getsearchmetrics",
@@ -109209,7 +109333,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L161",
+      "source_location": "L165",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_getsystemmetrics",
@@ -109221,7 +109345,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L166",
+      "source_location": "L170",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_calculatecpuusage",
@@ -109233,7 +109357,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L194",
+      "source_location": "L198",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_addtohistory",
@@ -109245,7 +109369,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L197",
+      "source_location": "L201",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_collectmetrics",
       "_tgt": "performance_monitor_performancemonitor_checkalerts",
@@ -109257,7 +109381,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L378",
+      "source_location": "L403",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getmetrics",
       "_tgt": "performance_monitor_performancemonitor_collectmetrics",
@@ -109269,7 +109393,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L710",
+      "source_location": "L736",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_ishealthy",
       "_tgt": "performance_monitor_performancemonitor_collectmetrics",
@@ -109281,7 +109405,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L724",
+      "source_location": "L750",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_exportmetrics",
       "_tgt": "performance_monitor_performancemonitor_collectmetrics",
@@ -109293,7 +109417,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L775",
+      "source_location": "L801",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_importmetrics",
       "_tgt": "performance_monitor_performancemonitor_collectmetrics",
@@ -109305,7 +109429,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L221",
+      "source_location": "L225",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_checkalerts",
       "_tgt": "performance_monitor_performancemonitor_resolvealert",
@@ -109317,7 +109441,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L236",
+      "source_location": "L240",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_checkalerts",
       "_tgt": "performance_monitor_performancemonitor_formatbytes",
@@ -109329,7 +109453,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L342",
+      "source_location": "L367",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_checkalerts",
       "_tgt": "performance_monitor_performancemonitor_handlecriticalalert",
@@ -109341,7 +109465,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L784",
+      "source_location": "L810",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_importmetrics",
       "_tgt": "performance_monitor_performancemonitor_addtohistory",
@@ -109353,7 +109477,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L433",
+      "source_location": "L459",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancereport",
       "_tgt": "performance_monitor_performancemonitor_getmetricshistory",
@@ -109365,7 +109489,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L722",
+      "source_location": "L748",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_exportmetrics",
       "_tgt": "performance_monitor_performancemonitor_getmetricshistory",
@@ -109377,7 +109501,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L434",
+      "source_location": "L460",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancereport",
       "_tgt": "performance_monitor_performancemonitor_getalerts",
@@ -109389,7 +109513,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L723",
+      "source_location": "L749",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_exportmetrics",
       "_tgt": "performance_monitor_performancemonitor_getalerts",
@@ -109401,7 +109525,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L801",
+      "source_location": "L827",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancesummary",
       "_tgt": "performance_monitor_performancemonitor_getalerts",
@@ -109413,7 +109537,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L711",
+      "source_location": "L737",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_ishealthy",
       "_tgt": "performance_monitor_performancemonitor_getactivealerts",
@@ -109425,7 +109549,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L802",
+      "source_location": "L828",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancesummary",
       "_tgt": "performance_monitor_performancemonitor_getallalerts",
@@ -109437,7 +109561,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L432",
+      "source_location": "L458",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancereport",
       "_tgt": "performance_monitor_performancemonitor_getperformancesummary",
@@ -109449,7 +109573,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L435",
+      "source_location": "L461",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancereport",
       "_tgt": "performance_monitor_performancemonitor_generaterecommendations",
@@ -109461,7 +109585,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L436",
+      "source_location": "L462",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancereport",
       "_tgt": "performance_monitor_performancemonitor_getmetricsanalytics",
@@ -109473,7 +109597,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L806",
+      "source_location": "L832",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_getperformancesummary",
       "_tgt": "performance_monitor_performancemonitor_analyzetrend",
@@ -109485,7 +109609,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L959",
+      "source_location": "L985",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_formatbytes",
       "_tgt": "performance_monitor_performancemonitor_log",
@@ -109497,7 +109621,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor.ts",
-      "source_location": "L1037",
+      "source_location": "L1063",
       "weight": 1.0,
       "_src": "performance_monitor_performancemonitor_handlecriticalalert",
       "_tgt": "performance_monitor_performancemonitor_optimizedatabase",
@@ -110565,7 +110689,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/monitoring/services/error-logging-service.ts",
-      "source_location": "L387",
+      "source_location": "L392",
       "weight": 1.0,
       "_src": "error_logging_service_errorloggingservice",
       "_tgt": "error_logging_service_errorloggingservice_cleanup",

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { DatabaseUtils } from '../../../../shared/utils/database.js';
+import { RememberTool } from '../remember-tool.js';
+
+/**
+ * 운영 DB와 동일: memory_item에 embedding 컬럼 없음, is_consolidated 있음.
+ * 임베딩은 memory_embedding 테이블에 저장된다.
+ */
+function initializeProductionLikeSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      is_consolidated BOOLEAN DEFAULT FALSE
+    );
+  `);
+}
+
+describe('RememberTool relation load (Issue #544)', () => {
+  let db: Database.Database;
+  let tool: RememberTool;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    initializeProductionLikeSchema(db);
+    tool = new RememberTool();
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+  });
+
+  describe('getExistingMemoriesForRelationExtraction', () => {
+    it('embedding 컬럼 없는 스키마에서 기존 기억을 반환한다', async () => {
+      DatabaseUtils.run(db, `
+        INSERT INTO memory_item (id, type, content, importance, privacy_scope, pinned, is_consolidated)
+        VALUES ('mem-existing-1', 'semantic', '기존 지식 A', 0.7, 'private', 0, 0)
+      `);
+      DatabaseUtils.run(db, `
+        INSERT INTO memory_item (id, type, content, importance, privacy_scope, pinned, is_consolidated)
+        VALUES ('mem-existing-2', 'episodic', '기존 경험 B', 0.5, 'team', 1, 1)
+      `);
+      DatabaseUtils.run(db, `
+        INSERT INTO memory_item (id, type, content, importance, privacy_scope, pinned, is_consolidated)
+        VALUES ('mem-new', 'episodic', '새로 저장된 기억', 0.6, 'private', 0, 0)
+      `);
+
+      const logWarningSpy = vi.spyOn(tool as any, 'logWarning');
+
+      const existing = await (tool as any).getExistingMemoriesForRelationExtraction(
+        db,
+        'mem-new',
+        100
+      );
+
+      expect(existing).toHaveLength(2);
+      expect(existing.map((m: { id: string }) => m.id).sort()).toEqual([
+        'mem-existing-1',
+        'mem-existing-2',
+      ]);
+      expect(existing[0]).toMatchObject({
+        type: expect.any(String),
+        content: expect.any(String),
+        importance: expect.any(Number),
+      });
+
+      const relationLoadWarnings = logWarningSpy.mock.calls.filter(
+        (call) => call[0] === '기존 기억 조회 실패'
+      );
+      expect(relationLoadWarnings).toHaveLength(0);
+    });
+
+    it('조회 실패 시 기존 기억 조회 실패 warn을 남기지 않는다', async () => {
+      DatabaseUtils.run(db, `
+        INSERT INTO memory_item (id, type, content)
+        VALUES ('mem-only', 'semantic', '단일 기억')
+      `);
+
+      const logWarningSpy = vi.spyOn(tool as any, 'logWarning');
+
+      const existing = await (tool as any).getExistingMemoriesForRelationExtraction(
+        db,
+        'mem-other',
+        10
+      );
+
+      expect(existing).toHaveLength(1);
+      expect(existing[0].id).toBe('mem-only');
+
+      const relationLoadWarnings = logWarningSpy.mock.calls.filter(
+        (call) => call[0] === '기존 기억 조회 실패'
+      );
+      expect(relationLoadWarnings).toHaveLength(0);
+    });
+  });
+
+  describe('getMemoryById', () => {
+    it('id로 memory_item 행을 조회해 content/type 등을 반환한다', async () => {
+      DatabaseUtils.run(db, `
+        INSERT INTO memory_item (
+          id, type, content, importance, privacy_scope, pinned, tags, source, is_consolidated
+        ) VALUES (
+          'mem-target',
+          'semantic',
+          '대상 기억 내용',
+          0.8,
+          'public',
+          1,
+          '["tag-a"]',
+          'test-source',
+          0
+        )
+      `);
+
+      const logWarningSpy = vi.spyOn(tool as any, 'logWarning');
+
+      const memory = await (tool as any).getMemoryById(db, 'mem-target');
+
+      expect(memory).not.toBeNull();
+      expect(memory).toMatchObject({
+        id: 'mem-target',
+        type: 'semantic',
+        content: '대상 기억 내용',
+        importance: 0.8,
+        privacy_scope: 'public',
+        pinned: true,
+        tags: ['tag-a'],
+        source: 'test-source',
+        isConsolidated: false,
+      });
+      expect(memory!.created_at).toBeInstanceOf(Date);
+
+      const lookupWarnings = logWarningSpy.mock.calls.filter(
+        (call) => call[0] === '기억 조회 실패'
+      );
+      expect(lookupWarnings).toHaveLength(0);
+    });
+
+    it('존재하지 않는 id면 null을 반환한다', async () => {
+      const memory = await (tool as any).getMemoryById(db, 'missing-id');
+      expect(memory).toBeNull();
+    });
+  });
+});

--- a/packages/memento-core/src/domains/memory/tools/remember-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool.ts
@@ -117,7 +117,6 @@ interface MemoryItemRow {
   pinned: number | boolean;
   tags?: string | null;
   source?: string | null;
-  embedding?: string | null;
   /** sleep consolidation 등 — 컬럼 없으면 undefined */
   is_consolidated?: number | boolean | null;
 }
@@ -1615,7 +1614,7 @@ export class RememberTool extends BaseTool {
       const rows = await DatabaseUtils.all(db, `
         SELECT 
           id, type, content, importance, privacy_scope, 
-          created_at, last_accessed, pinned, tags, source, embedding,
+          created_at, last_accessed, pinned, tags, source,
           is_consolidated
         FROM memory_item
         WHERE id != ? -- 새로 저장된 기억 제외
@@ -1634,7 +1633,6 @@ export class RememberTool extends BaseTool {
         pinned: Boolean(row.pinned),
         tags: row.tags ? JSON.parse(row.tags) : undefined,
         source: row.source || undefined,
-        embedding: row.embedding ? JSON.parse(row.embedding) : undefined,
         ...(row.is_consolidated !== undefined && row.is_consolidated !== null
           ? { isConsolidated: Boolean(row.is_consolidated) }
           : {})
@@ -1659,7 +1657,7 @@ export class RememberTool extends BaseTool {
       const row = await DatabaseUtils.get(db, `
         SELECT 
           id, type, content, importance, privacy_scope, 
-          created_at, last_accessed, pinned, tags, source, embedding,
+          created_at, last_accessed, pinned, tags, source,
           is_consolidated
         FROM memory_item
         WHERE id = ?
@@ -1680,7 +1678,6 @@ export class RememberTool extends BaseTool {
         pinned: Boolean(row.pinned),
         tags: row.tags ? JSON.parse(row.tags) : undefined,
         source: row.source || undefined,
-        embedding: row.embedding ? JSON.parse(row.embedding) : undefined,
         ...(row.is_consolidated !== undefined && row.is_consolidated !== null
           ? { isConsolidated: Boolean(row.is_consolidated) }
           : {})

--- a/specs/027-fix-remember-embedding-column/plan.md
+++ b/specs/027-fix-remember-embedding-column/plan.md
@@ -1,0 +1,50 @@
+# Implementation Plan: remember 관계 추출용 기존 기억 조회 수정
+
+**Branch**: `issue-544-remember-embedding-fix` | **Date**: 2026-06-18 | **Spec**: [spec.md](./spec.md)  
+**Input**: GitHub Issue #544
+
+## Summary
+
+`remember-tool.ts`의 `getExistingMemoriesForRelationExtraction`·`getMemoryById`가 운영 스키마에 없는 `memory_item.embedding` 컬럼을 SELECT하여 `no such column: embedding` 오류가 발생하고, catch 블록에서 `기존 기억 조회 실패` warn 후 빈 배열이 반환되어 관계 추출이 스킵된다. 임베딩은 `memory_embedding` 테이블에 저장되므로 두 private 메서드의 SELECT·row mapping에서 `embedding` 참조를 제거한다.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, Node.js ≥ 24, ES modules  
+**Primary Dependencies**: `better-sqlite3`, `@memento/core`, Vitest  
+**Storage**: SQLite — 스키마/마이그레이션 변경 없음  
+**Testing**: Vitest co-located spec `remember-tool-relation-load.spec.ts`  
+**Target Platform**: memento-core `RememberTool`  
+**Constraints**: 관계 추출 경로만 수정; `memory_embedding` JOIN 품질 개선은 범위 외
+
+## Project Structure
+
+```text
+specs/027-fix-remember-embedding-column/
+├── spec.md
+├── plan.md
+└── tasks.md
+
+packages/memento-core/src/domains/memory/tools/
+├── remember-tool.ts                              # [수정] embedding SELECT/매핑 제거
+└── __tests__/
+    └── remember-tool-relation-load.spec.ts       # [신규] 회귀 테스트
+```
+
+## Implementation Notes
+
+| Method | Change |
+|--------|--------|
+| `getExistingMemoriesForRelationExtraction` | SELECT에서 `embedding` 제거; row mapping에서 `embedding` 파싱 제거 |
+| `getMemoryById` | 동일 |
+| `MemoryItemRow` | `embedding?` 필드 제거 (해당 메서드 전용) |
+
+회귀 테스트는 `embedding` 컬럼 없이 `is_consolidated` 포함한 최소 `memory_item` 스키마를 사용한다.
+
+## Constitution Check
+
+| Gate | Status |
+|------|--------|
+| Test-First | 회귀 spec으로 embedding 없는 스키마 검증 |
+| Backward Compatibility | 존재하지 않는 컬럼 참조 제거 — 운영 DB와 정합 |
+| Schema Discipline | DB/마이그레이션 변경 없음 |
+| Quality Gates | lint, type-check, test |

--- a/specs/027-fix-remember-embedding-column/spec.md
+++ b/specs/027-fix-remember-embedding-column/spec.md
@@ -1,0 +1,44 @@
+# Feature Specification: remember 관계 추출용 기존 기억 조회 수정
+
+**Feature Branch**: `issue-544-remember-embedding-fix`  
+**Created**: 2026-06-18  
+**Status**: Draft  
+**Input**: GitHub Issue #544 — `[remember] 기존 기억 조회 실패: no such column: embedding`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — remember 시 관계 추출이 기존 기억을 조회한다 (Priority: P1)
+
+운영 DB 스키마에서 `memory_item`에 `embedding` 컬럼이 없고 임베딩은 `memory_embedding` 테이블에 저장된 상태에서, `remember` 호출 후 관계 추출 단계가 기존 기억 목록을 정상 조회해야 한다.
+
+**Why this priority**: 현재 SQL 오류로 빈 배열이 반환되어 관계 추출이 매번 스킵되고 운영 warn 로그가 반복된다.
+
+**Independent Test**: `embedding` 컬럼이 없는 `memory_item` 스키마에서 `getExistingMemoriesForRelationExtraction`이 기존 기억을 반환하고 `기존 기억 조회 실패` warn이 없다.
+
+**Acceptance Scenarios**:
+
+1. **Given** `memory_item`에 기존 기억 2건, **When** 새 기억 저장 후 관계 추출용 조회, **Then** 제외 ID 외 기존 기억이 1건 이상 반환된다.
+2. **Given** 동일 조건, **When** 조회 실행, **Then** `no such column: embedding` 오류 및 `기존 기억 조회 실패` warn이 없다.
+3. **Given** `getMemoryById`로 새 저장 기억 조회, **When** `memory_item`에 해당 행 존재, **Then** content/type 등 필드가 반환된다.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `getExistingMemoriesForRelationExtraction` SELECT는 현재 `memory_item` 스키마와 일치해야 하며 `embedding` 컬럼을 참조하지 않아야 한다.
+- **FR-002**: `getMemoryById` SELECT도 동일하게 `embedding` 컬럼을 참조하지 않아야 한다.
+- **FR-003**: 관계 추출 경로는 조회 실패 시 빈 배열 폴백을 유지하되, 정상 스키마에서는 폴백 없이 기존 기억을 사용해야 한다.
+
+## Out of Scope
+
+- `memory_embedding` JOIN으로 임베딩 후보 필터 품질 개선
+- 스키마/마이그레이션 변경
+- 관계 추출 알고리즘 자체 변경
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Issue #544 fingerprint 로그(`no such column: embedding`) 재발 없음
+- **SC-002**: 회귀 테스트 통과
+- **SC-003**: `npm run lint`, `npm run type-check`, `npm test` 통과

--- a/specs/027-fix-remember-embedding-column/tasks.md
+++ b/specs/027-fix-remember-embedding-column/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: remember 관계 추출용 기존 기억 조회 수정
+
+**Input**: `specs/027-fix-remember-embedding-column/` (spec.md, plan.md)  
+**Issue**: #544
+
+## Phase 1: Regression tests (TDD)
+
+- [ ] T001 [US1] `remember-tool-relation-load.spec.ts` — embedding 없는 최소 `memory_item` 스키마 + `is_consolidated` fixture
+- [ ] T002 [US1] `getExistingMemoriesForRelationExtraction` — exclude ID 외 기존 기억 반환 검증
+- [ ] T003 [US1] `기존 기억 조회 실패` logWarning 미발생 검증
+- [ ] T004 [US1] `getMemoryById` — id로 content/type 등 필드 반환 검증
+
+## Phase 2: Core fix
+
+- [ ] T005 [US1] `remember-tool.ts` — 두 private SELECT에서 `embedding` 제거
+- [ ] T006 [US1] row mapping에서 `embedding` JSON 파싱 제거
+- [ ] T007 [US1] `MemoryItemRow`에서 `embedding` 필드 정리
+
+## Phase 3: Verification & ship
+
+- [ ] T008 [POLISH] targeted vitest → `npm run lint`, `npm run type-check`, `npm test`
+- [ ] T009 [POLISH] graphify 코드 그래프 재빌드
+- [ ] T010 [POLISH] 커밋, push, PR 생성 (Closes #544)
+
+## Dependencies
+
+T001–T004 → T005–T007 → T008 → T009 → T010


### PR DESCRIPTION
## Summary

- Fix `getExistingMemoriesForRelationExtraction` and `getMemoryById` in `remember-tool.ts` to stop selecting non-existent `memory_item.embedding` (embeddings are stored in `memory_embedding`).
- Add regression tests in `remember-tool-relation-load.spec.ts` using a minimal production-like schema (with `is_consolidated`, without `embedding`).
- Add spec `specs/027-fix-remember-embedding-column/` (spec, plan, tasks).

Closes #544

## Spec reference

`specs/027-fix-remember-embedding-column/spec.md`

## Test plan

- [x] `npx vitest run packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts` — 4 tests pass
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` — 4598 tests pass
- [x] graphify code graph rebuild


Made with [Cursor](https://cursor.com)