### PR TITLE
fix(dashboard): Anchor Map 컨트롤을 탭 내부로 이동

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -93,27 +93,29 @@ body {
   color: var(--color-dashboard-auth-error);
 }
 
-.header-controls {
+.anchor-map-toolbar {
   display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
-  margin-top: var(--spacing-md);
   flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-bg-card);
+  border-bottom: 1px solid var(--color-border-light);
 }
 
-.header-controls label {
+.anchor-map-toolbar label {
   font-weight: 500;
 }
 
-.header-controls__auto-refresh {
+.anchor-map-toolbar__auto-refresh {
   margin-left: 1rem;
 }
 
-.header-controls__checkbox {
+.anchor-map-toolbar__checkbox {
   margin-right: 0.25rem;
 }
 
-.header-controls__interval {
+.anchor-map-toolbar__interval {
   margin-left: 0.5rem;
 }
 
@@ -176,6 +178,11 @@ body {
 }
 
 /* Main Content */
+#tab-anchor-map .dashboard-main {
+  flex: 1;
+  min-height: 0;
+}
+
 .dashboard-main {
   display: flex;
   flex: 1;
@@ -438,7 +445,7 @@ body {
     max-width: none;
   }
 
-  .header-controls {
+  .anchor-map-toolbar {
     width: 100%;
   }
 
@@ -476,15 +483,16 @@ body {
     align-items: stretch;
   }
 
-  .header-controls {
+  .anchor-map-toolbar {
     flex-direction: column;
     width: 100%;
   }
 
   .dashboard-auth-input,
   .dashboard-auth-btn,
-  .header-controls input,
-  .header-controls button {
+  .anchor-map-toolbar input,
+  .anchor-map-toolbar button,
+  .anchor-map-toolbar select {
     width: 100%;
   }
 }

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -37,7 +37,21 @@
           <p id="dashboard-auth-message" class="dashboard-auth-message" aria-live="polite"></p>
         </section>
       </div>
-      <div class="header-controls session-only">
+    </header>
+
+    <div class="m-tab-bar" role="tablist" aria-label="대시보드 보기 전환">
+      <button type="button" id="dashboard-tab-anchor" class="m-tab-btn active session-only" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-anchor-map" data-tab="anchor">Anchor Map</button>
+      <button type="button" id="dashboard-tab-embedding" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-embedding-map" data-tab="embedding">Embedding Map</button>
+      <button type="button" id="dashboard-tab-graph" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-graph" data-tab="graph">Memory Graph</button>
+      <button type="button" id="dashboard-tab-review" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-review-candidates" data-tab="review">Review Queue <span id="rc-tab-badge" class="m-tab-badge hidden" aria-hidden="true"></span></button>
+      <button type="button" id="dashboard-tab-agent-sessions" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-agent-sessions" data-tab="agent-sessions">Agent Sessions</button>
+      <button type="button" id="dashboard-tab-evolution-demo" class="m-tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-evolution-demo" data-tab="evolution-demo">기억 진화 데모</button>
+    </div>
+
+    
+
+    <div id="tab-anchor-map" class="tab-panel active session-only" role="tabpanel" aria-labelledby="dashboard-tab-anchor" aria-hidden="false">
+      <div class="anchor-map-toolbar" aria-label="Anchor Map controls">
         <label for="agent-id-select" title="맵·검색 API에 사용할 에이전트 식별자입니다. 앵커가 설정된 agent_id 목록에서 선택합니다.">Agent ID:</label>
         <select id="agent-id-select" class="m-input" title="맵·검색 API에 사용할 에이전트 식별자입니다. 앵커가 설정된 agent_id 목록에서 선택합니다.">
           <option value="default">default (앵커 없음)</option>
@@ -53,31 +67,17 @@
         <button id="load-map-btn" class="m-button m-button--secondary" title="현재 Agent ID의 앵커 맵 데이터를 불러옵니다.">Load Map</button>
         <button id="refresh-btn" class="m-button m-button--secondary" title="맵 데이터를 다시 불러와 그래프를 갱신합니다.">Refresh</button>
         <button id="clear-search-btn" class="m-button m-button--ghost" title="검색어, 하이라이트, 검색 결과 목록을 초기화합니다.">Clear</button>
-        <label for="auto-refresh-toggle" class="header-controls__auto-refresh" title="켜면 선택한 간격마다 맵 데이터를 자동으로 갱신합니다.">
-          <input type="checkbox" id="auto-refresh-toggle" class="header-controls__checkbox">
+        <label for="auto-refresh-toggle" class="anchor-map-toolbar__auto-refresh" title="켜면 선택한 간격마다 맵 데이터를 자동으로 갱신합니다.">
+          <input type="checkbox" id="auto-refresh-toggle" class="anchor-map-toolbar__checkbox">
           Auto Refresh
         </label>
-        <select id="refresh-interval-select" class="m-input header-controls__interval" title="자동 새로고침 간격을 설정합니다.">
+        <select id="refresh-interval-select" class="m-input anchor-map-toolbar__interval" title="자동 새로고침 간격을 설정합니다.">
           <option value="5000">5초</option>
           <option value="10000" selected>10초</option>
           <option value="30000">30초</option>
           <option value="60000">1분</option>
         </select>
       </div>
-    </header>
-
-    <div class="m-tab-bar" role="tablist" aria-label="대시보드 보기 전환">
-      <button type="button" id="dashboard-tab-anchor" class="m-tab-btn active session-only" role="tab" tabindex="0" aria-selected="true" aria-controls="tab-anchor-map" data-tab="anchor">Anchor Map</button>
-      <button type="button" id="dashboard-tab-embedding" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-embedding-map" data-tab="embedding">Embedding Map</button>
-      <button type="button" id="dashboard-tab-graph" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-graph" data-tab="graph">Memory Graph</button>
-      <button type="button" id="dashboard-tab-review" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-review-candidates" data-tab="review">Review Queue <span id="rc-tab-badge" class="m-tab-badge hidden" aria-hidden="true"></span></button>
-      <button type="button" id="dashboard-tab-agent-sessions" class="m-tab-btn session-only" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-agent-sessions" data-tab="agent-sessions">Agent Sessions</button>
-      <button type="button" id="dashboard-tab-evolution-demo" class="m-tab-btn" role="tab" tabindex="-1" aria-selected="false" aria-controls="tab-evolution-demo" data-tab="evolution-demo">기억 진화 데모</button>
-    </div>
-
-    
-
-    <div id="tab-anchor-map" class="tab-panel active session-only" role="tabpanel" aria-labelledby="dashboard-tab-anchor" aria-hidden="false">
       <main class="dashboard-main">
         <div class="sidebar">
           <section class="anchor-info">


### PR DESCRIPTION
## Summary

- 전역 헤더에 있던 Anchor Map 전용 컨트롤(Agent ID, Search, Load Map, Refresh, Auto Refresh)을 `#tab-anchor-map` 상단 `anchor-map-toolbar`로 이동
- Embedding Map / Memory Graph / Review Queue / Agent Sessions 탭에서 더 이상 맵 관련 UI가 노출되지 않음
- element ID는 유지해 `anchor-map.js` 변경 없음; CSS는 `em-controls` 패턴에 맞게 패널 상단 툴바 스타일 적용

## Test plan

- [x] `CI=true npx playwright test tests/e2e/dashboard/anchor-map.e2e.ts`
- [ ] 로그인 후 Anchor Map 탭에서 컨트롤·Load Map·Search 동작 확인
- [ ] 다른 세션 탭 전환 시 `anchor-map-toolbar` 미표시 확인
- [ ] 미로그인 시 `#tab-anchor-map` 전체 숨김(기존 `session-only` 규칙) 확인