### PR TITLE
feat(batch): periodic anchor auto-refresh + remove idle memento-base container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '3.8'
 
 services:
+  memento-base:
+    profiles:
+      - base-only
+    extends:
+      file: docker-compose.base.yml
+      service: memento-base
+
   memento-mcp-server:
     extends:
       file: docker-compose.base.yml

--- a/packages/memento-core/src/bootstrap.spec.ts
+++ b/packages/memento-core/src/bootstrap.spec.ts
@@ -39,6 +39,7 @@ const mockState = vi.hoisted(() => {
     setTelemetryCleanupRepository: vi.fn(),
     setIntrospectionScanCache: vi.fn(),
     setSleepConsolidationService: vi.fn(),
+    setAnchorManager: vi.fn(),
     start: vi.fn().mockResolvedValue(undefined),
     getStatus: vi.fn(() => ({
       isRunning: true,

--- a/packages/memento-core/src/bootstrap.ts
+++ b/packages/memento-core/src/bootstrap.ts
@@ -105,7 +105,8 @@ export async function initializeServices(db: Database.Database): Promise<ServerS
       db,
       embeddingService,
       runtimeDiagnosticsLogger,
-      reflexionWorker
+      reflexionWorker,
+      anchorManager
     );
     const { runtimeDiagnosticsSamplerCleanup } = createRuntimeDiagnosticsSampler({
       mementoConfig,

--- a/packages/memento-core/src/bootstrap/batch-telemetry-relation.ts
+++ b/packages/memento-core/src/bootstrap/batch-telemetry-relation.ts
@@ -9,12 +9,14 @@ import { TelemetryService } from '../domains/telemetry/services/telemetry-servic
 import type { MemoryEmbeddingService } from '../domains/memory/services/memory-embedding-service.js';
 import type { RuntimeDiagnosticsLogger } from '../domains/monitoring/services/runtime-diagnostics-logger.js';
 import type { IReflexionWorker } from '../shared/interfaces/reflexion-worker.interface.js';
+import type { AnchorManager } from '../domains/anchor/services/anchor/anchor-manager.js';
 
 export async function createBatchTelemetryRelationAndSleep(
   db: Database.Database,
   embeddingService: MemoryEmbeddingService,
   runtimeDiagnosticsLogger: RuntimeDiagnosticsLogger,
-  reflexionWorker: IReflexionWorker | undefined
+  reflexionWorker: IReflexionWorker | undefined,
+  anchorManager?: AnchorManager
 ): Promise<{
   introspectionScanCache: IntrospectionScanCache;
   telemetryRepository: TelemetryRepository;
@@ -30,6 +32,9 @@ export async function createBatchTelemetryRelationAndSleep(
   batchScheduler.setTelemetryCleanupRepository(telemetryRepository);
   const telemetryService = new TelemetryService(telemetryRepository, () => getBatchScheduler());
   batchScheduler.setIntrospectionScanCache(introspectionScanCache);
+  if (anchorManager) {
+    batchScheduler.setAnchorManager(anchorManager);
+  }
   const relationGraph = createRelationGraph(db);
   const sleepConsolidationService = new SleepConsolidationService(db, {
     relationGraph: relationGraph,

--- a/packages/memento-core/src/infrastructure/scheduler/batch-recurring-schedules.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-recurring-schedules.ts
@@ -7,6 +7,7 @@ export interface BatchRecurringScheduleContext {
   readonly hasConsolidationScoreWorker: boolean;
   readonly hasSleepConsolidation: boolean;
   readonly hasTelemetryCleanup: boolean;
+  readonly hasAnchorManager: boolean;
   scheduleJob: (name: string, interval: number, job: () => Promise<void>, priority: number) => void;
   readonly lastExecution: Map<string, Date>;
   readonly intervals: Map<string, ReturnType<typeof setInterval>>;
@@ -25,6 +26,7 @@ export interface BatchRecurringScheduleContext {
   runMemoryReviewCandidatesJob: () => Promise<BatchJobResult>;
   runSleepConsolidationBatch: () => Promise<BatchJobResult>;
   runTelemetryCleanupBatch: () => Promise<void>;
+  runAnchorAutoRefresh: () => Promise<BatchJobResult>;
 }
 
 export function scheduleCleanupJob(ctx: BatchRecurringScheduleContext): void {
@@ -241,9 +243,25 @@ export function scheduleTelemetryCleanup(ctx: BatchRecurringScheduleContext): vo
   );
 }
 
+export function scheduleAnchorAutoRefresh(ctx: BatchRecurringScheduleContext): void {
+  ctx.scheduleJob(
+    'anchor_auto_refresh',
+    ctx.config.anchorAutoRefreshInterval,
+    async () => { await ctx.runAnchorAutoRefresh(); },
+    9
+  );
+}
+
 export function registerAllRecurringJobs(ctx: BatchRecurringScheduleContext): void {
   scheduleCoreMaintenanceJobs(ctx);
   scheduleConsolidationRelationAndLogJobs(ctx);
   scheduleAugmentationAndTelemetryJobs(ctx);
   scheduleMetaMemoryAndReviewJobs(ctx);
+  if (ctx.config.anchorAutoRefreshEnabled && ctx.hasAnchorManager) {
+    scheduleAnchorAutoRefresh(ctx);
+  } else {
+    ctx.log('anchor_auto_refresh schedule disabled (ANCHOR_AUTO_REFRESH_ENABLED=false or anchorManager not available)', {
+      level: 'info'
+    });
+  }
 }

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts
@@ -48,6 +48,15 @@ export function mergeBatchSchedulerJobConfig(overrides?: Partial<BatchJobConfig>
     memoryReviewCandidatesSchedulerEnabled: resolveBoolean('MEMORY_REVIEW_CANDIDATES_SCHEDULER_ENABLED', {
       defaultValue: true
     }),
+    anchorAutoRefreshInterval: resolveValidatedNumber(
+      'ANCHOR_AUTO_REFRESH_INTERVAL_MS',
+      6 * 60 * 60 * 1000,
+      n => n >= 60_000,
+      '최솟값 60000'
+    ),
+    anchorAutoRefreshEnabled: resolveBoolean('ANCHOR_AUTO_REFRESH_ENABLED', {
+      defaultValue: true
+    }),
     maxBatchSize: 1000,
     enableLogging: true,
     enableNotifications: false,

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts
@@ -29,6 +29,10 @@ export interface BatchJobConfig {
    * Manual/HTTP `runJob('memory_review_candidates')` and `/admin/batch/run` still work.
    */
   memoryReviewCandidatesSchedulerEnabled: boolean;
+  /** Interval (ms) for the periodic anchor auto-refresh batch job. */
+  anchorAutoRefreshInterval: number;
+  /** When false, skip registering the anchor auto-refresh periodic schedule. */
+  anchorAutoRefreshEnabled: boolean;
 
   maxBatchSize: number;
   enableLogging: boolean;

--- a/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/batch-scheduler.ts
@@ -54,6 +54,8 @@ import {
   runSleepConsolidationBatch,
   runTelemetryCleanupBatch
 } from './handlers/batch-scheduler-sleep-telemetry-handlers.js';
+import { runAnchorAutoRefresh } from './handlers/batch-scheduler-anchor-handlers.js';
+import type { AnchorManager } from '../../domains/anchor/services/anchor/anchor-manager.js';
 import {
   registerAllRecurringJobs,
   scheduleCleanupJob,
@@ -95,6 +97,7 @@ export class BatchScheduler implements IBatchScheduler {
   private telemetryCleanupRepository: TelemetryRepository | null = null;
   private telemetryCleanupBatchJob: TelemetryCleanupBatchJob | null = null;
   private diagnosticsLogger?: Pick<RuntimeDiagnosticsLogger, 'writeEvent'>;
+  private anchorManager: AnchorManager | null = null;
   private jobExecutionCoordinator!: BatchJobExecutionCoordinator;
 
   constructor(
@@ -198,6 +201,7 @@ export class BatchScheduler implements IBatchScheduler {
       },
       lastExecution: self.lastExecution,
       totalExecutions: self.totalExecutions,
+      anchorManager: self.anchorManager,
       log: self.log.bind(self),
       emitMemoryReviewCandidatesRunRecord: self.emitMemoryReviewCandidatesRunRecord.bind(self)
     };
@@ -262,6 +266,7 @@ export class BatchScheduler implements IBatchScheduler {
       hasConsolidationScoreWorker: this.consolidationScoreWorker !== null,
       hasSleepConsolidation: this.sleepConsolidationService != null,
       hasTelemetryCleanup: this.telemetryCleanupRepository != null,
+      hasAnchorManager: this.anchorManager != null,
       scheduleJob: (name, interval, job, priority) => this.scheduleJob(name, interval, job, priority),
       lastExecution: this.lastExecution,
       intervals: this.intervals,
@@ -279,7 +284,8 @@ export class BatchScheduler implements IBatchScheduler {
       runMetaMemoryIntrospection: () => this.runMetaMemoryIntrospection(),
       runMemoryReviewCandidatesJob: () => this.runMemoryReviewCandidatesJob(),
       runSleepConsolidationBatch: () => this.runSleepConsolidationBatch(),
-      runTelemetryCleanupBatch: () => this.runTelemetryCleanupBatch()
+      runTelemetryCleanupBatch: () => this.runTelemetryCleanupBatch(),
+      runAnchorAutoRefresh: () => this.runAnchorAutoRefresh()
     };
   }
 
@@ -564,7 +570,7 @@ export class BatchScheduler implements IBatchScheduler {
    * 직접 실행하되 lastExecution과 totalExecutions을 기록함
    */
   async runJob(
-    jobType: 'cleanup' | 'monitoring' | 'healthcheck' | 'meta_memory_introspection' | 'memory_review_candidates'
+    jobType: 'cleanup' | 'monitoring' | 'healthcheck' | 'meta_memory_introspection' | 'memory_review_candidates' | 'anchor_auto_refresh'
   ): Promise<BatchJobResult> {
     let result: BatchJobResult;
 
@@ -583,6 +589,9 @@ export class BatchScheduler implements IBatchScheduler {
         break;
       case 'memory_review_candidates':
         result = await this.runMemoryReviewCandidatesJob();
+        break;
+      case 'anchor_auto_refresh':
+        result = await this.runAnchorAutoRefresh();
         break;
       default:
         throw new Error(`Unknown job type: ${jobType}`);
@@ -857,6 +866,10 @@ export class BatchScheduler implements IBatchScheduler {
     this.diagnosticsLogger = logger;
   }
 
+  setAnchorManager(anchorManager: AnchorManager | null): void {
+    this.anchorManager = anchorManager;
+  }
+
   getLastJobRunMeta(
     name: string
   ): { at: Date; success: boolean; durationMs: number } | undefined {
@@ -870,6 +883,10 @@ export class BatchScheduler implements IBatchScheduler {
 
   private async runSleepConsolidationBatch(): Promise<BatchJobResult> {
     return runSleepConsolidationBatch(this.buildRunContext());
+  }
+
+  private async runAnchorAutoRefresh(): Promise<BatchJobResult> {
+    return runAnchorAutoRefresh(this.buildRunContext());
   }
 }
 

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
@@ -1,0 +1,114 @@
+import type { BatchJobResult } from '../batch-scheduler-types.js';
+import { createEmptyBatchJobResult, finalizeBatchJobTiming } from '../batch-scheduler-internal-helpers.js';
+import type { BatchSchedulerRunContext } from './batch-scheduler-run-context.js';
+
+const SLOTS = ['A', 'B', 'C'] as const;
+type Slot = (typeof SLOTS)[number];
+
+interface AnchorRow {
+  agent_id: string;
+  slot: string;
+  updated_at: string;
+}
+
+interface MemoryCandidate {
+  id: string;
+}
+
+/**
+ * Periodically refreshes anchor slots with recent high-importance memories.
+ *
+ * Rationale: `autoReanchor` only discovers candidates via N-hop traversal from the
+ * *current* anchor embedding, so it can never reach memories that have no relation
+ * path back to a stale anchor.  This job bypasses that limitation by querying the
+ * DB directly for recent/important memories and calling setAnchor explicitly.
+ *
+ * Staleness threshold: 7 days.  Only slots whose `updated_at` is older than that
+ * are touched, so anchors updated by normal recall flow are never overwritten.
+ */
+export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promise<BatchJobResult> {
+  const result = createEmptyBatchJobResult('anchor_auto_refresh');
+
+  try {
+    if (!ctx.anchorManager || !ctx.db) {
+      ctx.log('anchor_auto_refresh skipped: anchorManager or db not available');
+      result.success = true;
+      result.processed = 0;
+      finalizeBatchJobTiming(result);
+      return result;
+    }
+
+    const db = ctx.db;
+
+    const agentIds = (
+      db.prepare('SELECT DISTINCT agent_id FROM anchor').all() as { agent_id: string }[]
+    ).map(r => r.agent_id);
+
+    if (agentIds.length === 0) {
+      result.success = true;
+      result.processed = 0;
+      finalizeBatchJobTiming(result);
+      return result;
+    }
+
+    let totalMoved = 0;
+    const stalenessThresholdDays = 7;
+    const now = Date.now();
+
+    for (const agentId of agentIds) {
+      const existingAnchors = db
+        .prepare('SELECT agent_id, slot, updated_at FROM anchor WHERE agent_id = ?')
+        .all(agentId) as AnchorRow[];
+
+      for (const slot of SLOTS) {
+        const existing = existingAnchors.find(a => a.slot === slot);
+        if (existing) {
+          const updatedAt = new Date(existing.updated_at).getTime();
+          const daysSince = (now - updatedAt) / (1000 * 60 * 60 * 24);
+          if (daysSince < stalenessThresholdDays) {
+            continue;
+          }
+        }
+
+        // Pick the most recent high-importance memory for this agent.
+        // NULL owner_id memories are shared across all agents (the common case).
+        const slotIndex = SLOTS.indexOf(slot as Slot);
+        const candidates = db
+          .prepare(
+            `SELECT id FROM memory_item
+             WHERE (owner_id = ? OR owner_id IS NULL)
+               AND deleted_at IS NULL
+             ORDER BY importance DESC, created_at DESC
+             LIMIT ?`
+          )
+          .all(agentId, slotIndex + 3) as MemoryCandidate[];
+
+        const candidate = candidates[slotIndex] ?? candidates[candidates.length - 1];
+        if (!candidate) {
+          continue;
+        }
+
+        try {
+          await ctx.anchorManager.setAnchor(agentId, candidate.id, slot as Slot);
+          totalMoved++;
+          ctx.log(`anchor_auto_refresh: moved ${agentId}/${slot} → ${candidate.id}`);
+        } catch (err) {
+          result.errors.push(
+            `Failed to set anchor ${agentId}/${slot}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+
+    result.success = result.errors.length === 0;
+    result.processed = totalMoved;
+    ctx.log('anchor_auto_refresh completed', { moved: totalMoved, agents: agentIds.length });
+  } catch (error) {
+    result.errors.push(error instanceof Error ? error.message : String(error));
+    ctx.log('anchor_auto_refresh failed', error, 'error');
+  } finally {
+    finalizeBatchJobTiming(result);
+  }
+
+  return result;
+}

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts
@@ -19,6 +19,7 @@ import type { TelemetryCleanupBatchJob } from '../jobs/telemetry-cleanup-batch-j
 import type { SleepConsolidationService } from '../../../domains/consolidation/services/sleep-consolidation-service.js';
 import type { TelemetryRepository } from '../../../domains/telemetry/repositories/telemetry-repository.js';
 import type { PerformanceMonitor } from '../../../domains/monitoring/services/performance-monitor.js';
+import type { AnchorManager } from '../../../domains/anchor/services/anchor/anchor-manager.js';
 
 /** Matches `BatchScheduler.log` (third arg defaults to info). */
 export type BatchSchedulerLogMethod = (
@@ -51,6 +52,7 @@ export interface BatchSchedulerRunContext {
   readonly telemetryCleanupBatchJob: MutableJobRef<TelemetryCleanupBatchJob>;
   readonly lastExecution: Map<string, Date>;
   readonly totalExecutions: Map<string, number>;
+  readonly anchorManager: AnchorManager | null;
   log: BatchSchedulerLogMethod;
   emitMemoryReviewCandidatesRunRecord: (result: BatchJobResult) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- **Anchor auto-refresh batch job**: anchors were stuck at 2026-03-17 because `autoReanchor()` uses N-hop traversal from the current anchor embedding — it cannot reach memories that have no relation path back to a stale anchor. New `anchor_auto_refresh` job bypasses this by directly querying `memory_item` for highest-importance, most-recent memories and calling `setAnchor()` explicitly. Only slots older than 7 days are refreshed.
- **Remove idle `memento-base` container**: `memento-base` is only needed as an `extends` source for `memento-mcp-server`. Added `profiles: [base-only]` in `docker-compose.yml` to prevent it from being started by `docker compose up`.

## Changes

- `batch-scheduler-anchor-handlers.ts` (new): `runAnchorAutoRefresh()` handler — queries DB directly, sets A/B/C slots
- `batch-scheduler-types.ts`: `anchorAutoRefreshInterval`, `anchorAutoRefreshEnabled` fields
- `batch-scheduler-default-config.ts`: defaults to 6h interval; env vars `ANCHOR_AUTO_REFRESH_INTERVAL_MS` / `ANCHOR_AUTO_REFRESH_ENABLED`
- `batch-scheduler-run-context.ts`: `anchorManager` field
- `batch-recurring-schedules.ts`: `scheduleAnchorAutoRefresh()` + register in `registerAllRecurringJobs()`
- `batch-scheduler.ts`: `setAnchorManager()`, `runAnchorAutoRefresh()`, `runJob('anchor_auto_refresh')` case
- `batch-telemetry-relation.ts`: accepts optional `anchorManager`, calls `setAnchorManager()` before `start()`
- `bootstrap.ts`: passes `anchorManager` to `createBatchTelemetryRelationAndSleep()`
- `docker-compose.yml`: `memento-base` re-declared with `profiles: [base-only]`

## Test plan

- [ ] `docker compose up` → only `memento-mcp-server-1` starts (no `memento-base-1`)
- [ ] Server logs show `anchorAutoRefreshEnabled: true` at startup
- [ ] After deploy, anchor `updated_at` advances from stale date to current timestamp
- [ ] Slots A/B/C point to recent high-importance memories
- [ ] Re-deploy within 7 days → anchor slots skipped (staleness guard works)
- [ ] TypeScript check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)