### PR TITLE
feat(graph): add search and bounded full graph view

### DIFF
--- a/packages/memento-server/src/server/routes/admin.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/admin.routes.spec.ts
@@ -797,6 +797,92 @@ describe('admin.routes graph', () => {
       await new Promise<void>(r => server.close(() => r()));
     }
   });
+
+  it('GET /admin/graph?view=full — 기본 1000개 제한을 넘겨 축약 그래프를 반환한다', async () => {
+    const insert = db.prepare(`
+      INSERT INTO memory_item (id, content, type, importance) VALUES (?, ?, 'semantic', ?)
+    `);
+    const tx = db.transaction(() => {
+      for (let i = 0; i < 1100; i++) {
+        insert.run(`m${i}`, `전체 그래프 테스트 기억 ${i}`, 0.5);
+      }
+    });
+    tx();
+
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/graph?view=full');
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as {
+        nodes: unknown[];
+        meta: {
+          total_available_nodes: number;
+          graph_view: string;
+          fields: string;
+          default_limit: number;
+          max_limit: number;
+          truncated: boolean;
+        };
+      };
+      expect(body.nodes).toHaveLength(1100);
+      expect(body.meta.total_available_nodes).toBe(1100);
+      expect(body.meta.graph_view).toBe('full');
+      expect(body.meta.fields).toBe('minimal');
+      expect(body.meta.default_limit).toBe(5000);
+      expect(body.meta.max_limit).toBe(5000);
+      expect(body.meta.truncated).toBe(false);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/graph?view=full&fields=minimal — 긴 content를 축약해 대용량 응답을 완화한다', async () => {
+    const longContent = '긴 본문 '.repeat(120);
+    db.prepare(`INSERT INTO memory_item (id, content, type, importance) VALUES (?, ?, ?, ?)`).run(
+      'm-long', longContent, 'semantic', 0.9
+    );
+
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/graph?view=full&fields=minimal');
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body) as {
+        nodes: Array<{ content: string; content_truncated?: boolean }>;
+        meta: { fields: string };
+      };
+      expect(body.meta.fields).toBe('minimal');
+      expect(body.nodes[0].content.length).toBeLessThan(longContent.length);
+      expect(body.nodes[0].content_truncated).toBe(true);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/graph?view=full&limit=5001 — full 모드 상한 초과 시 400 반환', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/graph?view=full&limit=5001');
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res.body) as { error: string; message: string };
+      expect(body.error).toBe('잘못된 파라미터');
+      expect(body.message).toContain('1~5000');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  it('GET /admin/graph?view=full&fields=full — 대용량 본문 응답을 거부한다', async () => {
+    const { server, port } = await listen(makeApp(db));
+    try {
+      const res = await getAdmin(port, '/admin/graph?view=full&fields=full');
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res.body) as { error: string; message: string };
+      expect(body.error).toBe('잘못된 파라미터');
+      expect(body.message).toContain('fields=minimal');
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
 });
 
 // ============================================================

