### PR TITLE
fix(dashboard): Memory Graph iframe layout and duplicate auth UI

### DIFF
--- a/static/graph.html
+++ b/static/graph.html
@@ -9,16 +9,13 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <link rel="stylesheet" href="/static/css/tokens.css">
   <link rel="stylesheet" href="/static/css/components.css">
-  <script>
-    (function () {
-      var params = new URLSearchParams(window.location.search);
-      if (params.get('embed') === 'dashboard') {
-        document.documentElement.classList.add('graph-view--embedded');
-      }
-    })();
-  </script>
+  <script src="/static/js/graph-embed-init.js"></script>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html {
+      height: 100%;
+    }
 
     body {
       font-family: var(--font-family-base);
@@ -27,6 +24,14 @@
       height: 100vh;
       display: flex;
       flex-direction: column;
+      overflow: hidden;
+    }
+
+    .graph-view-container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
       overflow: hidden;
     }
 
@@ -206,11 +211,13 @@
     .main {
       display: flex;
       flex: 1;
+      min-height: 0;
       overflow: hidden;
     }
 
     #graph-container {
       flex: 1;
+      min-height: 0;
       position: relative;
       overflow: hidden;
     }
@@ -455,8 +462,9 @@
       stroke-opacity: 0.12;
     }
 
-    /* Dashboard embed — Embedding Map 등 다른 탭과 동일한 라이트 패널 스타일 */
+    /* Dashboard embed — iframe viewport + Embedding Map 등과 동일한 라이트 패널 스타일 */
     .graph-view--embedded {
+      height: 100%;
       --color-bg-graph: var(--color-bg-main);
       --color-text-graph: var(--color-text-main);
       --color-border-graph: var(--color-border-light);
@@ -478,6 +486,10 @@
       --color-graph-badge-procedural-text: var(--color-agent-state-degraded-text);
       --color-graph-badge-working-bg: var(--color-memory-neutral-bg);
       --color-graph-badge-working-text: var(--color-memory-neutral-stroke);
+    }
+
+    .graph-view--embedded body {
+      height: 100%;
     }
 
     .graph-view--embedded header h1,

--- a/static/js/graph-embed-init.js
+++ b/static/js/graph-embed-init.js
@@ -1,0 +1,11 @@
+/**
+ * Dashboard iframe embed mode — must run from an external script (CSP blocks inline scripts).
+ */
+(function () {
+  'use strict';
+
+  var params = new URLSearchParams(window.location.search);
+  if (params.get('embed') === 'dashboard') {
+    document.documentElement.classList.add('graph-view--embedded');
+  }
+})();

--- a/static/js/graph-embed-init.js
+++ b/static/js/graph-embed-init.js
@@ -4,7 +4,7 @@
 (function () {
   'use strict';
 
-  var params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(window.location.search);
   if (params.get('embed') === 'dashboard') {
     document.documentElement.classList.add('graph-view--embedded');
   }

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -377,6 +377,12 @@
       errorEl.style.display   = 'none';
     }
 
+    function scheduleGraphResize() {
+      requestAnimationFrame(function () {
+        window.dispatchEvent(new Event('resize'));
+      });
+    }
+
     // ── 데이터 로드 ───────────────────────────────────────────
     async function loadGraph(url) {
       clearStatus();
@@ -402,6 +408,7 @@
         if (!data.nodes || data.nodes.length === 0) {
           applySearchHighlight();
           showEmpty(true);
+          scheduleGraphResize();
           return;
         }
 
@@ -409,6 +416,7 @@
         lastGraphNodes = data.nodes;
         lastGraphEdges = edges;
         renderGraph(data.nodes, edges);
+        scheduleGraphResize();
 
       } catch (err) {
         showLoading(false);

--- a/tests/static-design-contracts.spec.ts
+++ b/tests/static-design-contracts.spec.ts
@@ -63,10 +63,14 @@ describe('static design contracts', () => {
       .map((name) => readStaticFile('static/js/' + name))
       .join('\n');
     const graphSource = readStaticFile('static/graph.html');
+    const embedInitSource = readStaticFile('static/js/graph-embed-init.js');
 
     expect(tabsSource).toContain("'/graph?embed=dashboard'");
     expect(graphSource).toContain('graph-view--embedded');
-    expect(graphSource).toContain("params.get('embed') === 'dashboard'");
+    expect(graphSource).toContain('/static/js/graph-embed-init.js');
+    expect(graphSource).not.toMatch(/<script>\s*\(function\s*\(\)/);
+    expect(embedInitSource).toContain("params.get('embed') === 'dashboard'");
+    expect(embedInitSource).toContain('graph-view--embedded');
   });
 
   it('dashboard.css uses tokens for tab hover and auth messaging colors', () => {


### PR DESCRIPTION
## Summary
- Move dashboard embed detection from an inline script to `graph-embed-init.js` so CSP no longer blocks `graph-view--embedded`, which restores hiding of duplicate Admin API Key / Sign in / Sign out controls inside the Memory Graph iframe.
- Strengthen the flex height chain in `graph.html` so the graph canvas fills the remaining iframe viewport instead of clipping at the bottom.
- Dispatch a post-load resize from `graph.js` to stabilize initial canvas sizing in the dashboard tab.

## Test plan
- [ ] `npm test -- tests/static-design-contracts.spec.ts`
- [ ] `npm test -- packages/memento-server/src/server/dashboard-auth-assets.spec.ts`
- [ ] Open `/dashboard`, sign in, switch to Memory Graph — no duplicate auth row in the iframe toolbar
- [ ] Confirm the graph canvas reaches the bottom of the tab without clipping
- [ ] Open `/graph` standalone — auth UI still appears and graph uses full height after sign-in
- [ ] DevTools console shows no CSP inline-script violations on `/graph?embed=dashboard`