### PR TITLE
feat(benchmark): 오프라인 벤치마크에 mock 임베딩 provider 추가

### DIFF
--- a/packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts
+++ b/packages/memento-core/src/domains/embedding/providers/embedding-provider-factory.ts
@@ -15,6 +15,7 @@ import { MiniLMEmbeddingService } from '../services/minilm-embedding-service.js'
 import { LightweightEmbeddingService } from '../services/lightweight-embedding-service.js';
 import { GeminiEmbeddingService } from '../services/gemini-embedding-service.js';
 import { OpenAIEmbeddingService } from '../services/openai-embedding-service.js';
+import { MockEmbeddingService } from '../services/mock-embedding-service.js';
 import { ModelAvailabilityService } from './model-availability-service.js';
 
 /**
@@ -53,6 +54,7 @@ export class EmbeddingProviderFactory {
     this.providers.set('tfidf', this.createService('tfidf'));
     this.providers.set('gemini', this.createService('gemini'));
     this.providers.set('openai', this.createService('openai'));
+    this.providers.set('mock', this.createService('mock'));
   }
 
   /**
@@ -115,6 +117,16 @@ export class EmbeddingProviderFactory {
       priority: 1,
       cost: 'paid',
       performance: 'high'
+    });
+
+    // Mock (오프라인 벤치마크 전용, 항상 사용 가능)
+    const mock = this.providers.get('mock');
+    providerInfos.push({
+      name: 'mock',
+      available: this.resolveAvailability('mock', mock, this.availabilityService.getLastStatus('mock')),
+      priority: 99,
+      cost: 'free',
+      performance: 'low'
     });
 
     return providerInfos.sort((a, b) => a.priority - b.priority);
@@ -223,6 +235,8 @@ export class EmbeddingProviderFactory {
         return 'gemini';
       case 'lightweight':
         return 'tfidf';
+      case 'mock':
+        return 'mock';
       default:
         return null;
     }
@@ -263,6 +277,8 @@ export class EmbeddingProviderFactory {
         return new GeminiEmbeddingService();
       case 'openai':
         return new OpenAIEmbeddingService();
+      case 'mock':
+        return new MockEmbeddingService();
       default:
         return new LightweightEmbeddingService();
     }

--- a/packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts
+++ b/packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts
@@ -1,0 +1,74 @@
+/**
+ * Mock 임베딩 서비스
+ * 오프라인 벤치마크 전용 - 결정론적 해시 기반 벡터 생성
+ * API 호출 없이 콘텐츠에 따라 구별 가능한 벡터를 생성하여 alpha 가중치 효과를 검증
+ */
+
+import type {
+  EmbeddingResult,
+  EmbeddingServiceInterface,
+  SimilarityResult,
+  EmbeddingData,
+} from '../../../shared/types/embedding.types.js';
+
+export const MOCK_EMBEDDING_DIMENSIONS = 64;
+
+/**
+ * 결정론적 해시 함수 (seed 기반)
+ * 동일한 입력에 대해 항상 동일한 결과를 반환
+ */
+function deterministicHash(text: string, seed: number): number {
+  let h = seed;
+  for (let i = 0; i < text.length; i++) {
+    h = Math.imul(h ^ text.charCodeAt(i), 0x9e3779b9);
+    h ^= h >>> 16;
+  }
+  return h >>> 0;
+}
+
+/**
+ * 텍스트로부터 결정론적 단위 벡터를 생성
+ */
+function generateMockEmbedding(text: string): number[] {
+  const vec: number[] = [];
+  for (let i = 0; i < MOCK_EMBEDDING_DIMENSIONS; i++) {
+    const h = deterministicHash(text, i + 1);
+    vec.push((h / 0xffffffff) * 2 - 1);
+  }
+  const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0)) || 1;
+  return vec.map(v => v / norm);
+}
+
+export class MockEmbeddingService implements EmbeddingServiceInterface {
+  async generateEmbedding(text: string): Promise<EmbeddingResult | null> {
+    return {
+      embedding: generateMockEmbedding(text),
+      model: 'mock',
+      provider: 'mock',
+      usage: { prompt_tokens: 0, total_tokens: 0 },
+    };
+  }
+
+  async searchSimilar(
+    query: string,
+    embeddings: EmbeddingData[],
+    _limit?: number,
+    _threshold?: number
+  ): Promise<SimilarityResult[]> {
+    const qVec = generateMockEmbedding(query);
+    return embeddings
+      .map(e => {
+        const dot = e.embedding.reduce((s, v, i) => s + v * (qVec[i] ?? 0), 0);
+        return { id: e.id, content: e.content, similarity: dot, score: dot };
+      })
+      .sort((a, b) => b.score - a.score);
+  }
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  getModelInfo(): { model: string; dimensions: number; maxTokens: number } {
+    return { model: 'mock', dimensions: MOCK_EMBEDDING_DIMENSIONS, maxTokens: 0 };
+  }
+}

