### PR TITLE
fix(anchor-map): EmbeddingNotFoundError fallback 처리 및 clearSearch 슬롯 초기화 (#516)

### DIFF
--- a/packages/memento-core/src/domains/anchor/tools/search-local-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/search-local-tool.ts
@@ -105,8 +105,11 @@ export class SearchLocalTool extends BaseTool {
           anchor_info: searchResult.anchor_info
         });
       } catch (searchError: any) {
-        // 앵커가 없고 query가 있으면 fallback
-        if (query && searchError?.message?.includes('Anchor not found')) {
+        // 앵커가 없거나 앵커 메모리에 임베딩이 없으면 fallback
+        if (query && (
+          searchError?.message?.includes('Anchor not found') ||
+          searchError?.message?.includes('Embedding not found')
+        )) {
           if (!context.services.hybridSearchEngine) {
             throw new Error('HybridSearchEngine is not available for fallback');
           }

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -730,7 +730,7 @@ function clearSearch() {
   searchResults = null;
   highlightedNodeIds.clear();
   document.getElementById('search-query-input').value = '';
-  document.getElementById('search-slot-select').value = '';
+  document.getElementById('search-slot-select').value = 'A';
   
   // 노드 스타일 복원
   updateNodeHighlight();


### PR DESCRIPTION
## Summary

- **버그 1**: `search-local-tool.ts`의 catch 블록이 `'Anchor not found'`만 fallback 처리하여, 임베딩 없는 앵커로 검색 시 `EmbeddingNotFoundError`가 HTTP 500으로 반환되던 문제 수정 → `'Embedding not found'` 조건 추가
- **버그 2**: `clearSearch()`에서 `search-slot-select`를 빈 값(`''`)으로 초기화하여 이후 검색 시 "슬롯을 선택해주세요" alert 발생하던 문제 수정 → `'A'`로 초기화

## Changed Files

- `packages/memento-core/src/domains/anchor/tools/search-local-tool.ts` (L109)
- `static/js/anchor-map.js` (L733)

## Test Plan

- [ ] 임베딩 없는 메모리를 앵커로 설정 후 대시보드 검색 → 500 에러 없이 결과 반환 확인
- [ ] 검색 실행 → Clear 클릭 → 재검색 → "슬롯을 선택해주세요" alert 없이 정상 실행 확인

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)