### PR TITLE
chore(slop): ignore mcp-client examples in slop scan (#545)

### DIFF
--- a/.slopconfig.yaml
+++ b/.slopconfig.yaml
@@ -9,6 +9,7 @@ ignore:
   - "packages/**/src/test/**"
   - "packages/**/src/**/__tests__/**"
   - "packages/memento-server/src/test/**"
+  - "packages/mcp-client/examples/**"
   - "**/coverage/**"
   - "graphify-out/**"
   - "**/.next/**"


### PR DESCRIPTION
## Summary
- `.slopconfig.yaml`에 `packages/mcp-client/examples/**` ignore 패턴을 추가해 aggregate slop 스캔에서 예제 코드 노이즈를 제외합니다.
- `demo/.next`·`coverage`는 기존 `**/.next/**`·`**/coverage/**` 패턴으로 이미 aggregate에서 제외되어 있어 이번 PR 범위에서는 변경하지 않았습니다.

## 검증
- `slop-detector scan . --config .slopconfig.yaml`
  - Total Files: 652 → **647** (−5)
  - Weighted Deficit: 19.1 → **18.9** (CLEAN)
  - `packages/mcp-client/examples/**` triage 항목 **0건**

## Test plan
- [x] `slop-detector scan . --config .slopconfig.yaml` 재실행 — examples 미포함 확인
- [ ] (선택) CI advisory workflow `Slop detector (JS/TS)` — merge 필수 아님

Closes #545

Made with [Cursor](https://cursor.com)