### PR TITLE
refactor(server): agent.routes.ts 나머지 god function 4개 분리

### DIFF
--- a/packages/memento-server/src/server/routes/agent.routes.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.ts
@@ -678,92 +678,162 @@ async function handlePostSessions(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Batch ingest helpers
+// ---------------------------------------------------------------------------
+
+interface BatchPrepResult {
+  prepared?: ReturnType<typeof prepareEvent>;
+  errorResult?: { event_id: string; status: string; reason_code: string; late_arrival: boolean };
+}
+
+function prepareBatchEvent(item: unknown): BatchPrepResult {
+  try {
+    return { prepared: prepareEvent(item) };
+  } catch (error) {
+    const eventId =
+      item && typeof item === 'object' && 'event_id' in item
+      && typeof (item as { event_id?: unknown }).event_id === 'string'
+        ? (item as { event_id: string }).event_id
+        : '';
+    if (error instanceof AgentIntegrationError) {
+      return { errorResult: { event_id: eventId, status: 'INVALID', reason_code: error.reasonCode, late_arrival: false } };
+    }
+    return { errorResult: { event_id: eventId, status: 'DEGRADED', reason_code: 'INTERNAL_ERROR', late_arrival: false } };
+  }
+}
+
+function captureOneBatchEvent(
+  service: InstanceType<typeof AgentLifecycleService>,
+  prepared: ReturnType<typeof prepareEvent>,
+): object {
+  try {
+    const result = service.capture(prepared);
+    return {
+      event_id: result.eventId,
+      status: result.status,
+      reason_code: result.reasonCode,
+      observation_id: result.observationId,
+      late_arrival: result.lateArrival,
+    };
+  } catch (error) {
+    if (error instanceof AgentIntegrationError && error.reasonCode === 'IDEMPOTENCY_CONFLICT') {
+      throw error;
+    }
+    if (error instanceof AgentIntegrationError) {
+      return { event_id: prepared.eventId, status: 'INVALID', reason_code: error.reasonCode, late_arrival: false };
+    }
+    return { event_id: prepared.eventId, status: 'DEGRADED', reason_code: 'INTERNAL_ERROR', late_arrival: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Personal agent body helper
+// ---------------------------------------------------------------------------
+
+function parsePersonalRunBody(body: Record<string, unknown>) {
+  return {
+    userMessage: requireString(body.user_message ?? body.userMessage, 'user_message'),
+    projectId: optionalString(body.project_id ?? body.projectId, 'project_id'),
+    ownerId: optionalOwnerId(body.owner_id ?? body.ownerId),
+    sessionId: optionalString(body.session_id ?? body.sessionId, 'session_id'),
+    tokenBudget: optionalPositiveInteger(body.token_budget ?? body.tokenBudget, 'token_budget'),
+    maxMemories: optionalPositiveInteger(body.max_memories ?? body.maxMemories, 'max_memories'),
+    memoryTypes: optionalMemoryTypes(body.memory_types ?? body.memoryTypes),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Capture session event helpers
+// ---------------------------------------------------------------------------
+
+async function maybePreCompactInjection(
+  ctx: AgentRouterCtx,
+  prepared: ReturnType<typeof prepareEvent>,
+  payload: Record<string, unknown>,
+  tokenBudget: number,
+): Promise<AgentContextInjectionBundle | null> {
+  if (!ctx.injectionService) return null;
+  return ctx.buildInjection({
+    trigger: 'pre_compact',
+    query: typeof payload.context_summary === 'string' ? payload.context_summary : '',
+    scope: injectionScope(prepared),
+    tokenBudget,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Provenance detail helpers
+// ---------------------------------------------------------------------------
+
+function resolveProvenanceFilter(
+  query: Request['query'],
+): { memoryId: string | undefined; observationId: string | undefined } {
+  return {
+    memoryId: typeof query.memory_id === 'string' ? query.memory_id : undefined,
+    observationId: typeof query.observation_id === 'string' ? query.observation_id : undefined,
+  };
+}
+
+function loadProvenanceMemories(
+  db: Database.Database,
+  edges: ReadonlyArray<{ memoryId: string; sourceDeleted?: boolean | null }>,
+) {
+  const stmt = db.prepare(`
+    SELECT id, type, substr(content, 1, 240) AS content_preview, created_at
+    FROM memory_item
+    WHERE id = ?
+  `);
+  const memoryIds = [...new Set(edges.map(e => e.memoryId))];
+  return memoryIds.flatMap((id) => {
+    const row = stmt.get(id) as {
+      id: string; type: string; content_preview: string; created_at: string | null;
+    } | undefined;
+    return row ? [{ ...row, source_deleted: edges.some(e => e.memoryId === id && e.sourceDeleted) }] : [];
+  });
+}
+
+function loadProvenanceObservations(
+  repository: InstanceType<typeof SqliteAgentIntegrationRepository>,
+  edges: ReadonlyArray<{ observationId?: string | null }>,
+) {
+  const observationIds = [...new Set(edges.flatMap(e => e.observationId ? [e.observationId] : []))];
+  return observationIds.flatMap((id) => {
+    const observation = repository.getObservation(id);
+    return observation ? [observationDto(observation)] : [];
+  });
+}
+
+function loadProvenanceSessions(
+  service: InstanceType<typeof AgentLifecycleService>,
+  edges: ReadonlyArray<{ sessionId?: string | null }>,
+) {
+  const sessionIds = [...new Set(edges.flatMap(e => e.sessionId ? [e.sessionId] : []))];
+  return sessionIds.flatMap((id) => {
+    const session = service.getSession(id);
+    return session ? [sessionDto(session)] : [];
+  });
+}
+
 function handlePostObservationsIngest(req: Request, res: Response, ctx: AgentRouterCtx): Response {
   try {
     const { service } = ctx;
     if (!service) throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
     const events = Array.isArray(req.body?.events) ? req.body.events : [];
     if (events.length > BATCH_EVENTS) {
-      throw new AgentIntegrationError(
-        'Agent event batch exceeds configured limits',
-        'BATCH_TOO_LARGE',
-        413,
-      );
+      throw new AgentIntegrationError('Agent event batch exceeds configured limits', 'BATCH_TOO_LARGE', 413);
     }
-    const preparedEvents = events.map((item: unknown) => {
-      try {
-        return { prepared: prepareEvent(item) };
-      } catch (error) {
-        const eventId =
-          item && typeof item === 'object' && 'event_id' in item
-          && typeof (item as { event_id?: unknown }).event_id === 'string'
-            ? (item as { event_id: string }).event_id
-            : '';
-        if (error instanceof AgentIntegrationError) {
-          return {
-            errorResult: {
-              event_id: eventId,
-              status: 'INVALID',
-              reason_code: error.reasonCode,
-              late_arrival: false,
-            },
-          };
-        }
-        return {
-          errorResult: {
-            event_id: eventId,
-            status: 'DEGRADED',
-            reason_code: 'INTERNAL_ERROR',
-            late_arrival: false,
-          },
-        };
-      }
-    });
+    const preparedEvents = events.map((item: unknown) => prepareBatchEvent(item));
     const safeBatchBytes = Buffer.byteLength(
-      JSON.stringify(preparedEvents.flatMap(item =>
-        item.prepared ? [item.prepared] : [])),
+      JSON.stringify(preparedEvents.flatMap(item => item.prepared ? [item.prepared] : [])),
       'utf8',
     );
     if (safeBatchBytes > BATCH_PAYLOAD_BYTES) {
-      throw new AgentIntegrationError(
-        'Agent event batch exceeds configured limits',
-        'BATCH_TOO_LARGE',
-        413,
-      );
+      throw new AgentIntegrationError('Agent event batch exceeds configured limits', 'BATCH_TOO_LARGE', 413);
     }
     const results = preparedEvents.map((item) => {
       if (!item.prepared) return item.errorResult;
-      try {
-        const result = service.capture(item.prepared);
-        return {
-          event_id: result.eventId,
-          status: result.status,
-          reason_code: result.reasonCode,
-          observation_id: result.observationId,
-          late_arrival: result.lateArrival,
-        };
-      } catch (error) {
-        if (
-          error instanceof AgentIntegrationError
-          && error.reasonCode === 'IDEMPOTENCY_CONFLICT'
-        ) {
-          throw error;
-        }
-        if (error instanceof AgentIntegrationError) {
-          return {
-            event_id: item.prepared.eventId,
-            status: 'INVALID',
-            reason_code: error.reasonCode,
-            late_arrival: false,
-          };
-        }
-        return {
-          event_id: item.prepared.eventId,
-          status: 'DEGRADED',
-          reason_code: 'INTERNAL_ERROR',
-          late_arrival: false,
-        };
-      }
+      return captureOneBatchEvent(service, item.prepared);
     });
     return res.json({ results });
   } catch (error) {
@@ -806,18 +876,8 @@ function handlePostTranscriptsImport(req: Request, res: Response, ctx: AgentRout
 
 async function handlePostPersonalRun(req: Request, res: Response, ctx: AgentRouterCtx): Promise<Response | void> {
   try {
-    const body = req.body ?? {};
-    const service = createPersonalKnowledgeAgent(ctx);
-    const result = await service.runOneTurn({
-      userMessage: requireString(body.user_message ?? body.userMessage, 'user_message'),
-      projectId: optionalString(body.project_id ?? body.projectId, 'project_id'),
-      ownerId: optionalOwnerId(body.owner_id ?? body.ownerId),
-      sessionId: optionalString(body.session_id ?? body.sessionId, 'session_id'),
-      tokenBudget: optionalPositiveInteger(body.token_budget ?? body.tokenBudget, 'token_budget'),
-      maxMemories: optionalPositiveInteger(body.max_memories ?? body.maxMemories, 'max_memories'),
-      memoryTypes: optionalMemoryTypes(body.memory_types ?? body.memoryTypes),
-    });
-
+    const agent = createPersonalKnowledgeAgent(ctx);
+    const result = await agent.runOneTurn(parsePersonalRunBody(req.body ?? {}));
     return res.json({
       ok: true,
       knowledgeContext: {
@@ -830,12 +890,7 @@ async function handlePostPersonalRun(req: Request, res: Response, ctx: AgentRout
         metadata: result.llmMetadata ?? null,
       },
       candidates: result.candidates,
-      persistence: {
-        attempted: false,
-        items: [],
-        persistedCount: 0,
-        errorCount: 0,
-      },
+      persistence: { attempted: false, items: [], persistedCount: 0, errorCount: 0 },
     });
   } catch (error) {
     return writeError(res, error);
@@ -884,7 +939,7 @@ async function handleCaptureSessionEvent(
   expectedType: 'PRE_COMPACT' | 'STOP',
 ): Promise<Response> {
   try {
-    const { service, injectionService, buildInjection, recordInjection, initialInjectionTokenBudget } = ctx;
+    const { service, recordInjection, initialInjectionTokenBudget } = ctx;
     if (!service) throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
     const prepared = prepareEvent({ ...req.body, session_id: req.params.id });
     if (prepared.eventType !== expectedType) {
@@ -893,18 +948,11 @@ async function handleCaptureSessionEvent(
     const result = service.capture(prepared);
     const session = service.getSession(prepared.sessionId)!;
     const payload = parsePayload(prepared);
-    const requestedTokenBudget = typeof payload.token_budget === 'number'
+    const tokenBudget = typeof payload.token_budget === 'number'
       ? payload.token_budget
       : initialInjectionTokenBudget;
-    const injection = expectedType === 'PRE_COMPACT' && injectionService
-      ? await buildInjection({
-          trigger: 'pre_compact',
-          query: typeof payload.context_summary === 'string'
-            ? payload.context_summary
-            : '',
-          scope: injectionScope(prepared),
-          tokenBudget: requestedTokenBudget,
-        })
+    const injection = expectedType === 'PRE_COMPACT'
+      ? await maybePreCompactInjection(ctx, prepared, payload, tokenBudget)
       : null;
     if (injection) {
       recordInjection(injection, session.ownerId, session.id);
@@ -1107,57 +1155,16 @@ function handleGetProvenanceDetail(req: Request, res: Response, ctx: AgentRouter
     if (!service || !repository || !db) {
       throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
     }
-    const memoryId = typeof req.query.memory_id === 'string'
-      ? req.query.memory_id
-      : undefined;
-    const observationId = typeof req.query.observation_id === 'string'
-      ? req.query.observation_id
-      : undefined;
+    const { memoryId, observationId } = resolveProvenanceFilter(req.query);
     if (!memoryId && !observationId) {
-      throw new AgentIntegrationError(
-        'memory_id or observation_id is required',
-        'INVALID_ENVELOPE',
-        400,
-      );
+      throw new AgentIntegrationError('memory_id or observation_id is required', 'INVALID_ENVELOPE', 400);
     }
     const edges = repository.listProvenance({ memoryId, observationId }).slice(0, 100);
-    const memoryIds = [...new Set(edges.map(edge => edge.memoryId))];
-    const observationIds = [...new Set(
-      edges.flatMap(edge => edge.observationId ? [edge.observationId] : []),
-    )];
-    const sessionIds = [...new Set(
-      edges.flatMap(edge => edge.sessionId ? [edge.sessionId] : []),
-    )];
-    const memoryStatement = db.prepare(`
-      SELECT id, type, substr(content, 1, 240) AS content_preview, created_at
-      FROM memory_item
-      WHERE id = ?
-    `);
-    const memories = memoryIds.flatMap((id) => {
-      const row = memoryStatement.get(id) as {
-        id: string;
-        type: string;
-        content_preview: string;
-        created_at: string | null;
-      } | undefined;
-      return row ? [{
-        ...row,
-        source_deleted: edges.some(edge => edge.memoryId === id && edge.sourceDeleted),
-      }] : [];
-    });
-    const observations = observationIds.flatMap((id) => {
-      const observation = repository.getObservation(id);
-      return observation ? [observationDto(observation)] : [];
-    });
-    const sessions = sessionIds.flatMap((id) => {
-      const session = service.getSession(id);
-      return session ? [sessionDto(session)] : [];
-    });
     return res.json({
       edges: edges.map(provenanceDto),
-      memories,
-      observations,
-      sessions,
+      memories: loadProvenanceMemories(db, edges),
+      observations: loadProvenanceObservations(repository, edges),
+      sessions: loadProvenanceSessions(service, edges),
       truncated: edges.length === 100,
     });
   } catch (error) {

--- a/packages/memento-server/src/server/routes/agent.routes.ts
+++ b/packages/memento-server/src/server/routes/agent.routes.ts
@@ -185,6 +185,94 @@ function createPersonalKnowledgeAgent(ctx: AgentRouterCtx): PersonalKnowledgeAge
 }
 
 // ---------------------------------------------------------------------------
+// Injection / promotion / router-ctx helpers
+// ---------------------------------------------------------------------------
+
+function buildInjectionExtraData(
+  bundle: AgentContextInjectionBundle,
+  sessionId: string,
+): Record<string, unknown> {
+  return {
+    injection_id: bundle.injectionId,
+    session_id: sessionId,
+    trigger: bundle.trigger,
+    candidate_count: bundle.selected.length + bundle.excluded.length,
+    selected_count: bundle.selected.length,
+    exclusion_count: bundle.excluded.length,
+    selected: bundle.selected.map(item => ({
+      memory_id: item.id,
+      score: item.score,
+      token_estimate: item.tokenEstimate,
+      selection_reason: item.selectionReason,
+      scope_level: item.scopeLevel,
+    })),
+    exclusions: bundle.excluded.map(item => ({
+      memory_id: item.id,
+      reason: item.reason,
+      score: item.score,
+      token_estimate: item.tokenEstimate,
+      ...(item.duplicateOf ? { duplicate_of: item.duplicateOf } : {}),
+    })),
+    token_budget: bundle.tokenUsage.budget,
+    token_used: bundle.tokenUsage.used,
+    budget_exceeded: bundle.tokenUsage.used > bundle.tokenUsage.budget,
+    degraded_reasons: bundle.degradedReasons,
+  };
+}
+
+function promotionEventType(action: string): string {
+  const map: Record<string, string> = {
+    extracted: 'agent.promotion.extracted',
+    approved: 'agent.promotion.approved',
+    rejected: 'agent.promotion.rejected',
+    usage: 'agent.promotion.usage',
+  };
+  return map[action] ?? 'agent.promotion.unknown';
+}
+
+function promotionOutcome(
+  action: string,
+  usageOutcome?: string,
+): 'success' | 'failure' | 'empty' {
+  if (action === 'rejected' || (action === 'usage' && usageOutcome === 'negative')) {
+    return 'failure';
+  }
+  if (action === 'usage' && usageOutcome === 'unused') return 'empty';
+  return 'success';
+}
+
+function promotionRequestId(event: {
+  action: string;
+  sessionId?: string;
+  memoryId?: string;
+  candidateId?: string;
+}): string {
+  if (event.action === 'extracted') return `agent-promotion:${event.sessionId}`;
+  if (event.action === 'usage') return `agent-promotion-usage:${event.memoryId}`;
+  return `agent-promotion-review:${event.candidateId}`;
+}
+
+function clampTokenBudget(value: number | undefined): number {
+  return Number.isSafeInteger(value) ? Math.min(32_768, Math.max(1, value!)) : 2_048;
+}
+
+function buildSummarizer(
+  summaryService: InstanceType<typeof AgentSessionSummaryService> | null,
+  promotionService: InstanceType<typeof AgentMemoryPromotionService> | null,
+): AgentRouterCtx['summarizer'] {
+  if (!summaryService) return null;
+  return {
+    summarize(sessionId: string) {
+      const result = summaryService.summarize(sessionId);
+      if (result.status !== 'SKIPPED') {
+        promotionService?.extractCandidates(sessionId);
+      }
+      return result;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Service setup helpers
 // ---------------------------------------------------------------------------
 
@@ -208,32 +296,7 @@ function makeRecordInjection(
             ? 'empty'
             : 'failure',
         errorCode: bundle.failureReason ?? undefined,
-        extraData: {
-          injection_id: bundle.injectionId,
-          session_id: sessionId,
-          trigger: bundle.trigger,
-          candidate_count: bundle.selected.length + bundle.excluded.length,
-          selected_count: bundle.selected.length,
-          exclusion_count: bundle.excluded.length,
-          selected: bundle.selected.map(item => ({
-            memory_id: item.id,
-            score: item.score,
-            token_estimate: item.tokenEstimate,
-            selection_reason: item.selectionReason,
-            scope_level: item.scopeLevel,
-          })),
-          exclusions: bundle.excluded.map(item => ({
-            memory_id: item.id,
-            reason: item.reason,
-            score: item.score,
-            token_estimate: item.tokenEstimate,
-            ...(item.duplicateOf ? { duplicate_of: item.duplicateOf } : {}),
-          })),
-          token_budget: bundle.tokenUsage.budget,
-          token_used: bundle.tokenUsage.used,
-          budget_exceeded: bundle.tokenUsage.used > bundle.tokenUsage.budget,
-          degraded_reasons: bundle.degradedReasons,
-        },
+        extraData: buildInjectionExtraData(bundle, sessionId),
       });
     } catch {
       return;
@@ -262,27 +325,11 @@ function makePromotionTelemetryCallback(
   return function recordPromotionTelemetry(event: { action: string; sessionId?: string; memoryId?: string; candidateId?: string; usageOutcome?: string }) {
     const sessionId = event.action === 'extracted' ? event.sessionId ?? null : null;
     const session = sessionId ? repository.getSession(sessionId) : null;
-    const eventTypeMap: Record<string, string> = {
-      extracted: 'agent.promotion.extracted',
-      approved: 'agent.promotion.approved',
-      rejected: 'agent.promotion.rejected',
-      usage: 'agent.promotion.usage',
-    };
-    const outcome = event.action === 'rejected'
-      || (event.action === 'usage' && event.usageOutcome === 'negative')
-      ? 'failure'
-      : event.action === 'usage' && event.usageOutcome === 'unused'
-        ? 'empty'
-        : 'success';
     telemetryRepository?.insertEventSync({
-      eventType: (eventTypeMap[event.action] ?? 'agent.promotion.unknown') as Parameters<typeof telemetryRepository.insertEventSync>[0]['eventType'],
-      requestId: event.action === 'extracted'
-        ? `agent-promotion:${event.sessionId}`
-        : event.action === 'usage'
-          ? `agent-promotion-usage:${event.memoryId}`
-          : `agent-promotion-review:${event.candidateId}`,
+      eventType: promotionEventType(event.action) as Parameters<typeof telemetryRepository.insertEventSync>[0]['eventType'],
+      requestId: promotionRequestId(event),
       ownerId: session?.ownerId ?? null,
-      outcome: outcome as Parameters<typeof telemetryRepository.insertEventSync>[0]['outcome'],
+      outcome: promotionOutcome(event.action, event.usageOutcome) as Parameters<typeof telemetryRepository.insertEventSync>[0]['outcome'],
       extraData: { ...event },
     });
   };
@@ -332,17 +379,7 @@ function buildRouterCtx(
         recordTelemetry: makeSummaryTelemetryCallback(repository, telemetryRepository),
       })
     : null;
-  const summarizer = summaryService
-    ? {
-        summarize(sessionId: string) {
-          const result = summaryService.summarize(sessionId);
-          if (result.status !== 'SKIPPED') {
-            promotionService?.extractCandidates(sessionId);
-          }
-          return result;
-        },
-      }
-    : null;
+  const summarizer = buildSummarizer(summaryService, promotionService);
   const service = repository
     ? new AgentLifecycleService(repository, options, summarizer ?? undefined)
     : null;
@@ -354,9 +391,7 @@ function buildRouterCtx(
       })
     : null;
   const injectionService = options.contextInjectionService;
-  const initialInjectionTokenBudget = Number.isSafeInteger(options.initialInjectionTokenBudget)
-    ? Math.min(32_768, Math.max(1, options.initialInjectionTokenBudget!))
-    : 2_048;
+  const initialInjectionTokenBudget = clampTokenBudget(options.initialInjectionTokenBudget);
 
   return {
     db,
@@ -372,6 +407,117 @@ function buildRouterCtx(
     recordInjection: makeRecordInjection(telemetryRepository),
     buildInjection: makeBuildInjection(injectionService),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Operations status query helpers
+// ---------------------------------------------------------------------------
+
+interface ObservationRow {
+  occurred_at: string;
+  status: string;
+  drop_reason: string | null;
+  session_id: string;
+  adapter_name: string;
+  event_type: string;
+}
+
+interface InjectionRow {
+  created_at: string;
+  outcome: string;
+  error_code: string | null;
+  extra_data: string | null;
+}
+
+interface ObservationCounts {
+  captures: number;
+  dropped: number | null;
+  degraded: number | null;
+}
+
+interface InjectionCounts {
+  injections: number;
+  degraded: number | null;
+}
+
+function queryObservationRows(db: Database.Database, since: string, limit: number): ObservationRow[] {
+  return db.prepare(`
+    SELECT
+      received_at AS occurred_at,
+      status,
+      drop_reason,
+      session_id,
+      adapter_name,
+      event_type
+    FROM agent_observation
+    WHERE received_at >= ?
+    ORDER BY received_at DESC
+    LIMIT ?
+  `).all(since, limit) as ObservationRow[];
+}
+
+function queryInjectionRows(db: Database.Database, since: string, limit: number): InjectionRow[] {
+  return db.prepare(`
+    SELECT created_at, outcome, error_code, extra_data
+    FROM telemetry_events
+    WHERE event_type = 'agent.injection.completed'
+      AND created_at >= ?
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(since, limit) as InjectionRow[];
+}
+
+function queryObservationCounts(db: Database.Database, since: string): ObservationCounts {
+  return db.prepare(`
+    SELECT
+      COUNT(*) AS captures,
+      SUM(CASE WHEN status = 'DROPPED' THEN 1 ELSE 0 END) AS dropped,
+      SUM(CASE WHEN status = 'DEGRADED' THEN 1 ELSE 0 END) AS degraded
+    FROM agent_observation
+    WHERE received_at >= ?
+  `).get(since) as ObservationCounts;
+}
+
+function queryInjectionCounts(db: Database.Database, since: string): InjectionCounts {
+  return db.prepare(`
+    SELECT
+      COUNT(*) AS injections,
+      SUM(CASE WHEN outcome = 'failure' THEN 1 ELSE 0 END) AS degraded
+    FROM telemetry_events
+    WHERE event_type = 'agent.injection.completed'
+      AND created_at >= ?
+  `).get(since) as InjectionCounts;
+}
+
+function buildRecentEvents(
+  observationRows: ObservationRow[],
+  injectionRows: InjectionRow[],
+  limit: number,
+) {
+  return [
+    ...observationRows.map(row => ({
+      occurred_at: row.occurred_at,
+      kind: 'capture',
+      status: row.status,
+      reason_code: row.drop_reason ?? 'NONE',
+      session_id: row.session_id,
+      adapter_name: row.adapter_name,
+      event_type: row.event_type,
+    })),
+    ...injectionRows.map(row => ({
+      occurred_at: row.created_at,
+      kind: 'injection',
+      status: row.outcome === 'failure'
+        ? 'degraded'
+        : row.outcome === 'empty'
+          ? 'empty'
+          : 'ok',
+      reason_code: row.error_code ?? 'NONE',
+      session_id: safeTelemetrySessionId(row.extra_data),
+    })),
+  ]
+    .sort((left, right) => right.occurred_at.localeCompare(left.occurred_at))
+    .slice(0, limit);
 }
 
 // ---------------------------------------------------------------------------
@@ -464,90 +610,15 @@ function handleGetOperationsStatus(req: Request, res: Response, ctx: AgentRouter
   try {
     const { service, db, options } = ctx;
     if (!service || !db) {
-      throw new AgentIntegrationError(
-        'Database unavailable',
-        'SCHEMA_NOT_READY',
-        503,
-        true,
-      );
+      throw new AgentIntegrationError('Database unavailable', 'SCHEMA_NOT_READY', 503, true);
     }
     const generatedAt = (options.now ?? (() => new Date()))().toISOString();
     const since = boundedStatusSince(req.query.since, new Date(generatedAt));
     const limit = boundedStatusLimit(req.query.limit);
-    const observationRows = db.prepare(`
-      SELECT
-        received_at AS occurred_at,
-        status,
-        drop_reason,
-        session_id,
-        adapter_name,
-        event_type
-      FROM agent_observation
-      WHERE received_at >= ?
-      ORDER BY received_at DESC
-      LIMIT ?
-    `).all(since, limit) as Array<{
-      occurred_at: string;
-      status: string;
-      drop_reason: string | null;
-      session_id: string;
-      adapter_name: string;
-      event_type: string;
-    }>;
-    const injectionRows = db.prepare(`
-      SELECT created_at, outcome, error_code, extra_data
-      FROM telemetry_events
-      WHERE event_type = 'agent.injection.completed'
-        AND created_at >= ?
-      ORDER BY created_at DESC
-      LIMIT ?
-    `).all(since, limit) as Array<{
-      created_at: string;
-      outcome: string;
-      error_code: string | null;
-      extra_data: string | null;
-    }>;
-    const observationCounts = db.prepare(`
-      SELECT
-        COUNT(*) AS captures,
-        SUM(CASE WHEN status = 'DROPPED' THEN 1 ELSE 0 END) AS dropped,
-        SUM(CASE WHEN status = 'DEGRADED' THEN 1 ELSE 0 END) AS degraded
-      FROM agent_observation
-      WHERE received_at >= ?
-    `).get(since) as { captures: number; dropped: number | null; degraded: number | null };
-    const injectionCounts = db.prepare(`
-      SELECT
-        COUNT(*) AS injections,
-        SUM(CASE WHEN outcome = 'failure' THEN 1 ELSE 0 END) AS degraded
-      FROM telemetry_events
-      WHERE event_type = 'agent.injection.completed'
-        AND created_at >= ?
-    `).get(since) as { injections: number; degraded: number | null };
-    const recentEvents = [
-      ...observationRows.map(row => ({
-        occurred_at: row.occurred_at,
-        kind: 'capture',
-        status: row.status,
-        reason_code: row.drop_reason ?? 'NONE',
-        session_id: row.session_id,
-        adapter_name: row.adapter_name,
-        event_type: row.event_type,
-      })),
-      ...injectionRows.map(row => ({
-        occurred_at: row.created_at,
-        kind: 'injection',
-        status: row.outcome === 'failure'
-          ? 'degraded'
-          : row.outcome === 'empty'
-            ? 'empty'
-            : 'ok',
-        reason_code: row.error_code ?? 'NONE',
-        session_id: safeTelemetrySessionId(row.extra_data),
-      })),
-    ]
-      .sort((left, right) => right.occurred_at.localeCompare(left.occurred_at))
-      .slice(0, limit);
-
+    const observationRows = queryObservationRows(db, since, limit);
+    const injectionRows = queryInjectionRows(db, since, limit);
+    const observationCounts = queryObservationCounts(db, since);
+    const injectionCounts = queryInjectionCounts(db, since);
     return res.json({
       generated_at: generatedAt,
       window: { since, limit },
@@ -557,7 +628,7 @@ function handleGetOperationsStatus(req: Request, res: Response, ctx: AgentRouter
         dropped: observationCounts.dropped ?? 0,
         degraded: (observationCounts.degraded ?? 0) + (injectionCounts.degraded ?? 0),
       },
-      recent_events: recentEvents,
+      recent_events: buildRecentEvents(observationRows, injectionRows, limit),
     });
   } catch (error) {
     return writeError(res, error);
@@ -1193,7 +1264,7 @@ function handleDeleteSession(req: Request, res: Response, ctx: AgentRouterCtx): 
 }
 
 // ---------------------------------------------------------------------------
-// Router factory — thin shell that wires handlers to routes
+// Router factory - thin shell that wires handlers to routes
 // ---------------------------------------------------------------------------
 
 export function createAgentRouter(


### PR DESCRIPTION
## Summary

- `handlePostObservationsIngest` (92줄/복잡도18): `prepareBatchEvent`, `captureOneBatchEvent` 추출 → 23줄
- `handlePostPersonalRun` (37줄/복잡도11): `parsePersonalRunBody` 추출 → 14줄
- `handleCaptureSessionEvent` (49줄/복잡도11): `maybePreCompactInjection` 추출 → 32줄
- `handleGetProvenanceDetail` (63줄/복잡도15): `resolveProvenanceFilter`, `loadProvenanceMemories`, `loadProvenanceObservations`, `loadProvenanceSessions` 추출 → 18줄

## 결과

- slop-detector JS/TS 분석: **Clean** (god function 0개)
- `tsc --noEmit`: 에러 없음
- 21 tests: 모두 통과

## Test Plan

- [x] `npx tsc -p packages/memento-server/tsconfig.json --noEmit` 통과
- [x] `npx vitest run packages/memento-server/src/server/routes/agent.routes.spec.ts` 21/21 통과
- [x] `slop-detector ... --js` JS/TS Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)