--- a/packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts
+++ b/packages/memento-core/src/domains/embedding/services/vector-compatibility-service.ts
@@ -33,7 +33,8 @@ export class VectorCompatibilityService {
     lightweight: 384,
     minilm: 384,
     openai: 1536,
-    gemini: 768
+    gemini: 768,
+    mock: 64 // MockEmbeddingService는 64차원을 생성
   };
 
   /**

--- a/packages/memento-core/src/domains/memory/services/memory-embedding-service.ts
+++ b/packages/memento-core/src/domains/memory/services/memory-embedding-service.ts
@@ -517,6 +517,7 @@ export class MemoryEmbeddingService {
       case 'minilm':
       case 'openai':
       case 'gemini':
+      case 'mock':
         return normalized as EmbeddingProvider;
       default:
         return this.defaultProvider;
@@ -534,6 +535,7 @@ export class MemoryEmbeddingService {
             WHEN model LIKE '%minilm%' THEN 'minilm'
             WHEN model LIKE '%openai%' THEN 'openai'
             WHEN model LIKE '%gemini%' THEN 'gemini'
+            WHEN model = 'mock' THEN 'mock'
             ELSE ?
           END
         ),

--- a/packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts
+++ b/packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts
@@ -30,13 +30,14 @@ export class VectorPerformanceRepositoryImpl implements VectorPerformanceReposit
 
     try {
       const tableStatement = this.db.prepare(`
-        SELECT name FROM sqlite_master 
+        SELECT name FROM sqlite_master
         WHERE type='table' AND name IN (
           'memory_item_vec',
           'memory_item_vec_tfidf',
-          'memory_item_vec_minilm', 
+          'memory_item_vec_minilm',
           'memory_item_vec_openai',
-          'memory_item_vec_gemini'
+          'memory_item_vec_gemini',
+          'memory_item_vec_mock'
         )
       `);
       const tableRows = typeof tableStatement.all === 'function'

--- a/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
+++ b/packages/memento-core/src/domains/search/repositories/vector-search.repository.ts
@@ -74,7 +74,8 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
             'memory_item_vec_tfidf',
             'memory_item_vec_minilm',
             'memory_item_vec_openai',
-            'memory_item_vec_gemini'
+            'memory_item_vec_gemini',
+            'memory_item_vec_mock'
           )
         LIMIT 1
       `);
@@ -92,7 +93,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
 
       // tfidf 기본 resolve 한 번만 preflight하면 다른 provider 전용 vec 테이블만 있는 DB에서
       // isVecAvailable이 false로 고정되는 회귀가 생길 수 있음(issue #278 review).
-      const vecProbeProviders = ['tfidf', 'lightweight', 'minilm', 'openai', 'gemini'] as const;
+      const vecProbeProviders = ['tfidf', 'lightweight', 'minilm', 'openai', 'gemini', 'mock'] as const;
       let lastError: string | undefined;
 
       for (const probeProvider of vecProbeProviders) {
@@ -788,6 +789,7 @@ export class VectorSearchRepositoryImpl implements VectorSearchRepository {
       memory_item_vec_minilm: providerDimensions.minilm ?? defaultDimensions,
       memory_item_vec_openai: providerDimensions.openai ?? defaultDimensions,
       memory_item_vec_gemini: providerDimensions.gemini ?? defaultDimensions,
+      memory_item_vec_mock: providerDimensions.mock ?? 64,
     };
     return schemaByTable[tableName] ?? defaultDimensions;
   }

--- a/packages/memento-core/src/infrastructure/database/database/schema.sql
+++ b/packages/memento-core/src/infrastructure/database/database/schema.sql
@@ -333,29 +333,35 @@ CREATE VIRTUAL TABLE IF NOT EXISTS memory_item_vec_tfidf USING vec0(embedding fl
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_item_vec_minilm USING vec0(embedding float[384]);
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_item_vec_openai USING vec0(embedding float[1536]);
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_item_vec_gemini USING vec0(embedding float[768]);
+-- Mock 임베딩 제공자 (오프라인 벤치마크 전용, 결정론적 64차원 해시 벡터)
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_item_vec_mock USING vec0(embedding float[64]);
 
 -- VEC 테이블 트리거 (임베딩이 생성될 때 자동으로 VEC 테이블에 추가)
 -- 제공자별 테이블에 저장하도록 수정
 CREATE TRIGGER IF NOT EXISTS memory_embedding_vec_insert AFTER INSERT ON memory_embedding BEGIN
-  INSERT INTO memory_item_vec(rowid, embedding) 
+  INSERT INTO memory_item_vec(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.dimensions = 384;
-  
-  INSERT INTO memory_item_vec_tfidf(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_tfidf(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'tfidf' AND NEW.dimensions = 512 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_minilm(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_minilm(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'minilm' AND NEW.dimensions = 384 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_openai(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_openai(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'openai' AND NEW.dimensions = 1536 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_gemini(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_gemini(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'gemini' AND NEW.dimensions = 768 AND NEW.projection_type = 'native';
+
+  INSERT INTO memory_item_vec_mock(rowid, embedding)
+  SELECT NEW.id, json_extract(NEW.embedding, '$')
+  WHERE NEW.embedding_provider = 'mock' AND NEW.dimensions = 64 AND NEW.projection_type = 'native';
 END;
 
 CREATE TRIGGER IF NOT EXISTS memory_embedding_vec_update AFTER UPDATE ON memory_embedding BEGIN
@@ -364,26 +370,31 @@ CREATE TRIGGER IF NOT EXISTS memory_embedding_vec_update AFTER UPDATE ON memory_
   DELETE FROM memory_item_vec_minilm WHERE rowid = NEW.id;
   DELETE FROM memory_item_vec_openai WHERE rowid = NEW.id;
   DELETE FROM memory_item_vec_gemini WHERE rowid = NEW.id;
+  DELETE FROM memory_item_vec_mock WHERE rowid = NEW.id;
 
-  INSERT INTO memory_item_vec(rowid, embedding) 
+  INSERT INTO memory_item_vec(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.dimensions = 384;
-  
-  INSERT INTO memory_item_vec_tfidf(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_tfidf(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'tfidf' AND NEW.dimensions = 512 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_minilm(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_minilm(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'minilm' AND NEW.dimensions = 384 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_openai(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_openai(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'openai' AND NEW.dimensions = 1536 AND NEW.projection_type = 'native';
-  
-  INSERT INTO memory_item_vec_gemini(rowid, embedding) 
+
+  INSERT INTO memory_item_vec_gemini(rowid, embedding)
   SELECT NEW.id, json_extract(NEW.embedding, '$')
   WHERE NEW.embedding_provider = 'gemini' AND NEW.dimensions = 768 AND NEW.projection_type = 'native';
+
+  INSERT INTO memory_item_vec_mock(rowid, embedding)
+  SELECT NEW.id, json_extract(NEW.embedding, '$')
+  WHERE NEW.embedding_provider = 'mock' AND NEW.dimensions = 64 AND NEW.projection_type = 'native';
 END;
 
 CREATE TRIGGER IF NOT EXISTS memory_embedding_vec_delete AFTER DELETE ON memory_embedding BEGIN
@@ -392,6 +403,7 @@ CREATE TRIGGER IF NOT EXISTS memory_embedding_vec_delete AFTER DELETE ON memory_
   DELETE FROM memory_item_vec_minilm WHERE rowid = OLD.id;
   DELETE FROM memory_item_vec_openai WHERE rowid = OLD.id;
   DELETE FROM memory_item_vec_gemini WHERE rowid = OLD.id;
+  DELETE FROM memory_item_vec_mock WHERE rowid = OLD.id;
 END;
 
 -- Core Memory 테이블 (MIRIX Schema Expansion v2.0)

--- a/packages/memento-core/src/shared/config/vector-search.config.ts
+++ b/packages/memento-core/src/shared/config/vector-search.config.ts
@@ -15,14 +15,16 @@ export const VECTOR_SEARCH_CONFIG: VectorSearchConfig = {
     tfidf: 'memory_item_vec_tfidf',
     minilm: 'memory_item_vec_minilm',
     openai: 'memory_item_vec_openai',
-    gemini: 'memory_item_vec_gemini'
+    gemini: 'memory_item_vec_gemini',
+    mock: 'memory_item_vec_mock'
   },
   providerDimensions: {
     lightweight: 384,
     tfidf: 512,
     minilm: 384,
     openai: 1536,
-    gemini: 768
+    gemini: 768,
+    mock: 64
   }
 } as const;
 
@@ -31,7 +33,8 @@ export const VECTOR_SEARCH_PROVIDERS = {
   TFIDF: 'tfidf',
   MINILM: 'minilm',
   OPENAI: 'openai',
-  GEMINI: 'gemini'
+  GEMINI: 'gemini',
+  MOCK: 'mock'
 } as const;
 
 export const VECTOR_SEARCH_DEFAULTS = {

--- a/packages/memento-core/src/shared/types/benchmark.types.ts
+++ b/packages/memento-core/src/shared/types/benchmark.types.ts
@@ -5,10 +5,11 @@
 import type { EmbeddingProvider } from './embedding.types.js';
 
 /**
- * benchmark-v3 오프라인 시드(createSeededBenchmarkDatabase)는 TF-IDF 벡터만 저장한다.
+ * benchmark-v3 오프라인 시드(createSeededBenchmarkDatabase)는 TF-IDF + mock 벡터를 저장한다.
  * 하이브리드 검색 시 쿼리 임베딩도 동일 provider로 고정해 환경의 EMBEDDING_PROVIDER와 무관하게 결정론적 베이스라인을 만든다.
+ * mock provider는 콘텐츠 기반 해시 벡터로 TF-IDF와 상관관계가 낮아 alpha 가중치 조정 효과를 측정할 수 있다.
  */
