### PR TITLE
fix(dashboard): Anchor Map 검색 세션 보호 API로 전환 (#568)

### DIFF
--- a/packages/memento-server/src/server/auth-session.integration.spec.ts
+++ b/packages/memento-server/src/server/auth-session.integration.spec.ts
@@ -174,6 +174,41 @@ describe('auth session integration', () => {
     expect(api.statusCode).toBe(200);
   });
 
+  it('allows signed-in POST /api/anchors/search with search_local-compatible result shape', async () => {
+    const port = await startRealHttpServer();
+
+    const login = await postJson(port, '/auth/session', {}, {
+      Authorization: 'Bearer integration-admin-key'
+    });
+    const sessionCookie = login.headers['set-cookie']?.[0] ?? '';
+
+    const search = await postJson(
+      port,
+      '/api/anchors/search',
+      { query: 'test', slot: 'A', agent_id: 'default', limit: 10 },
+      { Cookie: sessionCookie }
+    );
+
+    expect(search.statusCode).toBe(200);
+    const payload = JSON.parse(search.body) as {
+      result?: { items?: unknown[] };
+    };
+    expect(Array.isArray(payload.result?.items)).toBe(true);
+  });
+
+  it('rejects unsigned POST /api/anchors/search with 401', async () => {
+    const port = await startRealHttpServer();
+
+    const search = await postJson(port, '/api/anchors/search', {
+      query: 'test',
+      slot: 'A',
+      agent_id: 'default',
+      limit: 10
+    });
+
+    expect(search.statusCode).toBe(401);
+  });
+
   it('deletes the session cookie and invalidates subsequent /api access', async () => {
     const port = await startRealHttpServer();
 

--- a/packages/memento-server/src/server/dashboard-auth-assets.spec.ts
+++ b/packages/memento-server/src/server/dashboard-auth-assets.spec.ts
@@ -297,4 +297,33 @@ describe('dashboard auth assets', () => {
     expect(protectedCallCount).toBe(2);
     expect(harness.context.__MEMENTO_DASHBOARD_AUTH__.getState()).toBe('signed-in');
   });
+
+  it('does not treat /tools/* 401 as dashboard session expiration', async () => {
+    const harness = createDashboardHarness((url) => {
+      if (url === '/api/anchors/map?agent_id=default') {
+        return Promise.resolve(createJsonResponse(200, { anchors: [], nodes: [], links: [] }));
+      }
+      if (url === '/tools/search_local') {
+        return Promise.resolve(
+          createJsonResponse(401, {
+            message: 'Programmatic routes require Authorization: Bearer <key> or X-API-Key.'
+          })
+        );
+      }
+      throw new Error('Unexpected fetch: ' + url);
+    });
+
+    await flushPromises();
+    expect(harness.context.__MEMENTO_DASHBOARD_AUTH__.getState()).toBe('signed-in');
+
+    const response = await harness.context.mementoAdminFetch('/tools/search_local', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: 'test', slot: 'A', agent_id: 'default' })
+    });
+
+    expect(response.status).toBe(401);
+    expect(harness.context.__MEMENTO_DASHBOARD_AUTH__.getState()).toBe('signed-in');
+    expect(harness.root.dataset.authState).toBe('signed-in');
+  });
 });

--- a/packages/memento-server/src/server/handlers/tool-result.utils.ts
+++ b/packages/memento-server/src/server/handlers/tool-result.utils.ts
@@ -1,0 +1,18 @@
+import type { ToolResult } from '@memento/core';
+
+/**
+ * MCP ToolResult content[] → parsed JSON payload (tools.routes / dashboard API 공용)
+ */
+export function extractToolResultPayload(toolResult: ToolResult): unknown {
+  if (toolResult.content && Array.isArray(toolResult.content) && toolResult.content.length > 0) {
+    const firstContent = toolResult.content[0];
+    if (firstContent && firstContent.text) {
+      try {
+        return JSON.parse(firstContent.text);
+      } catch {
+        return toolResult;
+      }
+    }
+  }
+  return toolResult;
+}

--- a/packages/memento-server/src/server/programmatic-auth.integration.spec.ts
+++ b/packages/memento-server/src/server/programmatic-auth.integration.spec.ts
@@ -250,6 +250,14 @@ describe('programmatic auth integration', () => {
     });
     expect(toolsWithCookieOnly.statusCode).toBe(401);
 
+    const searchLocalWithCookieOnly = await postJson(
+      port,
+      '/tools/search_local',
+      { query: 'test', slot: 'A', agent_id: 'default', limit: 10 },
+      { Cookie: sessionCookie }
+    );
+    expect(searchLocalWithCookieOnly.statusCode).toBe(401);
+
     const toolsWithHeader = await getRequest(port, '/tools', {
       Authorization: 'Bearer integration-admin-key'
     });

--- a/packages/memento-server/src/server/routes/api.routes.ts
+++ b/packages/memento-server/src/server/routes/api.routes.ts
@@ -8,7 +8,15 @@ import { Router } from 'express';
 import type Database from 'better-sqlite3';
 import type { ServerServices } from '../bootstrap.js';
 import { buildAnchorMapData } from '../handlers/anchor-map.handler.js';