--- a/packages/memento-server/src/server/routes/admin/admin-graph-response.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-graph-response.ts
@@ -8,6 +8,7 @@ export interface GraphNode {
   id: string;
   label: string;
   content: string;
+  content_truncated?: boolean;
   type: 'episodic' | 'semantic' | 'procedural' | 'working';
   importance: number;
   created_at: string;
@@ -29,6 +30,8 @@ export interface GraphFilter {
   relation_types?: string[] | null;
   min_importance?: number;
   limit?: number;
+  view?: 'focused' | 'full';
+  fields?: 'full' | 'minimal';
 }
 
 export interface GraphResponse {
@@ -36,9 +39,14 @@ export interface GraphResponse {
   edges: GraphEdge[];
   meta: {
     total_nodes: number;
+    total_available_nodes: number;
     total_edges: number;
     applied_filters: GraphFilter;
     truncated: boolean;
+    graph_view: 'focused' | 'full';
+    fields: 'full' | 'minimal';
+    default_limit: number;
+    max_limit: number;
   };
 }
 
@@ -65,24 +73,36 @@ interface MemoryRelationRow {
  * FR-001~FR-003, FR-010~FR-012
  */
 export function buildGraphResponse(db: Database.Database, filters: GraphFilter): GraphResponse {
-  const limit = Math.min(filters.limit ?? 200, 1000); // FR-006: 기본 200
+  const graphView = filters.view ?? 'focused';
+  const fields = filters.fields ?? (graphView === 'full' ? 'minimal' : 'full');
+  const defaultLimit = graphView === 'full' ? 5000 : 200;
+  const maxLimit = graphView === 'full' ? 5000 : 1000;
+  const limit = Math.min(filters.limit ?? defaultLimit, maxLimit); // FR-006: 기본 200
   const minImportance = filters.min_importance ?? 0.0;
 
   let nodeQuery = `SELECT id, content, type, importance, created_at, tags, pinned FROM memory_item WHERE 1=1`;
+  let countQuery = `SELECT COUNT(*) AS count FROM memory_item WHERE 1=1`;
   const nodeParams: (string | number)[] = [];
+  const countParams: (string | number)[] = [];
 
   if (filters.types && filters.types.length > 0) {
     const placeholders = filters.types.map(() => '?').join(', ');
     nodeQuery += ` AND type IN (${placeholders})`;
+    countQuery += ` AND type IN (${placeholders})`;
     nodeParams.push(...filters.types);
+    countParams.push(...filters.types);
   }
 
   nodeQuery += ` AND COALESCE(importance, 0.5) >= ?`;
+  countQuery += ` AND COALESCE(importance, 0.5) >= ?`;
   nodeParams.push(minImportance);
+  countParams.push(minImportance);
 
   nodeQuery += ` ORDER BY COALESCE(importance, 0.5) DESC LIMIT ?`;
   nodeParams.push(limit + 1);
 
+  const countRow = db.prepare(countQuery).get(...countParams) as { count: number } | undefined;
+  const totalAvailableNodes = countRow?.count ?? 0;
   const rawNodes = db.prepare(nodeQuery).all(...nodeParams) as MemoryItemRow[];
   const truncated = rawNodes.length > limit;
   const nodeRows = truncated ? rawNodes.slice(0, limit) : rawNodes;
@@ -92,7 +112,10 @@ export function buildGraphResponse(db: Database.Database, filters: GraphFilter):
   const nodes: GraphNode[] = nodeRows.map(r => ({
     id: r.id,
     label: r.content.length > 50 ? r.content.slice(0, 50) + '...' : r.content,
-    content: r.content,
+    content: fields === 'minimal' && r.content.length > 280
+      ? r.content.slice(0, 280) + '...'
+      : r.content,
+    content_truncated: fields === 'minimal' && r.content.length > 280,
     type: r.type as GraphNode['type'],
     importance: r.importance ?? 0.5,
     created_at: r.created_at ?? new Date().toISOString(),
@@ -136,14 +159,21 @@ export function buildGraphResponse(db: Database.Database, filters: GraphFilter):
     edges,
     meta: {
       total_nodes: nodes.length,
+      total_available_nodes: totalAvailableNodes,
       total_edges: edges.length,
       applied_filters: {
         types: filters.types ?? null,
         relation_types: filters.relation_types ?? null,
         min_importance: minImportance,
         limit,
+        view: graphView,
+        fields,
       },
       truncated,
+      graph_view: graphView,
+      fields,
+      default_limit: defaultLimit,
+      max_limit: maxLimit,
     },
   };
 }

--- a/packages/memento-server/src/server/routes/admin/admin-graph.routes.ts
+++ b/packages/memento-server/src/server/routes/admin/admin-graph.routes.ts
@@ -21,6 +21,8 @@ export function registerAdminGraphRoute(router: Router, db: Database.Database | 
       const relationTypesRaw = req.query['relation_types'] as string | undefined;
       const minImportanceRaw = req.query['min_importance'] as string | undefined;
       const limitRaw = req.query['limit'] as string | undefined;
+      const viewRaw = req.query['view'] as string | undefined;
+      const fieldsRaw = req.query['fields'] as string | undefined;
 
       const filters: GraphFilter = {};
 
@@ -46,12 +48,34 @@ export function registerAdminGraphRoute(router: Router, db: Database.Database | 
         }
         filters.min_importance = val;
       }
+      if (viewRaw !== undefined) {
+        if (viewRaw !== 'focused' && viewRaw !== 'full') {
+          return res.status(400).json({ error: '잘못된 파라미터', message: 'view는 focused 또는 full이어야 합니다' });
+        }
+        filters.view = viewRaw;
+      }
+      if (fieldsRaw !== undefined) {
+        if (fieldsRaw !== 'full' && fieldsRaw !== 'minimal') {
+          return res.status(400).json({ error: '잘못된 파라미터', message: 'fields는 full 또는 minimal이어야 합니다' });
+        }
+        filters.fields = fieldsRaw;
+      }
       if (limitRaw !== undefined) {
         const val = parseInt(limitRaw, 10);
-        if (isNaN(val) || val < 1 || val > 1000) {
-          return res.status(400).json({ error: '잘못된 파라미터', message: 'limit은 1~1000 사이여야 합니다' });
+        const maxLimit = filters.view === 'full' ? 5000 : 1000;
+        if (isNaN(val) || val < 1 || val > maxLimit) {
+          return res.status(400).json({ error: '잘못된 파라미터', message: `limit은 1~${maxLimit} 사이여야 합니다` });
         }
         filters.limit = val;
+      }
+      if (filters.view === 'full' && filters.fields === undefined) {
+        filters.fields = 'minimal';
+      }
+      if (filters.view === 'full' && filters.fields === 'full') {
+        return res.status(400).json({
+          error: '잘못된 파라미터',
+          message: 'view=full은 대용량 응답 완화를 위해 fields=minimal만 지원합니다',
+        });
       }
 
       const graphData = buildGraphResponse(db, filters);

--- a/static/graph.html
+++ b/static/graph.html
@@ -177,6 +177,32 @@
       min-width: 28px;
     }
 
+    .search-row {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-xs);
+    }
+
+    #graph-search {
+      width: min(260px, 38vw);
+      min-width: 160px;
+    }
+
+    #graph-match-badge,
+    #graph-mode-hint {
+      display: none;
+      font-size: var(--font-size-xs);
+      color: var(--color-graph-text-muted);
+      white-space: nowrap;
+    }
+
+    #graph-match-badge {
+      border: 1px solid var(--color-border-graph);
+      border-radius: var(--radius-sm);
+      padding: 2px 7px;
+      background: var(--color-graph-surface-elevated);
+    }
+
     .main {
       display: flex;
       flex: 1;
@@ -416,6 +442,19 @@
       stroke-opacity: 0.55;
     }
 
+    .node.search-dim {
+      opacity: 0.18;
+    }
+
+    .node.search-match circle {
+      stroke: var(--color-graph-title);
+      stroke-width: 4;
+    }
+
+    .link.search-dim {
+      stroke-opacity: 0.12;
+    }
+
     /* Dashboard embed — Embedding Map 등 다른 탭과 동일한 라이트 패널 스타일 */
     .graph-view--embedded {
       --color-bg-graph: var(--color-bg-main);
@@ -457,7 +496,9 @@
 
     .graph-view--embedded .filter-group label,
     .graph-view--embedded .type-check,
-    .graph-view--embedded #importance-val {
+    .graph-view--embedded #importance-val,
+    .graph-view--embedded #graph-match-badge,
+    .graph-view--embedded #graph-mode-hint {
       color: var(--color-text-muted);
     }
 
@@ -505,6 +546,26 @@
         <input type="range" id="importance-slider" min="0" max="1" step="0.05" value="0">
         <span id="importance-val">0.0</span>
       </div>
+    </div>
+    <div class="filter-group graph-session-only">
+      <label for="graph-search">검색</label>
+      <div class="search-row">
+        <input
+          id="graph-search"
+          class="m-input"
+          type="search"
+          placeholder="키워드 또는 문장"
+          autocomplete="off"
+        >
+        <button id="search-btn" class="graph-action-button m-button m-button--secondary" type="button">검색</button>
+        <span id="graph-match-badge" aria-live="polite"></span>
+      </div>
+    </div>
+    <div class="filter-group graph-session-only">
+      <label class="type-check" title="본문을 축약한 전체 그래프 모드로 최대 5,000개 노드를 요청합니다.">
+        <input type="checkbox" id="full-graph-toggle"> 전체 로드
+      </label>
+      <span id="graph-mode-hint"></span>
     </div>
     <button id="apply-btn" class="graph-session-only graph-action-button m-button m-button--primary">필터 적용</button>
     <button id="reset-btn" class="graph-session-only graph-action-button m-button m-button--secondary">초기화</button>

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -57,6 +57,11 @@
     const impVal     = document.getElementById('importance-val');
     const applyBtn   = document.getElementById('apply-btn');
     const resetBtn   = document.getElementById('reset-btn');
+    const searchInput = document.getElementById('graph-search');
+    const searchBtn = document.getElementById('search-btn');
+    const matchBadge = document.getElementById('graph-match-badge');
+    const fullGraphToggle = document.getElementById('full-graph-toggle');
+    const graphModeHint = document.getElementById('graph-mode-hint');
 
     // ── 슬라이더 표시 ─────────────────────────────────────────
     impSlider.addEventListener('input', () => {
@@ -73,6 +78,10 @@
       }
       const imp = parseFloat(impSlider.value);
       if (imp > 0) params.set('min_importance', imp.toFixed(2));
+      if (fullGraphToggle.checked) {
+        params.set('view', 'full');
+        params.set('fields', 'minimal');
+      }
       const q = params.toString();
       return '/admin/graph' + (q ? '?' + q : '');
     }
@@ -84,6 +93,10 @@
     /** @type {unknown[] | null} */
     let lastGraphEdges = null;
     let resizeRedrawTimer = null;
+    let lastGraphMeta = null;
+    let activeSearchQuery = '';
+    let renderedNodeSelection = null;
+    let renderedLinkSelection = null;
 
     function renderGraph(nodes, edges) {
       const container = document.getElementById('graph-container');
@@ -140,6 +153,7 @@
         .attr('class', 'link')
         .attr('stroke', d => palette.edgeColors[d.relation_type] ?? palette.edgeColors.default)
         .attr('stroke-width', d => Math.max(1, (d.confidence ?? 1) * 3));
+      renderedLinkSelection = link;
 
       // 노드 그룹 (T013)
       const node = g.append('g')
@@ -163,9 +177,13 @@
               d.fx = null; d.fy = null;
             })
         );
