### PR TITLE
fix(dashboard): Anchor Map 검색 limit 버그 및 UX 개선 (#570)

### DIFF
--- a/packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts
+++ b/packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, Mock, afterEach } from 'vitest';
-import { HybridSearchEngine, createHybridSearchEngine, SearchError, SearchErrorType } from '../hybrid-search-engine.js';
+import { HybridSearchEngine, createHybridSearchEngine, SearchError, SearchErrorType, resolveHybridVectorPrefetchLimit } from '../hybrid-search-engine.js';
 import type { ITextSearchEngine, IEmbeddingService, IVectorSearchEngine, ISearchResultCombiner, IAdaptiveWeightCalculator, ISearchLogger, IProceduralMemoryMatcher } from '../hybrid-search-engine.js';
 import Database from 'better-sqlite3';
 import type { RelationGraph } from '../../../relation/services/relation-graph.js';
@@ -73,6 +73,20 @@ const createMockLogger = (): ISearchLogger => ({
 });
 
 describe('HybridSearchEngine', () => {
+  describe('resolveHybridVectorPrefetchLimit', () => {
+    it('limit 100일 때 prefetch limit은 100을 넘지 않아야 함', () => {
+      expect(resolveHybridVectorPrefetchLimit(100)).toBe(100);
+    });
+
+    it('limit 5일 때 multiplier를 적용해야 함', () => {
+      expect(resolveHybridVectorPrefetchLimit(5)).toBe(10);
+    });
+
+    it('limit 미지정 시 기본값 10에 multiplier를 적용해야 함', () => {
+      expect(resolveHybridVectorPrefetchLimit()).toBe(20);
+    });
+  });
+
   let hybridSearchEngine: HybridSearchEngine;
   let mockTextEngine: ITextSearchEngine;
   let mockEmbeddingService: IEmbeddingService;
@@ -348,6 +362,52 @@ describe('HybridSearchEngine', () => {
           includeContent: true
         }),
         expect.any(String) // provider 파라미터
+      );
+      vectorSpy.mockRestore();
+      db.close();
+    });
+
+    it('limit이 100이어도 VEC 벡터 prefetch limit은 100을 넘기지 않아야 함', async () => {
+      const db = new Database(':memory:');
+      initializeTestDatabase(db);
+
+      insertMemoryItem(db, {
+        id: 'mem1',
+        type: 'episodic',
+        content: 'test content'
+      });
+
+      insertMemoryEmbedding(db, {
+        memory_id: 'mem1',
+        embedding: new Array(1536).fill(0.1),
+        embedding_provider: 'tfidf',
+        dim: 1536
+      });
+
+      const typeFilters = ['episodic', 'semantic'];
+      (mockTextEngine.search as Mock).mockResolvedValue({ items: [], total_count: 0, query_time: 0 });
+      (mockVectorEngine.getIndexStatus as Mock).mockReturnValue({ available: true });
+      (mockEmbeddingService.isAvailable as Mock).mockReturnValue(true);
+      (mockVectorEngine.search as Mock).mockResolvedValue([]);
+      (mockWeightCalculator.calculateWeights as Mock).mockReturnValue({ vectorWeight: 0.6, textWeight: 0.4 });
+      (mockResultCombiner.combine as Mock).mockReturnValue([]);
+      const vectorSpy = vi
+        .spyOn(hybridSearchEngine as unknown as { generateQueryVector: (query: string, provider?: string) => Promise<{ embedding: number[]; provider: string }> }, 'generateQueryVector')
+        .mockResolvedValue({
+          embedding: new Array(512).fill(0.1),
+          actualProvider: 'tfidf'
+        });
+
+      await hybridSearchEngine.search(db, {
+        query: 'test query',
+        limit: 100,
+        filters: { type: typeFilters }
+      });
+
+      expect(mockVectorEngine.search).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ limit: 100 }),
+        expect.any(String)
       );
       vectorSpy.mockRestore();
       db.close();