-export const BENCHMARK_OFFLINE_VECTOR_PROVIDER_FILTER: EmbeddingProvider[] = ['tfidf'];
+export const BENCHMARK_OFFLINE_VECTOR_PROVIDER_FILTER: EmbeddingProvider[] = ['tfidf', 'mock'];
 
 export type MacroCategory =
   | 'episodic_recent'

--- a/packages/memento-core/src/shared/types/embedding.types.ts
+++ b/packages/memento-core/src/shared/types/embedding.types.ts
@@ -64,7 +64,7 @@ export interface EmbeddingServiceInterface {
 /**
  * 임베딩 제공자 타입
  */
-export type EmbeddingProvider = 'tfidf' | 'lightweight' | 'minilm' | 'openai' | 'gemini';
+export type EmbeddingProvider = 'tfidf' | 'lightweight' | 'minilm' | 'openai' | 'gemini' | 'mock';
 
 /**
  * 임베딩 제공자 정보

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -222,7 +222,7 @@ export interface SearchRankingWeights {
   duplication_penalty: number; // ε = 0.15
 }
 
-export type EmbeddingProvider = 'tfidf' | 'lightweight' | 'minilm' | 'openai' | 'gemini';
+export type EmbeddingProvider = 'tfidf' | 'lightweight' | 'minilm' | 'openai' | 'gemini' | 'mock';
 export type LLMProvider = 'openai' | 'gemini' | 'ollama' | 'auto';
 
 /**

--- a/packages/memento-core/src/shared/utils/configuration-validator.ts
+++ b/packages/memento-core/src/shared/utils/configuration-validator.ts
@@ -35,7 +35,8 @@ const providerRequirements: Record<EmbeddingProvider, ProviderRequirement> = {
   lightweight: {},
   minilm: {},
   openai: { requiresKey: true, keyField: 'openaiApiKey' },
-  gemini: { requiresKey: true, keyField: 'geminiApiKey' }
+  gemini: { requiresKey: true, keyField: 'geminiApiKey' },
+  mock: {}
 };
 
 function issue(level: ValidationLevel, code: string, message: string, suggestion?: string): ConfigValidationIssue {

--- a/packages/memento-core/src/test/helpers/benchmark-search-database.ts
+++ b/packages/memento-core/src/test/helpers/benchmark-search-database.ts
@@ -126,4 +126,16 @@ async function seedOneCorpusRow(
         'TF-IDF health check must pass; do not rely on process.env after startup.'
     );
   }
+
+  /** mock 임베딩도 저장: TF-IDF와 랭킹 상관관계가 낮아 alpha 가중치 효과를 측정 가능하게 함 */
+  const mockEmb = await embeddingService.createAndStoreEmbedding(db, id, entry.content, type, 'mock');
+  if (!mockEmb) {
+    throw new Error(`Failed to create mock embedding for benchmark memory ${id}`);
+  }
+  const mockProviderUsed = String(mockEmb.provider ?? '').toLowerCase();
+  if (mockProviderUsed !== 'mock') {
+    throw new Error(
+      `Benchmark corpus seed must store mock embeddings with provider='mock' (got "${mockEmb.provider}").`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- `EmbeddingProvider` 타입에 `'mock'` 추가
- `MockEmbeddingService` 신규 구현 (64차원 결정론적 해시 벡터, API 호출 없음)
- `EmbeddingProviderFactory`에 mock provider 등록
- `schema.sql`에 `memory_item_vec_mock` 가상 테이블 및 INSERT/UPDATE/DELETE 트리거 추가
- `BENCHMARK_OFFLINE_VECTOR_PROVIDER_FILTER`를 `['tfidf', 'mock']`로 변경
- benchmark seed 시 tfidf + mock 두 임베딩 모두 저장하도록 변경

## Why

기존 벤치마크는 TF-IDF 임베딩만 사용해 `alpha`(벡터 유사도 가중치) 변경 시 랭킹 변화가 없었음. mock 벡터는 콘텐츠 해시 기반으로 TF-IDF BM25와 상관관계가 낮아, alpha 조정 시 실질적으로 다른 랭킹을 만들어 tune-weights 탐색 공간을 활성화함.

## Test plan

- [ ] `npm run quality:benchmark:tune-weights`에서 alpha 값 변화에 따라 검색 순위 변화 확인
- [ ] 기존 embedding 관련 테스트 통과 확인
- [ ] `benchmark-search-database.spec.ts` 통과 확인

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)