### PR TITLE
feat(tune-weights): NDCG/Recall 유의성 검정 추가 및 composite score 타이브레이커 개선

### DIFF
--- a/scripts/compare-weight-profiles.ts
+++ b/scripts/compare-weight-profiles.ts
@@ -58,6 +58,8 @@ export interface ProfileEvalResult {
   latency_ms: number[];
   p95_latency_ms: number;
   rr: number[];
+  ndcg_at_10_per_query: number[];
+  recall_at_10_per_query: number[];
 }
 
 export function calcP95(latencyMs: number[]): number {
@@ -156,16 +158,24 @@ export async function evaluateProfile(
   let recall10 = 0;
   let emptyCount = 0;
   const ndcgDenom = groundTruths.length;
+  const ndcgAt10PerQuery: number[] = [];
+  const recallAt10PerQuery: number[] = [];
 
   for (const gt of groundTruths) {
     const results = queryResults.get(gt.queryId) ?? [];
     if (results.length === 0) {
       emptyCount++;
+      ndcgAt10PerQuery.push(0);
+      recallAt10PerQuery.push(0);
       continue;
     }
+    const q10 = calculateNDCGAtK(results, gt.relevantIds, 10);
+    const r10 = calculateRecallAtK(results, gt.relevantIds, 10);
     ndcg5 += calculateNDCGAtK(results, gt.relevantIds, 5);
-    ndcg10 += calculateNDCGAtK(results, gt.relevantIds, 10);
-    recall10 += calculateRecallAtK(results, gt.relevantIds, 10);
+    ndcg10 += q10;
+    recall10 += r10;
+    ndcgAt10PerQuery.push(q10);
+    recallAt10PerQuery.push(r10);
   }
 
   return {
@@ -177,6 +187,8 @@ export async function evaluateProfile(
     latency_ms: latencyMs,
     p95_latency_ms: calcP95(latencyMs),
     rr,
+    ndcg_at_10_per_query: ndcgAt10PerQuery,
+    recall_at_10_per_query: recallAt10PerQuery,
   };
 }
 

--- a/scripts/tune-weights.ts
+++ b/scripts/tune-weights.ts
@@ -102,6 +102,28 @@ export function compositeScore(
 
 const LATENCY_BUDGET_MS = 2000;
 const NDCG_REGRESSION_THRESHOLD = 0.05;
+const COMPOSITE_EPSILON = 1e-4;
+
+type CandidateRecord = {
+  candidate_index: number;
+  weights: RankingWeights;
+  result: ProfileEvalResult;
+  composite_score: number;
+  gate_passed: boolean;
+  gate_reject_reason?: string;
+  sum_warning: boolean;
+};
+
+function selectBest(passed: CandidateRecord[]): CandidateRecord | null {
+  if (passed.length === 0) return null;
+  return passed.reduce((a, b) => {
+    const diff = b.composite_score - a.composite_score;
+    if (Math.abs(diff) > COMPOSITE_EPSILON) return diff > 0 ? b : a;
+    const ndcgDiff = b.result.ndcg_at_10 - a.result.ndcg_at_10;
+    if (Math.abs(ndcgDiff) > COMPOSITE_EPSILON) return ndcgDiff > 0 ? b : a;
+    return b.result.mrr > a.result.mrr ? b : a;
+  });
+}
 
 async function main(): Promise<void> {
   const args = parseTuneArgs(process.argv.slice(2));
@@ -124,16 +146,6 @@ async function main(): Promise<void> {
   try {
     const baseline = await evaluateProfile(db, baselineProfilePath, args.benchmarkDir);
     const baselineScore = compositeScore(baseline, baseline);
-
-    type CandidateRecord = {
-      candidate_index: number;
-      weights: RankingWeights;
-      result: ProfileEvalResult;
-      composite_score: number;
-      gate_passed: boolean;
-      gate_reject_reason?: string;
-      sum_warning: boolean;
-    };
 
     const results: CandidateRecord[] = [];
     let candidatesWithSumWarning = 0;
@@ -178,10 +190,7 @@ async function main(): Promise<void> {
     }
 
     const passed = results.filter((r) => r.gate_passed);
-    const best =
-      passed.length > 0
-        ? passed.reduce((a, b) => (a.composite_score > b.composite_score ? a : b))
-        : null;
+    const best = selectBest(passed);
 
     let mrrPValue = 1;
     let mrrSignificant = false;
@@ -198,6 +207,33 @@ async function main(): Promise<void> {
         : 'inconclusive';
     } else {
       mrrVerdict = 'no_candidates_passed_gate';
+    }
+
+    let ndcgPValue = 1;
+    let ndcgSignificant = false;
+    let ndcgVerdict: string;
+
+    let recallPValue = 1;
+    let recallSignificant = false;
+    let recallVerdict: string;
+
+    if (best) {
+      const ndcgPVal = pairedPermutationPValue(best.result.ndcg_at_10_per_query, baseline.ndcg_at_10_per_query, 1000);
+      ndcgPValue = ndcgPVal;
+      ndcgSignificant = ndcgPVal < 0.05;
+      ndcgVerdict = ndcgSignificant
+        ? best.result.ndcg_at_10 > baseline.ndcg_at_10 ? 'best_better' : 'baseline_better'
+        : 'inconclusive';
+
+      const recallPVal = pairedPermutationPValue(best.result.recall_at_10_per_query, baseline.recall_at_10_per_query, 1000);
+      recallPValue = recallPVal;
+      recallSignificant = recallPVal < 0.05;
+      recallVerdict = recallSignificant
+        ? best.result.recall_at_10 > baseline.recall_at_10 ? 'best_better' : 'baseline_better'
+        : 'inconclusive';
+    } else {
+      ndcgVerdict = 'no_candidates_passed_gate';
+      recallVerdict = 'no_candidates_passed_gate';
     }
 
     const sortedByScore = [...results].sort((a, b) => b.composite_score - a.composite_score);
@@ -227,6 +263,12 @@ async function main(): Promise<void> {
       mrr_p_value: mrrPValue,
       mrr_significant: mrrSignificant,
       mrr_verdict: mrrVerdict,
+      ndcg_p_value: ndcgPValue,
+      ndcg_significant: ndcgSignificant,
+      ndcg_verdict: ndcgVerdict,
+      recall_p_value: recallPValue,
+      recall_significant: recallSignificant,
+      recall_verdict: recallVerdict,
       top_candidates: topCandidates,
     };
 


### PR DESCRIPTION
## Summary

- `ProfileEvalResult`에 `ndcg_at_10_per_query`, `recall_at_10_per_query` per-query 배열 추가
- `tune-weights` summary.json에 NDCG/Recall paired permutation test 결과 추가
  - `ndcg_p_value`, `ndcg_significant`, `ndcg_verdict`
  - `recall_p_value`, `recall_significant`, `recall_verdict`
- `COMPOSITE_EPSILON(1e-4)` 기반 `selectBest` 함수로 레이턴시 노이즈 타이브레이커 제거
  - composite score 차이 epsilon 미만이면 NDCG → MRR 순으로 타이브레이크
- `CandidateRecord` 타입 모듈 레벨로 승격

## Test plan

- [ ] `npm run quality:benchmark:tune-weights` 실행 시 summary.json에 `ndcg_verdict`, `recall_verdict` 필드 존재 확인
- [ ] `compare-weight-profiles.ts` 관련 기존 테스트 통과 확인

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)