-import { MemoryNeighborService, MemoryNotFoundError, getVectorSearchEngine, logger } from '@memento/core';
+import { extractToolResultPayload } from '../handlers/tool-result.utils.js';
+import { createToolContext } from '../context.js';
+import {
+  MemoryNeighborService,
+  MemoryNotFoundError,
+  executeTool,
+  getVectorSearchEngine,
+  logger,
+} from '@memento/core';
 
 /**
  * API 라우터 생성
@@ -52,6 +60,35 @@ export function createApiRouter(
         error: 'Failed to get anchor map data',
         message: error instanceof Error ? error.message : 'Unknown error',
         agent_id: agentId
+      });
+    }
+  });
+
+  // Anchor Map 검색 (브라우저 세션; /tools/search_local 과 동일 result shape)
+  router.post('/anchors/search', async (req, res) => {
+    try {
+      if (!db || !serverServices) {
+        return res.status(500).json({
+          error: 'Services not initialized',
+          message: '서비스가 초기화되지 않았습니다',
+        });
+      }
+
+      const toolContext = createToolContext(db, serverServices);
+      const toolResult = await executeTool('search_local', req.body, toolContext);
+      const result = extractToolResultPayload(toolResult);
+
+      return res.json({
+        result,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('Anchor search failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({
+        error: 'Failed to search anchors',
+        message: error instanceof Error ? error.message : 'Unknown error',
       });
     }
   });

--- a/packages/memento-server/src/server/routes/tools.routes.ts
+++ b/packages/memento-server/src/server/routes/tools.routes.ts
@@ -10,6 +10,7 @@ import { Router } from 'express';
 import type { WebSocket } from 'ws';
 import type { ServerServices } from '../bootstrap.js';
 import { broadcastAnchorMapUpdate } from '../handlers/anchor-map.handler.js';
+import { extractToolResultPayload } from '../handlers/tool-result.utils.js';
 
 /**
  * Tools 라우터 생성
@@ -64,20 +65,7 @@ export function createToolsRouter(
       // 도구 실행
       const toolResult = await executeTool(name, params, toolContext);
 
-      // MCP 형식의 ToolResult에서 실제 데이터 추출
-      let actualResult: any = toolResult;
-      if (toolResult.content && Array.isArray(toolResult.content) && toolResult.content.length > 0) {
-        const firstContent = toolResult.content[0];
-        if (firstContent && firstContent.text) {
-          try {
-            const textContent = firstContent.text;
-            actualResult = JSON.parse(textContent);
-          } catch (parseError) {
-            // JSON 파싱 실패 시 원본 content 사용
-            actualResult = toolResult;
-          }
-        }
-      }
+      const actualResult = extractToolResultPayload(toolResult);
 
       // 앵커 관련 도구 실행 후 WebSocket 브로드캐스트
       if (name === 'set_anchor' || name === 'clear_anchor') {

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -593,7 +593,7 @@ async function performSearch() {
   try {
     // search_local 도구 호출
     const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
-    const response = await fetchFn(`/tools/search_local`, {
+    const response = await fetchFn(`/api/anchors/search`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/static/js/memento-admin-fetch.js
+++ b/static/js/memento-admin-fetch.js
@@ -25,12 +25,18 @@
     return merged;
   }
 
+  function isProgrammaticToolsRequest(url) {
+    const path = typeof url === 'string' ? url : String(url);
+    return path.indexOf('/tools/') === 0 || path === '/tools';
+  }
+
   function performFetch(url, opts, retriedAfterAuthReset) {
     return fetch(url, opts).then(function (response) {
       const dashboardAuth = getDashboardAuth();
       if (
         response.status === 401 &&
         !retriedAfterAuthReset &&
+        !isProgrammaticToolsRequest(url) &&
         dashboardAuth &&
         typeof dashboardAuth.handleUnauthorized === 'function'
       ) {

--- a/tests/static-design-contracts.spec.ts
+++ b/tests/static-design-contracts.spec.ts
@@ -15,6 +15,13 @@ describe('static design contracts', () => {
     expect(source).not.toMatch(/style\s*=/);
   });
 
+  it('anchor-map.js uses session-protected /api/anchors/search instead of /tools/search_local', () => {
+    const source = readStaticFile('static/js/anchor-map.js');
+
+    expect(source).toContain('/api/anchors/search');
+    expect(source).not.toContain('/tools/search_local');
+  });
+
   it('anchor-map.js emits observable debug events for document-level listeners', () => {
     const source = readStaticFile('static/js/anchor-map.js');
 


### PR DESCRIPTION
## Summary

- Anchor Map `Search`가 `/tools/search_local`(API key 전용)을 호출해 401 발생 → `mementoAdminFetch`가 세션 만료로 오인하고 Anchor Map 탭이 사라지던 문제를 수정합니다.
- **`POST /api/anchors/search`** 세션 보호 엔드포인트를 추가하고, `performSearch()`를 해당 경로로 전환했습니다.
- 응답 shape는 기존 `/tools/search_local`과 동일하게 `{ result: { items, ... } }`를 유지합니다.
- `/tools/*` cookie-only 401 동작은 그대로 두고, `mementoAdminFetch`가 `/tools/*` 401을 세션 만료로 처리하지 않도록 보조 수정했습니다.

Fixes #568

## Test plan

- [x] `auth-session.integration.spec.ts` — signed-in `POST /api/anchors/search` → 200 + `items`, signed-out → 401
- [x] `programmatic-auth.integration.spec.ts` — cookie-only `POST /tools/search_local` → 401 유지
- [x] `dashboard-auth-assets.spec.ts` — `/tools/*` 401 시 `signed-in` 상태 유지
- [x] `static-design-contracts.spec.ts` — `anchor-map.js`가 `/api/anchors/search` 사용
- [x] `npm run build` / `npm run type-check` 통과
- [ ] 수동: Dashboard Sign in → Anchor Map Search → 탭 유지 + 검색 하이라이트