### PR TITLE
feat(dashboard): Anchor Map Agent ID 드롭다운 선택

### DIFF
--- a/packages/memento-server/src/server/auth-session.integration.spec.ts
+++ b/packages/memento-server/src/server/auth-session.integration.spec.ts
@@ -174,6 +174,27 @@ describe('auth session integration', () => {
     expect(api.statusCode).toBe(200);
   });
 
+  it('allows signed-in GET /api/anchors/agents with agent list shape', async () => {
+    const port = await startRealHttpServer();
+
+    const login = await postJson(port, '/auth/session', {}, {
+      Authorization: 'Bearer integration-admin-key'
+    });
+    const sessionCookie = login.headers['set-cookie']?.[0] ?? '';
+
+    const agents = await getJson(port, '/api/anchors/agents', { Cookie: sessionCookie });
+
+    expect(agents.statusCode).toBe(200);
+    const payload = JSON.parse(agents.body) as {
+      agents?: unknown[];
+      agent_ids?: unknown[];
+      timestamp?: string;
+    };
+    expect(Array.isArray(payload.agents)).toBe(true);
+    expect(Array.isArray(payload.agent_ids)).toBe(true);
+    expect(typeof payload.timestamp).toBe('string');
+  });
+
   it('allows signed-in POST /api/anchors/search with search_local-compatible result shape', async () => {
     const port = await startRealHttpServer();
 

--- a/packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts
+++ b/packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { listAnchorAgentIds } from './anchor-map.handler.js';
+
+function createAnchorSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE anchor (
+      agent_id TEXT NOT NULL,
+      slot TEXT NOT NULL CHECK (slot IN ('A', 'B', 'C')),
+      memory_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (agent_id, slot)
+    );
+  `);
+}
+
+describe('listAnchorAgentIds', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createAnchorSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns empty array when no anchors have memory_id set', () => {
+    db.prepare(`
+      INSERT INTO anchor (agent_id, slot, memory_id)
+      VALUES ('default', 'A', NULL)
+    `).run();
+
+    expect(listAnchorAgentIds(db)).toEqual([]);
+  });
+
+  it('groups anchors by agent_id and counts only rows with memory_id', () => {
+    db.prepare(`
+      INSERT INTO anchor (agent_id, slot, memory_id) VALUES
+        ('agent-a', 'A', 'mem-1'),
+        ('agent-a', 'B', 'mem-2'),
+        ('agent-b', 'A', 'mem-3'),
+        ('agent-b', 'C', NULL)
+    `).run();
+
+    expect(listAnchorAgentIds(db)).toEqual([
+      { agent_id: 'agent-a', anchor_count: 2 },
+      { agent_id: 'agent-b', anchor_count: 1 },
+    ]);
+  });
+
+  it('orders results by agent_id ascending', () => {
+    db.prepare(`
+      INSERT INTO anchor (agent_id, slot, memory_id) VALUES
+        ('zebra', 'A', 'mem-z'),
+        ('alpha', 'A', 'mem-a'),
+        ('middle', 'A', 'mem-m')
+    `).run();
+
+    expect(listAnchorAgentIds(db).map(entry => entry.agent_id)).toEqual([
+      'alpha',
+      'middle',
+      'zebra',
+    ]);
+  });
+});

--- a/packages/memento-server/src/server/handlers/anchor-map.handler.ts
+++ b/packages/memento-server/src/server/handlers/anchor-map.handler.ts
@@ -36,6 +36,32 @@ export interface AnchorMapLink {
 }
 
 /**
+ * Agent ID별 앵커 개수 항목
+ */
+export interface AnchorAgentIdEntry {
+  agent_id: string;
+  anchor_count: number;
+}
+
+/**
+ * memory_id가 설정된 앵커를 agent_id별로 집계
+ */
+export function listAnchorAgentIds(db: Database.Database): AnchorAgentIdEntry[] {
+  const rows = db.prepare(`
+    SELECT agent_id, COUNT(*) AS anchor_count
+    FROM anchor
+    WHERE memory_id IS NOT NULL
+    GROUP BY agent_id
+    ORDER BY agent_id ASC
+  `).all() as Array<{ agent_id: string; anchor_count: number }>;
+
+  return rows.map(row => ({
+    agent_id: row.agent_id,
+    anchor_count: Number(row.anchor_count),
+  }));
+}
+
+/**
  * Anchor Map 데이터 타입
  */
 export interface AnchorMapData {

--- a/packages/memento-server/src/server/routes/api.routes.ts
+++ b/packages/memento-server/src/server/routes/api.routes.ts
@@ -7,7 +7,7 @@
 import { Router } from 'express';
 import type Database from 'better-sqlite3';
 import type { ServerServices } from '../bootstrap.js';
-import { buildAnchorMapData } from '../handlers/anchor-map.handler.js';
+import { buildAnchorMapData, listAnchorAgentIds } from '../handlers/anchor-map.handler.js';
 import { extractToolResultPayload } from '../handlers/tool-result.utils.js';
 import { createToolContext } from '../context.js';
 import {
@@ -26,6 +26,35 @@ export function createApiRouter(
   serverServices: ServerServices | null
 ): Router {
   const router = Router();
+
+  // Agent ID 목록 (앵커가 설정된 agent_id 집계)
+  router.get('/anchors/agents', (req, res) => {
+    try {
+      if (!db) {
+        return res.status(500).json({
+          error: 'Database not connected',
+          message: '데이터베이스가 연결되지 않았습니다',
+        });
+      }
+
+      const agents = listAnchorAgentIds(db);
+      const agent_ids = agents.map(entry => entry.agent_id);
+
+      return res.json({
+        agents,
+        agent_ids,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error) {
+      logger.error('Anchor agent list retrieval failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return res.status(500).json({
+        error: 'Failed to list anchor agent ids',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  });
 
   // Anchor Map 조회
   router.get('/anchors/map', async (req, res) => {

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -38,8 +38,10 @@
         </section>
       </div>
       <div class="header-controls session-only">
-        <label for="agent-id-input" title="맵·검색 API에 사용할 에이전트 식별자입니다. 기본값은 default입니다.">Agent ID:</label>
-        <input type="text" id="agent-id-input" class="m-input" value="default" placeholder="default" title="맵·검색 API에 사용할 에이전트 식별자입니다.">
+        <label for="agent-id-select" title="맵·검색 API에 사용할 에이전트 식별자입니다. 앵커가 설정된 agent_id 목록에서 선택합니다.">Agent ID:</label>
+        <select id="agent-id-select" class="m-input" title="맵·검색 API에 사용할 에이전트 식별자입니다. 앵커가 설정된 agent_id 목록에서 선택합니다.">
+          <option value="default">default (앵커 없음)</option>
+        </select>
         <label for="search-query-input" title="선택한 앵커 슬롯 주변에서 검색합니다. 국소 결과가 부족하면 전역 검색으로 확장됩니다.">Search:</label>
         <input type="text" id="search-query-input" class="m-input" placeholder="Search memories..." title="검색어를 입력하고 Search 또는 Enter를 누르세요.">
         <select id="search-slot-select" class="m-input" title="검색 기준 앵커 슬롯입니다. A=1-hop, B=2-hop, C=3-hop 범위가 적용됩니다.">

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -193,9 +193,10 @@ function debugAnchorMap(eventName, detail) {
 }
 
 // 초기화
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   initializeMap();
   setupEventListeners();
+  await loadAgentIdOptions();
   loadMapData();
 });
 
@@ -302,10 +303,9 @@ function setupEventListeners() {
     }
   });
   
-  document.getElementById('agent-id-input').addEventListener('keypress', (e) => {
-    if (e.key === 'Enter') {
-      loadMapData();
-    }
+  document.getElementById('agent-id-select').addEventListener('change', () => {
+    loadMapData();
+    resubscribeWebSocket();
   });
   
   document.getElementById('search-query-input').addEventListener('keypress', (e) => {
@@ -319,10 +319,73 @@ function setupEventListeners() {
 }
 
 /**
+ * 선택된 Agent ID 반환
+ */
+function getSelectedAgentId() {
+  const select = document.getElementById('agent-id-select');
+  return select?.value || 'default';
+}
+
+/**
+ * Agent ID 선택 목록 로드
+ */
+async function loadAgentIdOptions() {
+  const select = document.getElementById('agent-id-select');
+  if (!select) return;
+
+  const previousSelection = getSelectedAgentId();
+
+  try {
+    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+    const response = await fetchFn('/api/anchors/agents');
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const agents = Array.isArray(payload.agents) ? payload.agents : [];
+
+    select.innerHTML = '';
+
+    if (agents.length === 0) {
+      const option = document.createElement('option');
+      option.value = 'default';
+      option.textContent = 'default (앵커 없음)';
+      select.appendChild(option);
+    } else {
+      for (const entry of agents) {
+        const option = document.createElement('option');
+        option.value = entry.agent_id;
+        option.textContent = `${entry.agent_id} (${entry.anchor_count} anchors)`;
+        select.appendChild(option);
+      }
+    }
+
+    const validValues = Array.from(select.options).map(option => option.value);
+    if (validValues.includes(previousSelection)) {
+      select.value = previousSelection;
+    } else if (agents.length > 0) {
+      select.value = agents[0].agent_id;
+    } else {
+      select.value = 'default';
+    }
+  } catch (error) {
+    debugAnchorMap('agent-list-load-error', { message: error.message });
+    if (select.options.length === 0) {
+      const option = document.createElement('option');
+      option.value = 'default';
+      option.textContent = 'default (앵커 없음)';
+      select.appendChild(option);
+      select.value = 'default';
+    }
+  }
+}
+
+/**
  * 맵 데이터 로드
  */
 async function loadMapData() {
-  const agentId = document.getElementById('agent-id-input').value || 'default';
+  const agentId = getSelectedAgentId();
   
   try {
     const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
@@ -348,6 +411,8 @@ async function loadMapData() {
     } else {
       debugAnchorMap('map-unchanged');
     }
+
+    await loadAgentIdOptions();
   } catch (error) {
     debugAnchorMap('load-error', { message: error.message });
     // 에러 알림은 자동 새로고침 시에는 표시하지 않음
@@ -731,7 +796,7 @@ async function performSearch() {
   const query = document.getElementById('search-query-input').value.trim();
   const slotSelect = document.getElementById('search-slot-select');
   const slot = slotSelect ? slotSelect.value : 'A'; // 기본값: A
-  const agentId = document.getElementById('agent-id-input').value || 'default';
+  const agentId = getSelectedAgentId();
   
   if (!query) {
     alert('검색어를 입력해주세요.');
@@ -933,15 +998,7 @@ function tryConnectWebSocket() {
     
     websocket.onopen = () => {
       debugAnchorMap('websocket-open');
-      // WebSocket으로 Anchor Map 업데이트 구독 요청
-      const agentId = document.getElementById('agent-id-input').value || 'default';
-      websocket.send(JSON.stringify({
-        method: 'subscribe',
-        params: {
-          type: 'anchor_map_updates',
-          agent_id: agentId
-        }
-      }));
+      resubscribeWebSocket();
     };
     
     websocket.onmessage = (event) => {
@@ -996,6 +1053,21 @@ function tryConnectWebSocket() {
 }
 
 /**
+ * WebSocket 재구독
+ */
+function resubscribeWebSocket() {
+  if (websocket && websocket.readyState === WebSocket.OPEN) {
+    websocket.send(JSON.stringify({
+      method: 'subscribe',
+      params: {
+        type: 'anchor_map_updates',
+        agent_id: getSelectedAgentId()
+      }
+    }));
+  }
+}
+
+/**
  * WebSocket 연결 종료
  */
 function disconnectWebSocket() {
@@ -1004,25 +1076,6 @@ function disconnectWebSocket() {
     websocket = null;
   }
 }
-
-// Agent ID 변경 시 WebSocket 재구독
-document.addEventListener('DOMContentLoaded', () => {
-  const agentIdInput = document.getElementById('agent-id-input');
-  if (agentIdInput) {
-    agentIdInput.addEventListener('change', () => {
-      if (websocket && websocket.readyState === WebSocket.OPEN) {
-        const agentId = agentIdInput.value || 'default';
-        websocket.send(JSON.stringify({
-          method: 'subscribe',
-          params: {
-            type: 'anchor_map_updates',
-            agent_id: agentId
-          }
-        }));
-      }
-    });
-  }
-});
 
 // 페이지 언로드 시 정리
 window.addEventListener('beforeunload', () => {

--- a/tests/e2e/dashboard/anchor-map.e2e.ts
+++ b/tests/e2e/dashboard/anchor-map.e2e.ts
@@ -234,6 +234,17 @@ test.describe('Anchor Map dashboard', () => {
     await page.route('https://d3js.org/**', (route) =>
       route.fulfill({ status: 200, contentType: 'text/javascript', body: d3Stub }),
     );
+    await page.route('**/api/anchors/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [{ agent_id: 'default', anchor_count: 3 }],
+          agent_ids: ['default'],
+          timestamp: '2026-06-21T00:00:00.000Z',
+        }),
+      }),
+    );
     await page.route('**/api/anchors/map?**', (route) =>
       route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mapPayload) }),
     );


### PR DESCRIPTION
## Summary
- `GET /api/anchors/agents` API 추가 — `anchor` 테이블에서 `memory_id`가 있는 `agent_id` 목록과 슬롯 수 반환
- 대시보드 Agent ID 텍스트 입력을 `<select>` 드롭다운으로 교체 (`agent_id (N anchors)` 표시)
- Agent 선택 변경 시 맵 재로드 및 WebSocket 재구독, 맵 로드 성공 후 agent 목록 갱신

## Background
Anchor Map SVG는 선택한 `agent_id`의 앵커 데이터로만 그려집니다. 기존에는 `default` 등 ID를 직접 입력해야 해서 MCP `set_anchor`로 다른 agent에 앵커를 설정한 경우 빈 맵으로 보이는 문제가 있었습니다.

## Test plan
- [x] `anchor-map.handler.spec.ts` — `listAnchorAgentIds` unit test
- [x] `auth-session.integration.spec.ts` — signed-in `GET /api/anchors/agents`
- [x] `static-design-contracts.spec.ts` — 기존 anchor-map 계약 유지
- [x] `anchor-map.e2e.ts` — agents API mock 및 select 연동
- [ ] 수동: `npm run dev:http` → 대시보드 로그인 → Agent ID 드롭다운 확인 → Load Map