--- a/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
+++ b/packages/memento-core/src/domains/search/algorithms/hybrid-search-engine.ts
@@ -33,6 +33,15 @@ import { SearchRanking,type SearchFeatures } from './search-ranking.js';
 import { SearchResultCombiner } from './search-result-combiner.js';
 import { getVectorSearchEngine } from './vector-search-engine.js';
 
+/** 하이브리드 검색 벡터 prefetch limit (VectorSearchService 상한 100 준수) */
+export function resolveHybridVectorPrefetchLimit(requestedLimit?: number): number {
+  const base = requestedLimit ?? 10;
+  return Math.min(
+    HYBRID_SEARCH.MAX_VECTOR_PREFETCH_LIMIT,
+    base * HYBRID_SEARCH.VECTOR_SEARCH_LIMIT_MULTIPLIER
+  );
+}
+
 // 의존성 주입과 테스트 가능성을 위해 인터페이스를 정의하여 느슨한 결합을 유지합니다.
 export interface ITextSearchEngine {
   search(
@@ -641,7 +650,7 @@ export class HybridSearchEngine {
       
       // 여러 provider를 병렬로 검색하여 검색 속도를 향상시키고 포괄성을 확보합니다.
       const searchOptions = {
-        limit: (query.limit || 10) * HYBRID_SEARCH.VECTOR_SEARCH_LIMIT_MULTIPLIER,
+        limit: resolveHybridVectorPrefetchLimit(query.limit),
         threshold: HYBRID_SEARCH.HYBRID_VECTOR_THRESHOLD,
         types: query.filters?.type,
         includeContent: true,
@@ -889,7 +898,7 @@ export class HybridSearchEngine {
     const fallbackStart = process.hrtime.bigint();
     const raw = await this.embeddingService.searchBySimilarity(db, query.query, {
       type: query.filters?.type as MemoryType[],
-      limit: (query.limit || 10) * HYBRID_SEARCH.VECTOR_SEARCH_LIMIT_MULTIPLIER,
+      limit: resolveHybridVectorPrefetchLimit(query.limit),
       threshold: HYBRID_SEARCH.HYBRID_VECTOR_THRESHOLD,
       ...(typeof query.filters?.project_id === 'string' && query.filters.project_id.length > 0
         ? { project_id: query.filters.project_id }

--- a/packages/memento-core/src/shared/config/constants.ts
+++ b/packages/memento-core/src/shared/config/constants.ts
@@ -110,6 +110,11 @@ export const HYBRID_SEARCH = {
   VECTOR_SEARCH_LIMIT_MULTIPLIER: 2,
 
   /**
+   * VectorSearchService가 허용하는 prefetch limit 상한
+   */
+  MAX_VECTOR_PREFETCH_LIMIT: 100,
+
+  /**
    * 벡터 검색 기본 임계값 (일반 경로)
    */
   VECTOR_SEARCH_THRESHOLD: 0.5,

--- a/packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts
+++ b/packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts
@@ -1,9 +1,53 @@
 import { describe, expect, it } from 'vitest';
 
 /**
- * `static/js/anchor-map.js` 의 `highlightSearchResults` 첫 결과 포커스 경로를
- * DOM/D3 없이 재현한다. GH-150: `nodes` 가 undefined 일 때 `.find` 호출로 TypeError 나던 문제 회귀 방지.
+ * `static/js/anchor-map.js` 검색·하이라이트 순수 로직 회귀 테스트 (GH-150, #570)
  */
+
+function getSearchItemId(item: { id?: string; memory_id?: string } | null | undefined): string {
+  if (!item) return '';
+  return item.id || item.memory_id || '';
+}
+
+function countSearchMapMatches(
+  items: Array<{ id?: string; memory_id?: string }> | undefined,
+  mapNodes: Array<{ id: string }> | undefined,
+): number {
+  if (!Array.isArray(items) || !Array.isArray(mapNodes)) {
+    return 0;
+  }
+  const mapIds = new Set(mapNodes.map(n => n.id));
+  let matched = 0;
+  for (const item of items) {
+    if (mapIds.has(getSearchItemId(item))) {
+      matched += 1;
+    }
+  }
+  return matched;
+}
+
+function buildSearchStatusMessage(
+  searchResult: {
+    items?: unknown[];
+    fallback_used?: boolean;
+    local_results_count?: number;
+  } | null | undefined,
+  mapMatchCount: number,
+): string {
+  const total = searchResult?.items?.length ?? 0;
+  if (total === 0) {
+    return '검색 결과가 없습니다.';
+  }
+  const parts = [`${total}건 검색됨`, `맵 ${mapMatchCount}건 표시`];
+  if (searchResult?.fallback_used) {
+    parts.push('전역 검색 사용');
+  }
+  if (searchResult?.local_results_count != null && !searchResult?.fallback_used) {
+    parts.push(`국소 ${searchResult.local_results_count}건`);
+  }
+  return parts.join(' · ');
+}
+
 function highlightSearchFocusPath(
   searchResults: { items?: Array<{ id: string }> } | null | undefined,
   nodes: Array<{ id: string }> | undefined,
@@ -11,14 +55,14 @@ function highlightSearchFocusPath(
   if (!searchResults?.items?.length) {
     return;
   }
-  const firstResult = searchResults.items[0];
-  if (!Array.isArray(nodes)) {
+  const firstOnMap = searchResults.items
+    .map(item => (Array.isArray(nodes) ? nodes.find(n => n.id === item.id) : undefined))
+    .find(Boolean);
+  if (!firstOnMap) {
     return;
   }
-  nodes.find(n => n.id === firstResult.id);
 }
 
-/** `selectAnchorNode` 의 nodes.find 패턴 (배열 아닐 때 방어) */
 function findNodeForAnchor(nodes: unknown, memoryId: string) {
   if (!Array.isArray(nodes)) {
     return undefined;
@@ -26,7 +70,13 @@ function findNodeForAnchor(nodes: unknown, memoryId: string) {
   return nodes.find((n: { id: string }) => n.id === memoryId);
 }
 
-describe('anchor map search highlight (GH-150)', () => {
+function shouldDimNonMatchingNodes(highlightedIds: Set<string>, mapNodes: Array<{ id: string }>): boolean {
+  if (highlightedIds.size === 0) return false;
+  const mapMatchCount = mapNodes.filter(n => highlightedIds.has(n.id)).length;
+  return mapMatchCount > 0;
+}
+
+describe('anchor map search highlight (GH-150, #570)', () => {
   it('highlight focus path does not throw when nodes is undefined', () => {
     expect(() =>
       highlightSearchFocusPath({ items: [{ id: 'mem_1' }] }, undefined),
@@ -40,5 +90,39 @@ describe('anchor map search highlight (GH-150)', () => {
   it('selectAnchor lookup does not throw when nodes is undefined', () => {
     expect(() => findNodeForAnchor(undefined, 'x')).not.toThrow();
     expect(findNodeForAnchor(undefined, 'x')).toBeUndefined();
+  });
+
+  it('getSearchItemId prefers id then memory_id', () => {
+    expect(getSearchItemId({ id: 'a', memory_id: 'b' })).toBe('a');
+    expect(getSearchItemId({ memory_id: 'b' })).toBe('b');
+    expect(getSearchItemId(null)).toBe('');
+  });
+
+  it('countSearchMapMatches counts only nodes present on map', () => {
+    const items = [{ id: 'mem_1' }, { id: 'mem_2' }, { memory_id: 'mem_3' }];
+    const mapNodes = [{ id: 'mem_2' }];
+    expect(countSearchMapMatches(items, mapNodes)).toBe(1);
+  });
+
+  it('buildSearchStatusMessage includes fallback indicator', () => {
+    const msg = buildSearchStatusMessage(
+      { items: [{}, {}], fallback_used: true },
+      0,
+    );
+    expect(msg).toContain('2건 검색됨');
+    expect(msg).toContain('맵 0건 표시');
+    expect(msg).toContain('전역 검색 사용');
+  });
+
+  it('shouldDimNonMatchingNodes is false when no map matches', () => {
+    const highlighted = new Set(['mem_off_map']);
+    const mapNodes = [{ id: 'anchor_1' }];
+    expect(shouldDimNonMatchingNodes(highlighted, mapNodes)).toBe(false);
+  });
+
+  it('shouldDimNonMatchingNodes is true when map has matches', () => {
+    const highlighted = new Set(['mem_1', 'mem_off_map']);
+    const mapNodes = [{ id: 'mem_1' }, { id: 'mem_2' }];
+    expect(shouldDimNonMatchingNodes(highlighted, mapNodes)).toBe(true);
   });
 });

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -105,7 +105,70 @@ body {
   font-weight: 500;
 }
 
-.dashboard-container[data-auth-state='checking'] .session-only,
+.header-controls__auto-refresh {
+  margin-left: 1rem;
+}
+
+.header-controls__checkbox {
+  margin-right: 0.25rem;
+}
+
+.header-controls__interval {
+  margin-left: 0.5rem;
+}
+
+.anchor-search-status {
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-main);
+  color: var(--color-text-main);
+  font-style: normal;
+  text-align: left;
+}
+
+.anchor-search-status.is-active {
+  border-left: 3px solid var(--color-success);
+}
+
+#anchor-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.anchor-search-result-item {
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-light);
+  background-color: var(--color-bg-main);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.anchor-search-result-item:hover {
+  background-color: var(--color-bg-card);
+}
+
+.anchor-search-result-item.is-on-map {
+  border-color: var(--color-success);
+}
+
+.anchor-search-result-item .search-result-preview {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-main);
+  margin-top: var(--spacing-xs);
+  word-break: break-word;
+}
+
+.anchor-search-result-item .search-result-meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
 .dashboard-container[data-auth-state='signed-out'] .session-only,
 .dashboard-container[data-auth-state='signing-in'] .session-only,
 .dashboard-container[data-auth-state='signing-out'] .session-only {

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -38,24 +38,24 @@
         </section>
       </div>
       <div class="header-controls session-only">
-        <label for="agent-id-input">Agent ID:</label>
-        <input type="text" id="agent-id-input" class="m-input" value="default" placeholder="default">
-        <label for="search-query-input">Search:</label>
-        <input type="text" id="search-query-input" class="m-input" placeholder="Search memories...">
-        <select id="search-slot-select" class="m-input">
+        <label for="agent-id-input" title="맵·검색 API에 사용할 에이전트 식별자입니다. 기본값은 default입니다.">Agent ID:</label>
+        <input type="text" id="agent-id-input" class="m-input" value="default" placeholder="default" title="맵·검색 API에 사용할 에이전트 식별자입니다.">
+        <label for="search-query-input" title="선택한 앵커 슬롯 주변에서 검색합니다. 국소 결과가 부족하면 전역 검색으로 확장됩니다.">Search:</label>
+        <input type="text" id="search-query-input" class="m-input" placeholder="Search memories..." title="검색어를 입력하고 Search 또는 Enter를 누르세요.">
+        <select id="search-slot-select" class="m-input" title="검색 기준 앵커 슬롯입니다. A=1-hop, B=2-hop, C=3-hop 범위가 적용됩니다.">
           <option value="A" selected>Slot A</option>
           <option value="B">Slot B</option>
           <option value="C">Slot C</option>
         </select>
-        <button id="search-btn" class="m-button m-button--secondary">Search</button>
-        <button id="load-map-btn" class="m-button m-button--secondary">Load Map</button>
-        <button id="refresh-btn" class="m-button m-button--secondary">Refresh</button>
-        <button id="clear-search-btn" class="m-button m-button--ghost">Clear</button>
-        <label for="auto-refresh-toggle" style="margin-left: 1rem;">
-          <input type="checkbox" id="auto-refresh-toggle" style="margin-right: 0.25rem;">
+        <button id="search-btn" class="m-button m-button--secondary" title="앵커 주변 국소 검색을 실행합니다.">Search</button>
+        <button id="load-map-btn" class="m-button m-button--secondary" title="현재 Agent ID의 앵커 맵 데이터를 불러옵니다.">Load Map</button>
+        <button id="refresh-btn" class="m-button m-button--secondary" title="맵 데이터를 다시 불러와 그래프를 갱신합니다.">Refresh</button>
+        <button id="clear-search-btn" class="m-button m-button--ghost" title="검색어, 하이라이트, 검색 결과 목록을 초기화합니다.">Clear</button>
+        <label for="auto-refresh-toggle" class="header-controls__auto-refresh" title="켜면 선택한 간격마다 맵 데이터를 자동으로 갱신합니다.">
+          <input type="checkbox" id="auto-refresh-toggle" class="header-controls__checkbox">
           Auto Refresh
         </label>
-        <select id="refresh-interval-select" class="m-input" style="margin-left: 0.5rem;">
+        <select id="refresh-interval-select" class="m-input header-controls__interval" title="자동 새로고침 간격을 설정합니다.">
           <option value="5000">5초</option>
           <option value="10000" selected>10초</option>
           <option value="30000">30초</option>
@@ -79,14 +79,22 @@
       <main class="dashboard-main">
         <div class="sidebar">
           <section class="anchor-info">
-            <h2>Anchors</h2>
+            <h2 title="현재 Agent ID에 설정된 앵커 슬롯 목록입니다. 항목을 클릭하면 맵에서 해당 노드로 이동합니다.">Anchors</h2>
             <div id="anchor-list">
               <p class="no-data">No anchors set</p>
             </div>
           </section>
 
+          <section class="anchor-search-results">
+            <h2 title="검색 결과 목록입니다. 맵에 있는 항목은 강조 표시되며, 클릭하면 상세 정보를 볼 수 있습니다.">Search Results</h2>
+            <p id="anchor-search-status" class="anchor-search-status no-data" aria-live="polite">검색 후 결과가 여기에 표시됩니다.</p>
+            <div id="anchor-search-results">
+              <p class="no-data">No search results</p>
+            </div>
+          </section>
+
           <section class="memory-details">
-            <h2>Memory Details</h2>
+            <h2 title="맵 노드 또는 검색 결과를 선택하면 메모리 상세 정보가 표시됩니다.">Memory Details</h2>
             <div id="memory-details">
               <p class="no-data">Click on a node to view details</p>
             </div>
@@ -96,20 +104,20 @@
         <div class="map-container">
           <div id="anchor-map"></div>
           <div class="map-legend">
-            <h3>Legend</h3>
-            <div class="legend-item">
+            <h3 title="맵 노드 색상과 의미입니다.">Legend</h3>
+            <div class="legend-item" title="Slot A 앵커 — 1-hop 국소 검색 범위">
               <span class="legend-color anchor-a"></span>
               <span>Slot A (1-hop)</span>
             </div>
-            <div class="legend-item">
+            <div class="legend-item" title="Slot B 앵커 — 2-hop 국소 검색 범위">
               <span class="legend-color anchor-b"></span>
               <span>Slot B (2-hop)</span>
             </div>
-            <div class="legend-item">
+            <div class="legend-item" title="Slot C 앵커 — 3-hop 국소 검색 범위">
               <span class="legend-color anchor-c"></span>
               <span>Slot C (3-hop)</span>
             </div>
-            <div class="legend-item">
+            <div class="legend-item" title="앵커 주변 연결 메모리 노드">
               <span class="legend-color memory"></span>
               <span>Memory</span>
             </div>

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -4,7 +4,7 @@
  */
 
 // 전역 변수 (맵 미렌더/빈 데이터에서도 .find/.filter 호출 시 TypeError 방지)
-let svg, simulation;
+let svg, simulation, zoomBehavior;
 let nodes = [];
 let links = [];
 let mapData = null;
@@ -57,6 +57,107 @@ function escapeHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+/** 검색 결과 item에서 memory ID 추출 */
+function getSearchItemId(item) {
+  if (!item) return '';
+  return item.id || item.memory_id || '';
+}
+
+/** 검색 결과 중 맵에 표시된 노드와 일치하는 개수 */
+function countSearchMapMatches(items, mapNodes) {
+  if (!Array.isArray(items) || !Array.isArray(mapNodes)) {
+    return 0;
+  }
+  const mapIds = new Set(mapNodes.map(n => n.id));
+  let matched = 0;
+  for (const item of items) {
+    if (mapIds.has(getSearchItemId(item))) {
+      matched += 1;
+    }
+  }
+  return matched;
+}
+
+/** 검색 상태 메시지 생성 */
+function buildSearchStatusMessage(searchResult, mapMatchCount) {
+  const total = searchResult?.items?.length ?? 0;
+  if (total === 0) {
+    return '검색 결과가 없습니다.';
+  }
+  const parts = [`${total}건 검색됨`, `맵 ${mapMatchCount}건 표시`];
+  if (searchResult.fallback_used) {
+    parts.push('전역 검색 사용');
+  }
+  if (searchResult.local_results_count != null && !searchResult.fallback_used) {
+    parts.push(`국소 ${searchResult.local_results_count}건`);
+  }
+  return parts.join(' · ');
+}
+
+function updateSearchStatus(message, isActive = false) {
+  const statusEl = document.getElementById('anchor-search-status');
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.classList.toggle('is-active', isActive);
+  statusEl.classList.toggle('no-data', !isActive);
+}
+
+function renderSearchResultsList() {
+  const container = document.getElementById('anchor-search-results');
+  if (!container) return;
+
+  if (!searchResults?.items?.length) {
+    container.innerHTML = '<p class="no-data">No search results</p>';
+    return;
+  }
+
+  const mapIds = new Set(Array.isArray(nodes) ? nodes.map(n => n.id) : []);
+  container.innerHTML = searchResults.items
+    .map((item, index) => {
+      const id = getSearchItemId(item);
+      if (!id) return '';
+      const onMap = mapIds.has(id);
+      const preview = escapeHtml((item.content || '').substring(0, 80));
+      const suffix = item.content && item.content.length > 80 ? '...' : '';
+      const similarity = item.similarity != null
+        ? escapeHtml((item.similarity * 100).toFixed(1) + '%')
+        : 'N/A';
+      return `
+        <div class="anchor-search-result-item${onMap ? ' is-on-map' : ''} js-search-result-item"
+             data-memory-id="${escapeHtml(id)}"
+             title="${onMap ? '맵에 표시됨 — 클릭하여 포커스' : '맵 밖 결과 — 클릭하여 상세 보기'}">
+          <div class="search-result-meta">#${index + 1} · ${escapeHtml(id)} · ${similarity}</div>
+          <div class="search-result-preview">${preview}${suffix}</div>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+function focusOnNode(node, scale = 1.5) {
+  if (!node || node.x == null || node.y == null || !zoomBehavior || !svg) {
+    return;
+  }
+  const width = parseFloat(svg.attr('width'));
+  const height = parseFloat(svg.attr('height'));
+  const transform = d3.zoomIdentity
+    .translate(width / 2 - node.x * scale, height / 2 - node.y * scale)
+    .scale(scale);
+  svg.transition().duration(750).call(zoomBehavior.transform, transform);
+}
+
+function displaySearchResultDetails(item) {
+  displayMemoryDetails({
+    id: getSearchItemId(item),
+    type: 'memory',
+    content: item.content || '',
+    hop_distance: item.hop_distance,
+    similarity: item.similarity,
+    importance: item.importance,
+    created_at: item.created_at,
+  });
+}
+
 function debugAnchorMap(eventName, detail) {
   if (window.localStorage.getItem('memento.debug') !== '1') {
     return;
@@ -91,13 +192,13 @@ function initializeMap() {
     .attr('height', height);
 
   // Zoom 패닝 기능
-  const zoom = d3.zoom()
+  zoomBehavior = d3.zoom()
     .scaleExtent([0.1, 4])
     .on('zoom', (event) => {
       svg.select('g').attr('transform', event.transform);
     });
 
-  svg.call(zoom);
+  svg.call(zoomBehavior);
 
   // 그룹 생성 (zoom 적용)
   svg.append('g');
@@ -135,6 +236,22 @@ function setupEventListeners() {
   document.getElementById('anchor-list')?.addEventListener('click', (e) => {
     const el = e.target.closest('.js-select-anchor');
     if (el && el.dataset.memoryId) selectAnchorNode(el.dataset.memoryId);
+  });
+
+  document.getElementById('anchor-search-results')?.addEventListener('click', (e) => {
+    const el = e.target.closest('.js-search-result-item');
+    if (!el?.dataset.memoryId || !searchResults?.items) return;
+    const item = searchResults.items.find(i => getSearchItemId(i) === el.dataset.memoryId);
+    if (!item) return;
+    if (Array.isArray(nodes)) {
+      const node = nodes.find(n => n.id === el.dataset.memoryId);
+      if (node) {
+        selectNode(node);
+        focusOnNode(node, 1.5);
+        return;
+      }
+    }
+    displaySearchResultDetails(item);
   });
   
   // 자동 새로고침 토글
@@ -332,6 +449,10 @@ function renderMap() {
 
   simulation.force('link').links(links);
   simulation.alpha(1).restart();
+
+  if (searchResults?.items?.length) {
+    highlightSearchResults();
+  }
 }
 
 /**
@@ -546,19 +667,7 @@ function selectAnchorNode(memoryId) {
   const node = nodes.find(n => n.id === memoryId);
   if (node) {
     selectNode(node);
-    
-    // 맵에서 해당 노드로 이동 (노드가 보이도록 확대 및 이동)
-    const width = svg.attr('width');
-    const height = svg.attr('height');
-    if (node.x && node.y) {
-      const transform = d3.zoomIdentity
-        .translate(parseFloat(width) / 2 - node.x, parseFloat(height) / 2 - node.y)
-        .scale(2);
-      svg.transition().duration(750).call(
-        svg.node().dispatchEvent,
-        new CustomEvent('zoom', { detail: { transform } })
-      );
-    }
+    focusOnNode(node, 2);
   }
 }
 
@@ -591,7 +700,8 @@ async function performSearch() {
   }
   
   try {
-    // search_local 도구 호출
+    updateSearchStatus('검색 중...', false);
+
     const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
     const response = await fetchFn(`/api/anchors/search`, {
       method: 'POST',
@@ -613,14 +723,13 @@ async function performSearch() {
     const result = await response.json();
     searchResults = result.result || result;
     
-    // 검색 결과 하이라이트
     highlightSearchResults();
     
-    // 검색 결과 요약 표시
     const resultCount = searchResults.items ? searchResults.items.length : 0;
     debugAnchorMap('search-complete', { resultCount });
     
   } catch (error) {
+    updateSearchStatus(`검색 실패: ${error.message}`, false);
     debugAnchorMap('search-error', { message: error.message });
     alert(`검색 중 오류가 발생했습니다: ${error.message}`);
   }
@@ -631,38 +740,30 @@ async function performSearch() {
  */
 function highlightSearchResults() {
   if (!searchResults || !searchResults.items) {
+    updateSearchStatus('검색 결과가 없습니다.', false);
+    renderSearchResultsList();
     return;
   }
   
-  // 하이라이트할 노드 ID 수집
   highlightedNodeIds.clear();
   searchResults.items.forEach(item => {
-    highlightedNodeIds.add(item.id);
+    const id = getSearchItemId(item);
+    if (id) highlightedNodeIds.add(id);
   });
   
-  // 노드 스타일 업데이트
   updateNodeHighlight();
+
+  const mapMatchCount = countSearchMapMatches(searchResults.items, nodes);
+  updateSearchStatus(buildSearchStatusMessage(searchResults, mapMatchCount), true);
+  renderSearchResultsList();
   
-  // 검색 결과가 있는 경우 첫 번째 결과로 이동 (맵 노드 배열이 준비된 경우에만 줌/선택)
-  if (searchResults.items.length > 0) {
-    const firstResult = searchResults.items[0];
-    if (Array.isArray(nodes)) {
-      const node = nodes.find(n => n.id === firstResult.id);
-      if (node) {
-        selectNode(node);
-        // 노드가 보이도록 확대 및 이동
-        const width = svg.attr('width');
-        const height = svg.attr('height');
-        if (node.x && node.y) {
-          const transform = d3.zoomIdentity
-            .translate(parseFloat(width) / 2 - node.x, parseFloat(height) / 2 - node.y)
-            .scale(1.5);
-          svg.transition().duration(750).call(
-            svg.node().dispatchEvent,
-            new CustomEvent('zoom', { detail: { transform } })
-          );
-        }
-      }
+  if (searchResults.items.length > 0 && Array.isArray(nodes)) {
+    const firstOnMap = searchResults.items
+      .map(item => nodes.find(n => n.id === getSearchItemId(item)))
+      .find(Boolean);
+    if (firstOnMap) {
+      selectNode(firstOnMap);
+      focusOnNode(firstOnMap, 1.5);
     }
   }
 }
@@ -672,28 +773,30 @@ function highlightSearchResults() {
  */
 function updateNodeHighlight() {
   const nodeElements = svg.selectAll('.node');
+  const mapMatchCount = Array.isArray(nodes)
+    ? nodes.filter(n => highlightedNodeIds.has(n.id)).length
+    : 0;
+  const shouldDimOthers = highlightedNodeIds.size > 0 && mapMatchCount > 0;
   
   nodeElements
     .classed('highlighted', d => highlightedNodeIds.has(d.id))
     .attr('stroke-width', d => {
       if (highlightedNodeIds.has(d.id)) {
-        return d.type === 'anchor' ? 5 : 4; // 하이라이트된 노드는 더 두꺼운 테두리
+        return d.type === 'anchor' ? 5 : 4;
       }
       return d.type === 'anchor' ? 3 : 2;
     })
     .attr('opacity', d => {
-      // 하이라이트되지 않은 노드는 약간 투명하게
-      if (highlightedNodeIds.size > 0 && !highlightedNodeIds.has(d.id)) {
+      if (shouldDimOthers && !highlightedNodeIds.has(d.id)) {
         return 0.3;
       }
-      return 1.0;
+      return d.embedding_missing ? 0.6 : 1.0;
     });
   
-  // 링크도 하이라이트 (검색 결과와 연결된 링크)
   const linkElements = svg.selectAll('.link');
   linkElements
     .attr('opacity', d => {
-      if (highlightedNodeIds.size > 0) {
+      if (shouldDimOthers) {
         const sourceHighlighted = highlightedNodeIds.has(d.source.id || d.source);
         const targetHighlighted = highlightedNodeIds.has(d.target.id || d.target);
         if (sourceHighlighted || targetHighlighted) {
@@ -732,7 +835,8 @@ function clearSearch() {
   document.getElementById('search-query-input').value = '';
   document.getElementById('search-slot-select').value = 'A';
   
-  // 노드 스타일 복원
+  updateSearchStatus('검색 후 결과가 여기에 표시됩니다.', false);
+  renderSearchResultsList();
   updateNodeHighlight();
   
   debugAnchorMap('search-cleared');


### PR DESCRIPTION
## Summary

Closes #570

- **벡터 검색 limit 버그**: `limit: 100`일 때 `HybridSearchEngine`이 VEC prefetch limit `200`을 전달해 `VectorSearchService` 검증(1–100)에 실패하던 문제를 `resolveHybridVectorPrefetchLimit()`으로 상한 100 캡
- **검색 UX**: sidebar 검색 상태 메시지·결과 목록 추가, 맵 매칭 0건일 때 불필요한 dimming 비활성, `d3.zoom().transform` 기반 포커스 이동 수정
- **툴팁**: Agent ID, Search, Slot, 버튼, Auto Refresh, legend 등 Anchor Map 컨트롤에 `title` 설명 추가

## Test plan

- [x] `npx vitest run packages/memento-core/.../hybrid-search-engine.spec.ts -t "resolveHybridVectorPrefetchLimit|limit이 100"`
- [x] `npx vitest run packages/memento-server/.../anchor-map-search-highlight.spec.ts`
- [x] `npx vitest run tests/static-design-contracts.spec.ts`
- [x] `npm run build` / `npm run lint`
- [ ] `npm run dev:http` → Anchor Map에서 `memento` 검색 시 sidebar 결과·상태 표시, 서버 로그에 `VEC 벡터 검색 실패` 없음