### PR TITLE
[codex] wire personal agent persistence into server runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,14 @@ http://localhost:9001/graph
 | `/admin/memory/review-candidates/:id/dismiss` | 기억 리뷰 후보 기각 | POST |
 | `/admin/stats/forgetting` | 망각 통계 조회 | GET |
 
+#### 개인 지식 Agent
+| 엔드포인트 | 설명 | 메서드 |
+|-----------|------|--------|
+| `/api/v1/agent/personal:run` | 한 턴 실행, 지식 후보 반환(저장 없음) | POST |
+| `/api/v1/agent/personal:persist-approved` | 승인된 후보만 `remember`로 저장 | POST |
+
+사용 절차: [개인 지식 에이전트 HTTP 서버 런타임 사용법](docs/guides/ko/personal-knowledge-agent-mvp.md#http-서버-런타임-사용법)
+
 #### 앵커 관리
 | 엔드포인트 | 설명 | 메서드 |
 |-----------|------|--------|

--- a/docs/guides/ko/personal-knowledge-agent-mvp.md
+++ b/docs/guides/ko/personal-knowledge-agent-mvp.md
@@ -14,6 +14,8 @@
 
 MCP 서버나 HTTP 대시보드 없이 SQLite DB 파일 하나로 완결되는 가벼운 사용 방식입니다.
 
+HTTP 서버를 띄운 호스트는 같은 개인 지식 Agent를 두 단계 API로 사용할 수 있습니다. 이 경로는 서버 프로세스의 실제 `ToolContext`와 `remember` 도구를 사용하므로, 승인된 후보가 현재 서버 DB에 저장됩니다.
+
 ## 전제 조건
 
 저장소 루트에서 `npm install`과 `npm run build`를 완료한 상태여야 합니다.
@@ -114,6 +116,69 @@ node packages/memento-server/dist/cli.js --db-path "$DB" agent ask \
 ```
 
 stdout에 JSON 한 줄이 출력되고, 저장이나 대화형 입력 없이 종료됩니다.
+
+## HTTP 서버 런타임 사용법
+
+HTTP 호스트는 저장을 자동으로 수행하지 않습니다. 먼저 한 턴을 실행해 후보를 받은 뒤, 사용자 승인 결과를 별도 요청으로 제출합니다.
+
+### 1. 서버 실행
+
+`/api/v1/agent/*` 엔드포인트는 API 키 인증을 사용합니다. 로컬 테스트에서는 mock LLM이 기본값입니다.
+
+```bash
+export ADMIN_API_KEY=dev-key
+export MEMENTO_PERSONAL_AGENT_LLM_PROVIDER=mock
+npm run dev:http
+```
+
+### 2. 한 턴 실행
+
+```bash
+curl -sS http://127.0.0.1:3000/api/v1/agent/personal:run \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_message": "앞으로는 커밋 메시지는 영어로 쓰자",
+    "project_id": "my-project",
+    "session_id": "session-1",
+    "token_budget": 1000
+  }'
+```
+
+응답에는 `llm.response`, `knowledgeContext`, `candidates`, `persistence`가 포함됩니다. 이 단계의 `persistence.attempted`는 항상 `false`이며 DB 저장을 하지 않습니다.
+
+호스트는 응답의 `candidates` 배열을 그대로 보관해야 합니다. 후보 `id`는 해당 응답 스냅샷 안에서 승인 목록과 매칭하기 위한 값입니다.
+
+### 3. 승인 후보 저장
+
+사용자가 승인한 후보 id만 `approved_candidate_ids`에 넣고, 직전 응답의 `candidates` 배열을 그대로 보냅니다.
+
+```bash
+curl -sS http://127.0.0.1:3000/api/v1/agent/personal:persist-approved \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "candidates": [
+      {
+        "id": "kc_...",
+        "category": "preference",
+        "content": "커밋 메시지는 영어로 쓰자",
+        "reason": "사용자 메시지에 선호·습관 변경 신호가 포함되어 있습니다.",
+        "suggestedMemoryType": "semantic",
+        "tags": ["personal-agent", "preference"],
+        "importance": 0.62,
+        "confidence": 0.9,
+        "sourceContext": "앞으로는 커밋 메시지는 영어로 쓰자"
+      }
+    ],
+    "approved_candidate_ids": ["kc_..."],
+    "project_id": "my-project",
+    "session_id": "session-1",
+    "process_id": "http-host"
+  }'
+```
+
+성공 응답의 `persistence.items[]`에는 후보별 `status`, 성공 시 `memoryId`, 실패 시 `errorMessage`가 들어갑니다. 승인하지 않은 후보는 저장되지 않습니다.
 
 ## 관련 문서
 

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -318,6 +318,7 @@ async function initializeServer() {
       initialInjectionTokenBudget: Number.isFinite(initialInjectionTokenBudget)
         ? initialInjectionTokenBudget
         : undefined,
+      serverServices,
     });
     
     // 라우터 등록 (/admin, /api는 브라우저 세션; /api/v1/quality, /tools, /mcp는 API 키)

--- a/packages/memento-server/src/server/routes/agent-personal.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/agent-personal.routes.spec.ts
@@ -1,0 +1,126 @@
+import type { Request, Response } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeterministicMockLlmAdapter } from '@memento/core';
+import { createAgentRouter } from './agent.routes.js';
+import {
+  cleanupTestDatabase,
+  setupTestDatabase,
+  type TestDatabaseContext,
+} from '../test/helpers/test-database.js';
+
+describe('personal knowledge agent HTTP routes', () => {
+  let ctx: TestDatabaseContext;
+  let router: ReturnType<typeof createAgentRouter>;
+  let response: Partial<Response>;
+
+  beforeEach(async () => {
+    ctx = await setupTestDatabase();
+    router = createAgentRouter(ctx.db, {
+      serverServices: ctx.services,
+      personalAgentLlm: new DeterministicMockLlmAdapter(),
+    } as Parameters<typeof createAgentRouter>[1]);
+    response = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    };
+  });
+
+  afterEach(async () => {
+    await new Promise(resolve => setTimeout(resolve, 150));
+    await cleanupTestDatabase(ctx);
+  });
+
+  async function invoke(method: 'post', path: string, request: Partial<Request> = {}) {
+    const layer = router.stack.find(
+      candidate => candidate.route?.path === path && candidate.route.methods[method],
+    );
+    expect(layer?.route).toBeTruthy();
+    await layer!.route!.stack[0]!.handle(
+      {
+        body: {},
+        params: {},
+        query: {},
+        ...request,
+      } as Request,
+      response as Response,
+      vi.fn(),
+    );
+  }
+
+  it('runs one turn without persisting candidates', async () => {
+    await invoke('post', '/personal\\:run', {
+      body: {
+        user_message: '앞으로는 커밋 메시지는 영어로 쓰자',
+        project_id: 'issue-390',
+        token_budget: 128,
+      },
+    });
+
+    expect(response.status).not.toHaveBeenCalled();
+    const payload = vi.mocked(response.json!).mock.calls.at(-1)?.[0] as {
+      ok: true;
+      candidates: Array<{ id: string; content: string }>;
+      persistence: { attempted: boolean };
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.persistence.attempted).toBe(false);
+    expect(payload.candidates).toHaveLength(1);
+    expect(payload.candidates[0]?.id).toMatch(/^kc_/);
+
+    const stored = ctx.db.prepare('SELECT COUNT(*) AS count FROM memory_item').get() as { count: number };
+    expect(stored.count).toBe(0);
+  });
+
+  it('persists approved candidates through the server ToolContext', async () => {
+    await invoke('post', '/personal\\:run', {
+      body: {
+        user_message: '앞으로는 커밋 메시지는 영어로 쓰자',
+        project_id: 'issue-390',
+      },
+    });
+    const runPayload = vi.mocked(response.json!).mock.calls.at(-1)?.[0] as {
+      candidates: Array<{ id: string; content: string }>;
+    };
+
+    await invoke('post', '/personal\\:persist-approved', {
+      body: {
+        candidates: runPayload.candidates,
+        approved_candidate_ids: [runPayload.candidates[0]!.id],
+        project_id: 'issue-390',
+        session_id: 'session-390',
+        process_id: 'server-route-test',
+      },
+    });
+
+    expect(response.status).not.toHaveBeenCalled();
+    const persistPayload = vi.mocked(response.json!).mock.calls.at(-1)?.[0] as {
+      ok: true;
+      persistence: { attempted: boolean; persistedCount: number; errorCount: number };
+    };
+    expect(persistPayload.ok).toBe(true);
+    expect(persistPayload.persistence).toMatchObject({
+      attempted: true,
+      persistedCount: 1,
+      errorCount: 0,
+    });
+
+    const stored = ctx.db.prepare(`
+      SELECT content, type, project_id, session_id, process_id
+      FROM memory_item
+      WHERE source = 'personal-knowledge-agent'
+    `).get() as {
+      content: string;
+      type: string;
+      project_id: string;
+      session_id: string;
+      process_id: string;
+    };
+    expect(stored).toMatchObject({
+      content: '커밋 메시지는 영어로 쓰자',
+      type: 'semantic',
+      project_id: 'issue-390',
+      session_id: 'session-390',
+      process_id: 'server-route-test',
+    });
+  });
+});

--- a/packages/memento-server/src/server/routes/agent.routes.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.ts
@@ -6,9 +6,23 @@ import {
   AgentLifecycleService,
   AgentMemoryPromotionService,
   AgentSessionSummaryService,
+  createPersonalAgentLlmPort,
+  createToolContext,
+  GeminiChatLlmAdapter,
+  mementoConfig,
+  OllamaChatLlmAdapter,
+  OpenAiChatLlmAdapter,
+  parsePersonalAgentLlmEnv,
+  PersonalAgentLlmError,
+  PersonalKnowledgeAgentService,
+  ToolContextKnowledgeContextAdapter,
+  ToolContextRememberPersistenceAdapter,
   SqliteAgentIntegrationRepository,
   TelemetryRepository,
   type AgentLifecycleServiceOptions,
+  type ILLMPort,
+  type KnowledgeCandidate,
+  type ServerServices,
 } from '@memento/core';
 import {
   AGENT_EVENT_TYPES,
@@ -50,10 +64,13 @@ const EVENT_TYPES = [...AGENT_EVENT_TYPES];
 const EVENT_PAYLOAD_BYTES = MAX_EVENT_BYTES;
 const BATCH_EVENTS = MAX_BATCH_EVENTS;
 const BATCH_PAYLOAD_BYTES = MAX_BATCH_BYTES;
+type PersonalAgentMemoryType = 'working' | 'episodic' | 'semantic' | 'procedural';
 
 export interface AgentRouterOptions extends AgentLifecycleServiceOptions {
   contextInjectionService?: Pick<AgentContextInjectionService, 'build'>;
   initialInjectionTokenBudget?: number;
+  serverServices?: ServerServices;
+  personalAgentLlm?: ILLMPort;
 }
 
 interface AgentRouterCtx {
@@ -75,6 +92,96 @@ interface AgentRouterCtx {
   buildInjection: (
     request: AgentContextInjectionRequest,
   ) => Promise<AgentContextInjectionBundle | null>;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new AgentIntegrationError(`${name} must be a non-empty string`, 'INVALID_PAYLOAD', 400);
+  }
+  return value.trim();
+}
+
+function optionalStringArray(value: unknown, name: string): string[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string' || item.trim() === '')) {
+    throw new AgentIntegrationError(`${name} must be an array of non-empty strings`, 'INVALID_PAYLOAD', 400);
+  }
+  return value.map(item => item.trim());
+}
+
+function optionalOwnerId(value: unknown): string | string[] | undefined {
+  if (Array.isArray(value)) return optionalStringArray(value, 'owner_id');
+  return optionalString(value, 'owner_id');
+}
+
+function optionalPositiveInteger(value: unknown, name: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new AgentIntegrationError(`${name} must be a positive integer`, 'INVALID_PAYLOAD', 400);
+  }
+  return value;
+}
+
+function optionalMemoryTypes(value: unknown): PersonalAgentMemoryType[] | undefined {
+  if (value === undefined || value === null) return undefined;
+  const allowed = new Set<PersonalAgentMemoryType>(['working', 'episodic', 'semantic', 'procedural']);
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string' || !allowed.has(item as PersonalAgentMemoryType))) {
+    throw new AgentIntegrationError('memory_types must be an array of memory type strings', 'INVALID_PAYLOAD', 400);
+  }
+  return value as PersonalAgentMemoryType[];
+}
+
+function requireCandidates(value: unknown): KnowledgeCandidate[] {
+  if (!Array.isArray(value)) {
+    throw new AgentIntegrationError('candidates must be an array', 'INVALID_PAYLOAD', 400);
+  }
+  for (const candidate of value) {
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+      throw new AgentIntegrationError('candidates must contain objects', 'INVALID_PAYLOAD', 400);
+    }
+  }
+  return value as KnowledgeCandidate[];
+}
+
+function createDefaultPersonalAgentLlm(): ILLMPort {
+  const parsed = parsePersonalAgentLlmEnv(process.env, {
+    openaiApiKey: mementoConfig.openaiApiKey,
+    geminiApiKey: mementoConfig.geminiApiKey,
+  });
+  return createPersonalAgentLlmPort(parsed, {
+    createOpenAi: (cfg) => new OpenAiChatLlmAdapter({
+      apiKey: mementoConfig.openaiApiKey ?? '',
+      model: cfg.model,
+    }),
+    createGemini: (cfg) => new GeminiChatLlmAdapter({
+      apiKey: mementoConfig.geminiApiKey ?? '',
+      model: cfg.model,
+    }),
+    createOllama: (cfg) => new OllamaChatLlmAdapter({
+      baseUrl: cfg.baseUrl,
+      model: cfg.model,
+    }),
+  });
+}
+
+function createPersonalKnowledgeAgent(ctx: AgentRouterCtx): PersonalKnowledgeAgentService {
+  if (!ctx.db || !ctx.options.serverServices) {
+    throw new AgentIntegrationError('Personal knowledge agent runtime is not initialized', 'SERVER_UNAVAILABLE', 503, true);
+  }
+  try {
+    const toolContext = createToolContext(ctx.db, ctx.options.serverServices);
+    return new PersonalKnowledgeAgentService({
+      llm: ctx.options.personalAgentLlm ?? createDefaultPersonalAgentLlm(),
+      context: new ToolContextKnowledgeContextAdapter(toolContext),
+      persistence: new ToolContextRememberPersistenceAdapter(toolContext),
+    });
+  } catch (error) {
+    if (error instanceof PersonalAgentLlmError) {
+      throw new AgentIntegrationError(error.message, 'INVALID_PAYLOAD', 400);
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -626,6 +733,79 @@ function handlePostTranscriptsImport(req: Request, res: Response, ctx: AgentRout
   }
 }
 
+async function handlePostPersonalRun(req: Request, res: Response, ctx: AgentRouterCtx): Promise<Response | void> {
+  try {
+    const body = req.body ?? {};
+    const service = createPersonalKnowledgeAgent(ctx);
+    const result = await service.runOneTurn({
+      userMessage: requireString(body.user_message ?? body.userMessage, 'user_message'),
+      projectId: optionalString(body.project_id ?? body.projectId, 'project_id'),
+      ownerId: optionalOwnerId(body.owner_id ?? body.ownerId),
+      sessionId: optionalString(body.session_id ?? body.sessionId, 'session_id'),
+      tokenBudget: optionalPositiveInteger(body.token_budget ?? body.tokenBudget, 'token_budget'),
+      maxMemories: optionalPositiveInteger(body.max_memories ?? body.maxMemories, 'max_memories'),
+      memoryTypes: optionalMemoryTypes(body.memory_types ?? body.memoryTypes),
+    });
+
+    return res.json({
+      ok: true,
+      knowledgeContext: {
+        itemCount: result.knowledgeContext.itemCount,
+        tokenEstimate: result.knowledgeContext.tokenEstimate,
+        summary: result.knowledgeContext.summary,
+      },
+      llm: {
+        response: result.llmResponse,
+        metadata: result.llmMetadata ?? null,
+      },
+      candidates: result.candidates,
+      persistence: {
+        attempted: false,
+        items: [],
+        persistedCount: 0,
+        errorCount: 0,
+      },
+    });
+  } catch (error) {
+    return writeError(res, error);
+  }
+}
+
+async function handlePostPersonalPersistApproved(req: Request, res: Response, ctx: AgentRouterCtx): Promise<Response | void> {
+  try {
+    const body = req.body ?? {};
+    const approvedCandidateIds = optionalStringArray(
+      body.approved_candidate_ids ?? body.approvedCandidateIds,
+      'approved_candidate_ids',
+    );
+    if (!approvedCandidateIds) {
+      throw new AgentIntegrationError('approved_candidate_ids is required', 'INVALID_PAYLOAD', 400);
+    }
+
+    const service = createPersonalKnowledgeAgent(ctx);
+    const result = await service.persistApprovedCandidates({
+      candidates: requireCandidates(body.candidates),
+      approvedCandidateIds,
+      projectId: optionalString(body.project_id ?? body.projectId, 'project_id'),
+      ownerId: optionalOwnerId(body.owner_id ?? body.ownerId),
+      sessionId: optionalString(body.session_id ?? body.sessionId, 'session_id'),
+      processId: optionalString(body.process_id ?? body.processId, 'process_id'),
+    });
+
+    return res.json({
+      ok: true,
+      persistence: {
+        attempted: approvedCandidateIds.length > 0,
+        items: result.items,
+        persistedCount: result.persistedCount,
+        errorCount: result.errorCount,
+      },
+    });
+  } catch (error) {
+    return writeError(res, error);
+  }
+}
+
 async function handleCaptureSessionEvent(
   req: Request,
   res: Response,
@@ -1027,6 +1207,8 @@ export function createAgentRouter(
   router.get('/sessions', (req, res) => handleGetSessions(req, res, ctx));
   router.get('/sessions/aggregate', (_req, res) => handleGetSessionsAggregate(_req, res, ctx));
   router.get('/operations/status', (req, res) => handleGetOperationsStatus(req, res, ctx));
+  router.post('/personal\\:run', (req, res) => handlePostPersonalRun(req, res, ctx));
+  router.post('/personal\\:persist-approved', (req, res) => handlePostPersonalPersistApproved(req, res, ctx));
   router.post('/sessions', (req, res) => handlePostSessions(req, res, ctx));
   router.post('/observations:ingest', (req, res) => handlePostObservationsIngest(req, res, ctx));
   router.post('/transcripts/import', (req, res) => handlePostTranscriptsImport(req, res, ctx));


### PR DESCRIPTION
## Summary
- Add authenticated HTTP two-step personal Agent endpoints for run and approved persistence.
- Wire server services into the agent router so the personal Agent uses real ToolContext/RememberTool persistence.
- Document the host workflow and cover actual DB persistence with route tests.

## Test Plan
- npx vitest run packages/memento-server/src/server/routes/agent.routes.spec.ts packages/memento-server/src/server/routes/agent-personal.routes.spec.ts
- npm run type-check
- npm run lint (0 errors; existing warnings remain)
- git diff --check

Closes #390