+      renderedNodeSelection = node;
 
       node.append('circle')
-        .attr('r', d => rScale(d.importance))
+        .attr('r', d => {
+          d.__graphRadius = rScale(d.importance);
+          return d.__graphRadius;
+        })
         .attr('fill', d => getNodeFillColor(d.type, palette))
         .attr('stroke', d => getNodeStrokeColor(d.type, palette))
         // 마우스오버 툴팁 (T018)
@@ -191,6 +209,8 @@
         .attr('text-anchor', 'middle')
         .text(d => d.label.length > 18 ? d.label.slice(0, 18) + '…' : d.label);
 
+      applySearchHighlight();
+
       simulation.on('tick', () => {
         link
           .attr('x1', d => d.source.x)
@@ -202,12 +222,100 @@
       });
     }
 
+    function normalizeSearchText(value) {
+      return String(value ?? '').trim().toLocaleLowerCase('ko-KR');
+    }
+
+    function getSearchHaystack(node) {
+      return [
+        node.content,
+        node.summary,
+        node.label,
+        ...(Array.isArray(node.tags) ? node.tags : []),
+      ].map(value => String(value ?? '')).join(' ').toLocaleLowerCase('ko-KR');
+    }
+
+    function getNodeId(edgeEndpoint) {
+      return typeof edgeEndpoint === 'object' && edgeEndpoint !== null ? edgeEndpoint.id : edgeEndpoint;
+    }
+
+    function setMatchBadge(count, total) {
+      if (!activeSearchQuery) {
+        matchBadge.style.display = 'none';
+        matchBadge.textContent = '';
+        return;
+      }
+      matchBadge.textContent = `${count}개 노드 매칭`;
+      matchBadge.style.display = 'inline-block';
+      if (total > 0 && count === 0) {
+        matchBadge.textContent = '0개 노드 매칭';
+      }
+    }
+
+    function applySearchHighlight() {
+      const nodes = Array.isArray(lastGraphNodes) ? lastGraphNodes : [];
+      const query = normalizeSearchText(activeSearchQuery);
+      const hasQuery = query.length > 0;
+      const matchingIds = new Set();
+
+      if (hasQuery) {
+        for (const node of nodes) {
+          if (getSearchHaystack(node).includes(query)) {
+            matchingIds.add(node.id);
+          }
+        }
+      }
+
+      setMatchBadge(matchingIds.size, nodes.length);
+
+      if (!renderedNodeSelection || !renderedLinkSelection) {
+        return;
+      }
+
+      renderedNodeSelection
+        .classed('search-match', d => hasQuery && matchingIds.has(d.id))
+        .classed('search-dim', d => hasQuery && !matchingIds.has(d.id));
+
+      renderedNodeSelection.select('circle')
+        .attr('r', d => hasQuery && matchingIds.has(d.id)
+          ? (d.__graphRadius ?? 8) * 1.25
+          : (d.__graphRadius ?? 8));
+
+      renderedLinkSelection
+        .classed('search-dim', d => {
+          if (!hasQuery) return false;
+          return !matchingIds.has(getNodeId(d.source)) && !matchingIds.has(getNodeId(d.target));
+        });
+    }
+
+    function applySearchFromInput() {
+      activeSearchQuery = searchInput.value;
+      applySearchHighlight();
+    }
+
+    function updateGraphModeHint(meta) {
+      if (!meta) {
+        graphModeHint.style.display = 'none';
+        graphModeHint.textContent = '';
+        return;
+      }
+      const total = meta.total_available_nodes ?? meta.total_nodes ?? 0;
+      const shown = meta.total_nodes ?? 0;
+      const mode = meta.graph_view === 'full' ? '전체' : '기본';
+      const suffix = meta.truncated ? ` / ${total}개 중 ${shown}개 표시` : ` / ${shown}개 표시`;
+      graphModeHint.textContent = `${mode} 모드${suffix}`;
+      graphModeHint.style.display = 'inline';
+    }
+
     // ── 상세 패널 (T019, T020) ────────────────────────────────
     function showDetail(d) {
       const badgeClass = getTypeBadgeClass(d.type);
       const tagsHtml = (d.tags ?? []).length > 0
         ? `<div class="tag-list">${d.tags.map(t => `<span class="tag">${escHtml(t)}</span>`).join('')}</div>`
         : '<span class="detail-empty">없음</span>';
+      const contentNote = d.content_truncated
+        ? '<div class="detail-empty">전체 로드 모드에서는 본문이 축약됩니다.</div>'
+        : '';
 
       detailContent.innerHTML = `
         <div class="detail-row">
@@ -218,7 +326,7 @@
         </div>
         <div class="detail-row">
           <div class="detail-label">내용</div>
-          <div class="detail-value">${escHtml(d.content)}</div>
+          <div class="detail-value">${escHtml(d.content)}${contentNote}</div>
         </div>
         <div class="detail-row">
           <div class="detail-label">중요도</div>
@@ -275,6 +383,10 @@
       showLoading(true);
       lastGraphNodes = null;
       lastGraphEdges = null;
+      lastGraphMeta = null;
+      renderedNodeSelection = null;
+      renderedLinkSelection = null;
+      updateGraphModeHint(null);
       d3.select(svgEl).selectAll('*').remove();
       if (simulation) { simulation.stop(); simulation = null; }
 
@@ -284,8 +396,11 @@
         if (!res.ok) throw new Error(`서버 오류 ${res.status}`);
         const data = await res.json();
         showLoading(false);
+        lastGraphMeta = data.meta ?? null;
+        updateGraphModeHint(lastGraphMeta);
 
         if (!data.nodes || data.nodes.length === 0) {
+          applySearchHighlight();
           showEmpty(true);
           return;
         }
@@ -303,12 +418,31 @@
     }
 
     // ── 이벤트 바인딩 ─────────────────────────────────────────
-    applyBtn.addEventListener('click', () => loadGraph(buildUrl()));
+    applyBtn.addEventListener('click', () => {
+      activeSearchQuery = searchInput.value;
+      loadGraph(buildUrl());
+    });
+    searchBtn.addEventListener('click', applySearchFromInput);
+    searchInput.addEventListener('keydown', event => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        applySearchFromInput();
+      }
+    });
+    searchInput.addEventListener('input', () => {
+      if (searchInput.value.trim() === '' && activeSearchQuery !== '') {
+        activeSearchQuery = '';
+        applySearchHighlight();
+      }
+    });
 
     resetBtn.addEventListener('click', () => {
       document.querySelectorAll('.type-check input').forEach(el => { el.checked = true; });
       impSlider.value = '0';
       impVal.textContent = '0.0';
+      searchInput.value = '';
+      activeSearchQuery = '';
+      fullGraphToggle.checked = false;
       loadGraph('/admin/graph');
     });
 


### PR DESCRIPTION
## Summary
- Add /graph search input with loaded-node highlighting, dimming, and match-count badge for issue #149.
- Add bounded full graph mode via view=full&fields=minimal with 5,000-node cap and response metadata for issue #151.
- Keep full mode minimal-only to avoid oversized JSON responses while exposing broader topology.

## Validation
- npx vitest run packages/memento-server/src/server/routes/admin.routes.spec.ts --no-file-parallelism
- npm run lint:js
- npm run lint:ts (passes with existing warnings)
- npm run type-check
- git diff --check

Closes #149
Closes #151