### PR TITLE
chore: 프로덕션 코드 TypeScript any 타입 제거 (Wave 4-8)

### DIFF
--- a/packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts
@@ -36,11 +36,11 @@ export class FallbackStrategy implements IFallbackStrategy {
   /**
    * 전략 실행 (ISearchStrategy 인터페이스 구현)
    */
-  async execute(...args: any[]): Promise<SearchResult> {
+  async execute(...args: unknown[]): Promise<SearchResult> {
     return this.fallback(
-      args[0], // query
-      args[1], // options
-      args[2]  // startTime
+      args[0] as string, // query
+      args[1] as SearchOptions | undefined, // options
+      args[2] as number | undefined  // startTime
     );
   }
 }

--- a/packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts
@@ -178,9 +178,10 @@ export class LocalSearchService {
 
       // Local 결과와 Fallback 결과 병합 (중복 제거)
       const localMemoryIds = new Set(localResults.map(r => r.id));
-      const fallbackItems = fallbackResult.items
-        .filter((item: any) => !localMemoryIds.has(item.id))
-        .map((item: any) => ({
+      type FallbackItem = { id: string; content: string; importance: number; type: string; created_at: string; similarity?: number; hop_distance?: number; tags?: string[] };
+      const fallbackItems = (fallbackResult.items as FallbackItem[])
+        .filter((item) => !localMemoryIds.has(item.id))
+        .map((item) => ({
           id: item.id,
           content: item.content,
           type: item.type,
@@ -189,7 +190,7 @@ export class LocalSearchService {
           importance: item.importance ?? 0.5,
           created_at: item.created_at ?? new Date().toISOString(),
           tags: item.tags ?? undefined
-        }));
+        }))
 
       const finalResults = [...localResults, ...fallbackItems].slice(0, limit);
 

--- a/packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts
@@ -47,15 +47,15 @@ export class NHopSearchStrategy implements INHopSearchStrategy {
   /**
    * 전략 실행 (ISearchStrategy 인터페이스 구현)
    */
-  async execute(...args: any[]): Promise<NHopSearchResult[]> {
+  async execute(...args: unknown[]): Promise<NHopSearchResult[]> {
     return this.search(
-      args[0], // anchorEmbedding
-      args[1], // provider
-      args[2], // anchorMemoryId
-      args[3], // threshold
-      args[4], // maxHops
-      args[5], // limit
-      args[6]  // useRelations
+      args[0] as number[], // anchorEmbedding
+      args[1] as string, // provider
+      args[2] as string, // anchorMemoryId
+      args[3] as number, // threshold
+      args[4] as number, // maxHops
+      args[5] as number, // limit
+      args[6] as boolean | undefined // useRelations
     );
   }
 }

--- a/packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts
@@ -35,11 +35,11 @@ export class QueryFilterStrategy implements IQueryFilterStrategy {
   /**
    * 전략 실행 (ISearchStrategy 인터페이스 구현)
    */
-  async execute(...args: any[]): Promise<NHopSearchResult[]> {
+  async execute(...args: unknown[]): Promise<NHopSearchResult[]> {
     return this.filter(
-      args[0], // query
-      args[1], // results
-      args[2]  // provider
+      args[0] as string, // query
+      args[1] as NHopSearchResult[], // results
+      args[2] as string  // provider
     );
   }
 }

--- a/packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts
@@ -4,7 +4,7 @@
  */
 
 import type { NHopSearchResult } from './n-hop-search-service.js';
-import type { SearchOptions } from './anchor-interfaces.js';
+import type { SearchOptions, SearchResult } from './anchor-interfaces.js';
 
 /**
  * N-hop 검색 결과 타입 (재export)
@@ -70,6 +70,6 @@ export interface IFallbackStrategy extends ISearchStrategy {
     query: string,
     options: SearchOptions | undefined,
     startTime: number | undefined
-  ): Promise<any>; // SearchResult는 anchor-interfaces에서 import
+  ): Promise<SearchResult>;
 }
 

--- a/packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts
+++ b/packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts
@@ -24,7 +24,7 @@ export interface ISearchStrategy {
   /**
    * 전략 실행
    */
-  execute(...args: any[]): Promise<any>;
+  execute(...args: unknown[]): Promise<unknown>;
 }
 
 /**

--- a/packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts
@@ -35,7 +35,7 @@ export class ClearAnchorTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     try {
       // 파라미터 검증
       const { slot, agent_id } = ClearAnchorSchema.parse(params);

--- a/packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts
@@ -35,7 +35,7 @@ export class GetAnchorTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     try {
       // 파라미터 검증
       const { slot, agent_id } = GetAnchorSchema.parse(params);

--- a/packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts
@@ -30,7 +30,7 @@ export class RestoreAnchorsTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     try {
       // 파라미터 검증
       const { agent_id } = RestoreAnchorsSchema.parse(params);
@@ -47,7 +47,7 @@ export class RestoreAnchorsTool extends BaseTool {
       await context.services.anchorManager!.restoreCacheFromDB(context.db!);
       
       // 복원된 앵커 정보 조회
-      const restoredAnchors: any = {};
+      const restoredAnchors: Record<string, { A: unknown; B: unknown; C: unknown }> = {};
       
       if (agent_id) {
         // 특정 agent_id의 앵커만 조회
@@ -103,7 +103,7 @@ export class RestoreAnchorsTool extends BaseTool {
       }
       
       const agentCount = Object.keys(restoredAnchors).length;
-      const totalAnchors = Object.values(restoredAnchors).reduce((sum: number, anchors: any) => {
+      const totalAnchors = Object.values(restoredAnchors).reduce((sum: number, anchors) => {
         return sum + (anchors.A ? 1 : 0) + (anchors.B ? 1 : 0) + (anchors.C ? 1 : 0);
       }, 0);
       

--- a/packages/memento-core/src/domains/anchor/tools/search-local-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/search-local-tool.ts
@@ -71,7 +71,7 @@ export class SearchLocalTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     try {
       // 파라미터 검증
       const { slot, query, hop_limit, limit, min_results, agent_id, use_relations } = SearchLocalSchema.parse(params);
@@ -104,11 +104,12 @@ export class SearchLocalTool extends BaseTool {
           query_time: searchResult.query_time,
           anchor_info: searchResult.anchor_info
         });
-      } catch (searchError: any) {
+      } catch (searchError: unknown) {
         // 앵커가 없거나 앵커 메모리에 임베딩이 없으면 fallback
+        const searchMsg = searchError instanceof Error ? searchError.message : '';
         if (query && (
-          searchError?.message?.includes('Anchor not found') ||
-          searchError?.message?.includes('Embedding not found')
+          searchMsg.includes('Anchor not found') ||
+          searchMsg.includes('Embedding not found')
         )) {
           if (!context.services.hybridSearchEngine) {
             throw new Error('HybridSearchEngine is not available for fallback');
@@ -128,7 +129,7 @@ export class SearchLocalTool extends BaseTool {
               query_time: fallbackResult.query_time || 0,
               anchor_info: null
             });
-          } catch (fallbackError: any) {
+          } catch (fallbackError: unknown) {
             // Fallback도 실패하면 빈 결과 반환
             return this.createSuccessResult({
               items: [],

--- a/packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts
+++ b/packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts
@@ -42,7 +42,7 @@ export class SetAnchorTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     try {
       // 파라미터 검증
       const { memory_id, slot, agent_id } = SetAnchorSchema.parse(params);

--- a/packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts
+++ b/packages/memento-core/src/domains/embedding/services/minilm-embedding-service.ts
@@ -48,7 +48,7 @@ export class MiniLMEmbeddingService implements EmbeddingServiceInterface {
   private readonly modelName = MiniLMEmbeddingService.MODEL_NAME;
   private readonly dimensions = MiniLMEmbeddingService.DIMENSIONS;
   private readonly maxTokens = MiniLMEmbeddingService.MAX_TOKENS;
-  private model: any = null;
+  private model: unknown = null;
   private loadingPromise: Promise<any> | null = null;
   private readonly cache = new Map<string, EmbeddingResult>();
 

--- a/packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts
+++ b/packages/memento-core/src/domains/forgetting/services/spaced-repetition/optimal-interval.service.ts
@@ -129,7 +129,7 @@ export class AdaptiveOptimalIntervalRecommender implements OptimalIntervalRecomm
  * 고급 알고리즘을 사용한 간격 추천
  */
 export class MLBasedOptimalIntervalRecommender implements OptimalIntervalRecommender {
-  private model: Map<string, any> = new Map();
+  private model: Map<string, { weights: ModelWeights }> = new Map();
 
   recommendOptimalInterval(
     currentInterval: number,
@@ -184,7 +184,7 @@ export class MLBasedOptimalIntervalRecommender implements OptimalIntervalRecomme
     features: SpacedRepetitionFeatures;
     actualInterval: number;
     performance: number;
-  }>): any {
+  }>): ModelWeights {
     // 간단한 가중치 계산 (실제로는 더 정교한 ML 알고리즘 사용)
     return {
       importance: 0.6,
@@ -228,4 +228,11 @@ export class EnsembleOptimalIntervalRecommender implements OptimalIntervalRecomm
     
     return Math.ceil(weightedSum);
   }
+}interface ModelWeights {
+  importance: number;
+  usage: number;
+  helpful_feedback: number;
+  bad_feedback: number;
 }
+
+

--- a/packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts
+++ b/packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts
@@ -20,7 +20,7 @@ export class ForgettingStatsTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     // 데이터베이스 연결 확인
     this.validateDatabase(context);
     

--- a/packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts
+++ b/packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts
@@ -11,17 +11,17 @@ export interface CoreMemoryPreparedStatement {
   /**
    * 모든 결과 행을 반환
    */
-  all(...params: any[]): Promise<any[]>;
+  all(...params: unknown[]): Promise<unknown[]>;
 
   /**
    * 첫 번째 결과 행을 반환
    */
-  get(...params: any[]): Promise<any>;
+  get(...params: unknown[]): Promise<unknown>;
 
   /**
    * 쿼리를 실행하고 변경된 행 수와 마지막 삽입된 행 ID를 반환
    */
-  run(...params: any[]): Promise<{ changes: number; lastInsertRowid: number }>;
+  run(...params: unknown[]): Promise<{ changes: number; lastInsertRowid: number }>;
 }
 
 /**

--- a/packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts
@@ -29,7 +29,7 @@ export class CleanupMemoryTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     const { dry_run } = CleanupMemorySchema.parse(params);
     
     // 데이터베이스 연결 확인

--- a/packages/memento-core/src/domains/memory/tools/forget-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/forget-tool.ts
@@ -72,7 +72,7 @@ export class ForgetTool extends BaseTool {
     return getValidatedVectorTableName(provider, dimensions);
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     this.logInfo('Forget 도구 호출됨', { params });
     
     try {
@@ -298,17 +298,18 @@ export class ForgetTool extends BaseTool {
   /**
    * 삭제 권한 확인
    */
-  private async validateDeletePermission(memory: any, _context: ToolContext): Promise<void> {
+  private async validateDeletePermission(memory: unknown, _context: ToolContext): Promise<void> {
+    const record = memory as { pinned?: unknown; importance?: number; id?: string };
     // 핀된 기억은 하드 삭제 전에 확인 필요
-    if (memory.pinned) {
+    if (record.pinned) {
       throw new Error('핀된 기억은 먼저 핀을 해제해야 합니다');
     }
     
     // 중요도가 높은 기억은 확인 필요
-    if (memory.importance > 0.8) {
+    if (typeof record.importance === 'number' && record.importance > 0.8) {
       logger.warn('높은 중요도의 기억 삭제', {
-        memoryId: memory.id,
-        importance: memory.importance
+        memoryId: record.id,
+        importance: record.importance
       });
     }
   }

--- a/packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts
@@ -52,7 +52,7 @@ export class GetMemoryNeighborsTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     this.logInfo('Get Memory Neighbors 도구 호출됨', { params });
     
     try {

--- a/packages/memento-core/src/domains/memory/tools/pin-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/pin-tool.ts
@@ -60,7 +60,7 @@ export class PinTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     const { id, reason, priority = 3, batch } = PinSchema.parse(params);
     
     // 데이터베이스 연결 확인

--- a/packages/memento-core/src/domains/monitoring/services/error-logging-service.ts
+++ b/packages/memento-core/src/domains/monitoring/services/error-logging-service.ts
@@ -25,14 +25,14 @@ export interface ErrorLog {
     requestId?: string;
     operation?: string;
     component?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   metadata: {
     userAgent?: string;
     ipAddress?: string;
     memoryUsage?: NodeJS.MemoryUsage;
     cpuUsage?: NodeJS.CpuUsage;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   resolved: boolean;
   resolvedAt?: Date;
@@ -109,10 +109,10 @@ export class ErrorLoggingService {
       message: errorMessage,
       stack,
       context: {
-        ...maskedContext,
-        component: maskedContext.component || 'unknown'
+        ...(maskedContext as Record<string, unknown>),
+        component: (maskedContext as Record<string, unknown>)['component'] as string | undefined || 'unknown'
       },
-      metadata: maskedMetadata,
+      metadata: maskedMetadata as ErrorLog['metadata'],
       resolved: false
     };
 

--- a/packages/memento-core/src/domains/monitoring/services/failure-detector.ts
+++ b/packages/memento-core/src/domains/monitoring/services/failure-detector.ts
@@ -71,7 +71,7 @@ export class FailureDetector {
   detectToolError(
     toolName: string,
     error: Error,
-    params?: any,
+    params?: unknown,
     executionTimeMs?: number
   ): FailureDetectionResult {
     try {
@@ -87,7 +87,7 @@ export class FailureDetector {
         error_message_hash: this.hashMessage(error.message),
         timestamp: new Date().toISOString(),
         context: {
-          params,
+          params: params as Record<string, unknown> | undefined,
           stack: error.stack,
           execution_time_ms: executionTimeMs
         },
@@ -95,11 +95,12 @@ export class FailureDetector {
       };
 
       // 원래 작업 목표 추출 시도
-      if (params?.task_goal) {
-        event.original_task = params.task_goal;
-      } else if (params?.content) {
+      const paramsRecord = params as Record<string, unknown> | undefined;
+      if (paramsRecord?.task_goal) {
+        event.original_task = String(paramsRecord.task_goal);
+      } else if (paramsRecord?.content) {
         // content에서 작업 목표 추출 시도
-        event.original_task = this.extractTaskGoal(params.content);
+        event.original_task = this.extractTaskGoal(String(paramsRecord.content));
       }
 
       logger.info('Tool 에러 감지', {
@@ -131,7 +132,7 @@ export class FailureDetector {
   detectUserFeedback(
     toolName: string,
     feedback: string,
-    params?: any
+    params?: unknown
   ): FailureDetectionResult {
     try {
       // 키워드 기반 감지
@@ -156,10 +157,10 @@ export class FailureDetector {
         error_message_hash: this.hashMessage(feedback),
         timestamp: new Date().toISOString(),
         context: {
-          params,
+          params: params as Record<string, unknown> | undefined,
           feedback_text: feedback
         },
-        original_task: params?.task_goal || this.extractTaskGoal(feedback),
+        original_task: (params as Record<string, unknown> | undefined)?.task_goal as string | undefined || this.extractTaskGoal(feedback),
         priority: 8 // 사용자 피드백은 높은 우선순위
       };
 
@@ -192,7 +193,7 @@ export class FailureDetector {
     toolName: string,
     executionTimeMs: number,
     success: boolean,
-    params?: any
+    params?: unknown
   ): FailureDetectionResult {
     try {
       // 메트릭 업데이트
@@ -225,7 +226,7 @@ export class FailureDetector {
         error_message_hash: this.hashMessage(`performance_${executionTimeMs}ms`),
         timestamp: new Date().toISOString(),
         context: {
-          params,
+          params: params as Record<string, unknown> | undefined,
           execution_time_ms: executionTimeMs,
           response_time_exceeded: responseTimeExceeded,
           error_rate_exceeded: errorRateExceeded,
@@ -237,7 +238,7 @@ export class FailureDetector {
             error_rate: metrics.failure / metrics.count
           } : undefined
         },
-        original_task: params?.task_goal,
+        original_task: (params as Record<string, unknown> | undefined)?.task_goal as string | undefined,
         priority: responseTimeExceeded ? 6 : 5
       };
 

--- a/packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-alert-service.ts
@@ -46,7 +46,7 @@ export interface PerformanceAlert {
     operation?: string;
     userId?: string;
     sessionId?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   resolved: boolean;
   resolvedAt?: Date;

--- a/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
+++ b/packages/memento-core/src/domains/monitoring/services/performance-monitor.ts
@@ -1177,8 +1177,8 @@ export class PerformanceMonitor {
   /**
    * 로깅
    */
-  private log(message: string, data?: any): void {
-    logger.debug(`PerformanceMonitor: ${message}`, data);
+  private log(message: string, data?: unknown): void {
+    logger.debug(`PerformanceMonitor: ${message}`, data as Record<string, unknown> | undefined);
   }
 }
 

--- a/packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts
+++ b/packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts
@@ -289,7 +289,7 @@ export class QualityRecorder {
       FROM quality_measurement_history
     `;
 
-    const params: any[] = [];
+    const params: unknown[] = [];
     const conditions: string[] = [];
 
     if (namespace) {
@@ -363,7 +363,7 @@ export class QualityRecorder {
       FROM quality_metrics
     `;
 
-    const params: any[] = [];
+    const params: unknown[] = [];
     const conditions: string[] = [];
 
     if (namespace) {

--- a/packages/memento-core/src/domains/monitoring/tools/error-stats.ts
+++ b/packages/memento-core/src/domains/monitoring/tools/error-stats.ts
@@ -45,8 +45,12 @@ export const errorStatsTool = {
   }
 };
 
-export async function executeErrorStats(args: any, context: ToolContext) {
-  const { hours, severity, category, includeResolved, limit } = args;
+export async function executeErrorStats(args: Record<string, unknown>, context: ToolContext) {
+  const hours = args['hours'] as number | undefined;
+  const severity = args['severity'] as string | undefined;
+  const category = args['category'] as string | undefined;
+  const includeResolved = args['includeResolved'] as boolean | undefined;
+  const limit = args['limit'] as number | undefined;
   
   try {
     // 에러 로깅 서비스가 없으면 기본 응답
@@ -70,7 +74,7 @@ export async function executeErrorStats(args: any, context: ToolContext) {
     const alerts = context.services.errorLoggingService.getActiveAlerts();
     
     // 필터링된 에러 검색
-    const searchFilters: any = {};
+    const searchFilters: Record<string, unknown> = {};
     if (severity) searchFilters.severity = severity;
     if (category) searchFilters.category = category;
     if (includeResolved !== undefined) searchFilters.resolved = includeResolved;
@@ -82,7 +86,7 @@ export async function executeErrorStats(args: any, context: ToolContext) {
       success: true,
       stats: {
         ...stats,
-        filteredErrors: filteredErrors.map((error: any) => ({
+        filteredErrors: filteredErrors.map((error) => ({
           id: error.id,
           timestamp: error.timestamp.toISOString(),
           severity: error.severity,
@@ -93,7 +97,7 @@ export async function executeErrorStats(args: any, context: ToolContext) {
           resolvedAt: error.resolvedAt?.toISOString()
         }))
       },
-      alerts: alerts.map((alert: any) => ({
+      alerts: alerts.map((alert) => ({
         id: alert.id,
         errorId: alert.errorId,
         severity: alert.severity,

--- a/packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts
+++ b/packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts
@@ -113,7 +113,7 @@ export class GetMetaMemoryStatsTool extends BaseTool {
    * @throws {Error} 파라미터 검증 실패 시
    * @throws {Error} 통계 조회 실패 시
    */
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     // 데이터베이스 연결 확인
     this.validateDatabase(context);
 

--- a/packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts
+++ b/packages/memento-core/src/domains/monitoring/tools/performance-alerts.ts
@@ -63,8 +63,16 @@ export const performanceAlertsTool = {
   }
 };
 
-export async function executePerformanceAlerts(args: any, context: ToolContext) {
-  const { action, hours, level, type, resolved, limit, alertId, resolvedBy, resolution } = args;
+export async function executePerformanceAlerts(args: Record<string, unknown>, context: ToolContext) {
+  const action = args['action'] as string | undefined;
+  const hours = args['hours'] as number | undefined;
+  const level = args['level'] as string | undefined;
+  const type = args['type'] as string | undefined;
+  const resolved = args['resolved'] as boolean | undefined;
+  const limit = args['limit'] as number | undefined;
+  const alertId = args['alertId'] as string | undefined;
+  const resolvedBy = args['resolvedBy'] as string | undefined;
+  const resolution = args['resolution'] as string | undefined;
   
   try {
     // 성능 알림 서비스가 없으면 기본 응답
@@ -85,16 +93,16 @@ export async function executePerformanceAlerts(args: any, context: ToolContext) 
 
     switch (action) {
       case 'stats':
-        return await handleStats(context, hours);
-      
+        return await handleStats(context, hours ?? 24);
+
       case 'list':
-        return await handleList(context, hours, limit);
-      
+        return await handleList(context, hours ?? 24, limit ?? 10);
+
       case 'search':
         return await handleSearch(context, { level, type, resolved, hours, limit });
-      
+
       case 'resolve':
-        return await handleResolve(context, alertId, resolvedBy, resolution);
+        return await handleResolve(context, alertId, resolvedBy ?? '', resolution);
       
       default:
         return {
@@ -120,7 +128,7 @@ async function handleStats(context: ToolContext, hours: number) {
     success: true,
     stats: {
       ...stats,
-      recentAlerts: stats.recentAlerts.map((alert: any) => ({
+      recentAlerts: stats.recentAlerts.map((alert) => ({
         id: alert.id,
         timestamp: alert.timestamp.toISOString(),
         level: alert.level,
@@ -154,7 +162,7 @@ async function handleList(context: ToolContext, hours: number, limit: number) {
 
   return {
     success: true,
-    activeAlerts: activeAlerts.map((alert: any) => ({
+    activeAlerts: activeAlerts.map((alert) => ({
       id: alert.id,
       timestamp: alert.timestamp.toISOString(),
       level: alert.level,
@@ -165,7 +173,7 @@ async function handleList(context: ToolContext, hours: number, limit: number) {
       message: alert.message,
       context: alert.context
     })),
-    recentAlerts: recentAlerts.map((alert: any) => ({
+    recentAlerts: recentAlerts.map((alert) => ({
       id: alert.id,
       timestamp: alert.timestamp.toISOString(),
       level: alert.level,
@@ -180,7 +188,7 @@ async function handleList(context: ToolContext, hours: number, limit: number) {
   };
 }
 
-async function handleSearch(context: ToolContext, filters: any) {
+async function handleSearch(context: ToolContext, filters: Record<string, unknown>) {
   if (!context.services.performanceAlertService) {
     throw new Error('성능 알림 서비스가 초기화되지 않았습니다');
   }
@@ -188,7 +196,7 @@ async function handleSearch(context: ToolContext, filters: any) {
 
   return {
     success: true,
-    alerts: alerts.map((alert: any) => ({
+    alerts: alerts.map((alert) => ({
       id: alert.id,
       timestamp: alert.timestamp.toISOString(),
       level: alert.level,

--- a/packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts
+++ b/packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts
@@ -20,7 +20,7 @@ export class PerformanceStatsTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     // 데이터베이스 연결 확인
     this.validateDatabase(context);
     

--- a/packages/memento-core/src/domains/monitoring/tools/resolve-error.ts
+++ b/packages/memento-core/src/domains/monitoring/tools/resolve-error.ts
@@ -29,8 +29,10 @@ export const resolveErrorTool = {
   }
 };
 
-export async function executeResolveError(args: any, context: ToolContext) {
-  const { errorId, resolvedBy, reason } = args;
+export async function executeResolveError(args: Record<string, unknown>, context: ToolContext) {
+  const errorId = args['errorId'] as string;
+  const resolvedBy = args['resolvedBy'] as string | undefined;
+  const reason = args['reason'] as string | undefined;
   
   try {
     if (!context.services.errorLoggingService) {

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts
@@ -72,7 +72,7 @@ export interface ITripleParser {
    * @param triple - 검증할 Triple 객체
    * @returns 유효성 검증 결과
    */
-  isValidTriple(triple: any): boolean;
+  isValidTriple(triple: unknown): boolean;
 }
 
 /**

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-extractor.ts
@@ -471,7 +471,7 @@ export class TripleExtractor implements ITripleExtractor {
 
       const data = await response.json();
       const models = data.models || [];
-      return models.some((m: any) => m.name === model || m.name.startsWith(`${model}:`));
+      return (models as Array<{ name: string }>).some((m) => m.name === model || m.name.startsWith(`${model}:`));
     } catch {
       return false;
     }
@@ -495,11 +495,11 @@ export class TripleExtractor implements ITripleExtractor {
         return { success: false, triples: [], error: 'triples 배열이 없거나 유효하지 않습니다.', errorType: 'parse' };
       }
       const validTriples = parsed.triples
-        .filter((t: any) => this.isValidTriple(t))
-        .map((t: any) => ({
-          subject: String(t.subject).trim(),
-          predicate: String(t.predicate).trim(),
-          object: String(t.object).trim()
+        .filter((t: unknown) => this.isValidTriple(t))
+        .map((t: unknown) => ({
+          subject: String((t as Record<string, unknown>)['subject']).trim(),
+          predicate: String((t as Record<string, unknown>)['predicate']).trim(),
+          object: String((t as Record<string, unknown>)['object']).trim()
         }));
       if (validTriples.length === 0 && parsed.triples.length > 0) {
         return { success: false, triples: [], error: '모든 triple이 유효하지 않습니다.', errorType: 'no_triple' };
@@ -548,14 +548,16 @@ export class TripleExtractor implements ITripleExtractor {
    * When: Triple의 유효성을 검증함
    * Then: 유효성 검증 결과를 반환함
    */
-  private isValidTriple(triple: any): boolean {
-    return triple &&
-           typeof triple === 'object' &&
-           typeof triple.subject === 'string' &&
-           typeof triple.predicate === 'string' &&
-           typeof triple.object === 'string' &&
-           triple.subject.trim().length > 0 &&
-           triple.predicate.trim().length > 0 &&
-           triple.object.trim().length > 0;
+  private isValidTriple(triple: unknown): boolean {
+    if (!triple || typeof triple !== 'object') return false;
+    const t = triple as Record<string, unknown>;
+    return (
+      typeof t['subject'] === 'string' &&
+      typeof t['predicate'] === 'string' &&
+      typeof t['object'] === 'string' &&
+      t['subject'].trim().length > 0 &&
+      t['predicate'].trim().length > 0 &&
+      t['object'].trim().length > 0
+    );
   }
 }

--- a/packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts
+++ b/packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts
@@ -140,18 +140,19 @@ export class TripleParser implements ITripleParser {
    * @param triple - 검증할 Triple 객체
    * @returns 유효성 검증 결과
    */
-  isValidTriple(triple: any): boolean {
+  isValidTriple(triple: unknown): boolean {
     if (!triple || typeof triple !== 'object') {
       return false;
     }
     
+    const t = triple as Record<string, unknown>;
     return (
-      typeof triple.subject === 'string' &&
-      typeof triple.predicate === 'string' &&
-      typeof triple.object === 'string' &&
-      triple.subject.trim().length > 0 &&
-      triple.predicate.trim().length > 0 &&
-      triple.object.trim().length > 0
+      typeof t['subject'] === 'string' &&
+      typeof t['predicate'] === 'string' &&
+      typeof t['object'] === 'string' &&
+      t['subject'].trim().length > 0 &&
+      t['predicate'].trim().length > 0 &&
+      t['object'].trim().length > 0
     );
   }
 }

--- a/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
+++ b/packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts
@@ -28,11 +28,12 @@ export class SearchResultCombiner implements ISearchResultCombiner {
    * @param vectorWeight - 벡터 검색 가중치
    * @returns 통합된 하이브리드 검색 결과 배열
    */
-  combine(textResults: any[], vectorResults: VectorSearchResult[], textWeight: number, vectorWeight: number): HybridSearchResult[] {
+  combine(textResults: unknown[], vectorResults: VectorSearchResult[], textWeight: number, vectorWeight: number): HybridSearchResult[] {
     const resultMap = new Map<string, HybridSearchResult>();
 
     // 텍스트 검색 결과를 먼저 추가하여 기본 점수를 설정합니다.
-    textResults.forEach(result => {
+    textResults.forEach((rawResult) => {
+      const result = rawResult as { id: string; content: string; type: string; importance: number; created_at: string; last_accessed: string; pinned: number | boolean; tags: string[]; score?: number; recall_reason?: string; project_id?: string; owner_id?: string; process_id?: string; session_id?: string };
       const textScore = typeof result.score === 'number' ? result.score : HYBRID_SEARCH.DEFAULT_TEXT_WEIGHT * 0; // 0
       const entry: HybridSearchResult = {
         id: result.id,
@@ -41,7 +42,7 @@ export class SearchResultCombiner implements ISearchResultCombiner {
         importance: result.importance,
         created_at: result.created_at,
         last_accessed: result.last_accessed,
-        pinned: result.pinned,
+        pinned: Boolean(result.pinned),
         tags: result.tags,
         textScore: textScore,
         vectorScore: 0,

--- a/packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts
+++ b/packages/memento-core/src/domains/search/algorithms/vector-search-engine-migration.ts
@@ -182,8 +182,8 @@ export class MigrationValidator {
     newEngine: VectorSearchEngine,
     testVector: number[]
   ): Promise<{
-    oldPerformance: any;
-    newPerformance: any;
+    oldPerformance: { averageTime: number; minTime: number; maxTime: number; results: number; successRate: number };
+    newPerformance: { averageTime: number; minTime: number; maxTime: number; results: number; successRate: number };
     improvement: number;
   }> {
     try {

--- a/packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts
+++ b/packages/memento-core/src/infrastructure/database/adapters/sqlite-core-memory-adapter.ts
@@ -22,7 +22,7 @@ class SqliteCoreMemoryPreparedStatement implements CoreMemoryPreparedStatement {
   /**
    * 모든 결과 행을 반환
    */
-  async all(...params: any[]): Promise<any[]> {
+  async all(...params: unknown[]): Promise<unknown[]> {
     try {
       return Promise.resolve(this.stmt.all(...params));
     } catch (error) {
@@ -33,7 +33,7 @@ class SqliteCoreMemoryPreparedStatement implements CoreMemoryPreparedStatement {
   /**
    * 첫 번째 결과 행을 반환
    */
-  async get(...params: any[]): Promise<any> {
+  async get(...params: unknown[]): Promise<unknown> {
     try {
       return Promise.resolve(this.stmt.get(...params));
     } catch (error) {
@@ -44,7 +44,7 @@ class SqliteCoreMemoryPreparedStatement implements CoreMemoryPreparedStatement {
   /**
    * 쿼리를 실행하고 변경된 행 수와 마지막 삽입된 행 ID를 반환
    */
-  async run(...params: any[]): Promise<{ changes: number; lastInsertRowid: number }> {
+  async run(...params: unknown[]): Promise<{ changes: number; lastInsertRowid: number }> {
     try {
       const result = this.stmt.run(...params);
       return Promise.resolve({

--- a/packages/memento-core/src/infrastructure/database/database-lock-monitor.ts
+++ b/packages/memento-core/src/infrastructure/database/database-lock-monitor.ts
@@ -208,8 +208,8 @@ export class DatabaseLockMonitor {
         detectionMethod: 'immediate_transaction',
         busyCount: this.busyCount
       };
-    } catch (error: any) {
-      if (error.code === 'SQLITE_BUSY') {
+    } catch (error: unknown) {
+      if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'SQLITE_BUSY') {
         // 락 감지 (IMMEDIATE 트랜잭션 방법)
         this.busyCount++;
         
@@ -249,8 +249,8 @@ export class DatabaseLockMonitor {
           detectionMethod: 'immediate_transaction',
           busyCount: this.busyCount
         };
-      } catch (queryError: any) {
-        if (queryError.code === 'SQLITE_BUSY') {
+      } catch (queryError: unknown) {
+        if (queryError instanceof Error && (queryError as NodeJS.ErrnoException).code === 'SQLITE_BUSY') {
           // 락 감지 (단순 상태 확인 쿼리 방법)
           this.busyCount++;
           

--- a/packages/memento-core/src/infrastructure/database/database-optimize-tool.ts
+++ b/packages/memento-core/src/infrastructure/database/database-optimize-tool.ts
@@ -35,7 +35,7 @@ export class DatabaseOptimizeTool extends BaseTool {
     );
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     const { analyze, create_indexes } = DatabaseOptimizeSchema.parse(params);
     
     // 데이터베이스 연결 확인
@@ -45,7 +45,7 @@ export class DatabaseOptimizeTool extends BaseTool {
     this.validateService(context.services.databaseOptimizer, '데이터베이스 최적화기');
     
     try {
-      const results: any = {
+      const results: { message: string; operations: string[] } = {
         message: '데이터베이스 최적화 완료',
         operations: []
       };
@@ -60,7 +60,7 @@ export class DatabaseOptimizeTool extends BaseTool {
       
       if (create_indexes) {
         const recommendations = await context.services.databaseOptimizer.generateIndexRecommendations();
-        const highPriorityRecs = recommendations.filter((r: any) => r.priority === 'high');
+        const highPriorityRecs = recommendations.filter((r) => r.priority === 'high');
         
         for (const rec of highPriorityRecs) {
           const indexName = `idx_${rec.table}_${rec.columns.join('_')}`;

--- a/packages/memento-core/src/infrastructure/database/database-optimizer.ts
+++ b/packages/memento-core/src/infrastructure/database/database-optimizer.ts
@@ -19,7 +19,7 @@ export interface IndexRecommendation {
 export interface QueryAnalysis {
   query: string;
   executionTime: number;
-  explainPlan: any[];
+  explainPlan: unknown[];
   recommendations: string[];
   complexity: 'simple' | 'medium' | 'complex';
 }

--- a/packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.ts
@@ -154,11 +154,11 @@ export class DependencyValidator {
           on_update: fk.on_update
         }
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         name: 'memory_embedding_foreign_key',
         success: false,
-        error: error.message || 'Unknown error during foreign key validation'
+        error: (error instanceof Error ? error.message : null) || 'Unknown error during foreign key validation'
       };
     }
   }
@@ -226,11 +226,11 @@ export class DependencyValidator {
           fts_table_exists: true
         }
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         name: 'fts5_triggers',
         success: false,
-        error: error.message || 'Unknown error during FTS5 trigger validation'
+        error: (error instanceof Error ? error.message : null) || 'Unknown error during FTS5 trigger validation'
       };
     }
   }
@@ -357,11 +357,11 @@ export class DependencyValidator {
           }
         }
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       return {
         name: 'vec_triggers',
         success: false,
-        error: error.message || 'Unknown error during VEC trigger validation'
+        error: (error instanceof Error ? error.message : null) || 'Unknown error during VEC trigger validation'
       };
     }
   }

--- a/packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts
@@ -96,7 +96,7 @@ export class MigrationDetector {
         const module = await import(importPath);
         
         // default export 또는 named export 찾기
-        let MigrationClass: any = module.default;
+        let MigrationClass: unknown = module.default;
         
         // named export에서 Migration 클래스 찾기
         if (!MigrationClass || typeof MigrationClass !== 'function') {
@@ -129,7 +129,7 @@ export class MigrationDetector {
         }
 
         // 클래스 인스턴스 생성
-        const migration = new MigrationClass() as Migration;
+        const migration = new (MigrationClass as new () => Migration)();
 
         if (!migration || !migration.version || !migration.up) {
           logger.warn('⚠️  마이그레이션 파일에서 유효한 마이그레이션 인스턴스를 생성할 수 없습니다', {

--- a/packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migration-logger.ts
@@ -28,7 +28,7 @@ export interface LogEntry {
   timestamp: Date;
   level: LogLevel;
   message: string;
-  data?: any;
+  data?: unknown;
 }
 
 /**
@@ -99,7 +99,7 @@ export class MigrationLogger {
   /**
    * 로그 기록
    */
-  log(level: LogLevel, message: string, data?: any): void {
+  log(level: LogLevel, message: string, data?: unknown): void {
     const entry: LogEntry = {
       timestamp: new Date(),
       level,
@@ -130,28 +130,28 @@ export class MigrationLogger {
   /**
    * INFO 레벨 로그
    */
-  info(message: string, data?: any): void {
+  info(message: string, data?: unknown): void {
     this.log(LogLevel.INFO, message, data);
   }
 
   /**
    * WARN 레벨 로그
    */
-  warn(message: string, data?: any): void {
+  warn(message: string, data?: unknown): void {
     this.log(LogLevel.WARN, message, data);
   }
 
   /**
    * ERROR 레벨 로그
    */
-  error(message: string, data?: any): void {
+  error(message: string, data?: unknown): void {
     this.log(LogLevel.ERROR, message, data);
   }
 
   /**
    * DEBUG 레벨 로그
    */
-  debug(message: string, data?: any): void {
+  debug(message: string, data?: unknown): void {
     this.log(LogLevel.DEBUG, message, data);
   }
 

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.ts
@@ -212,9 +212,9 @@ export class ConsolidationScoreFieldsMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'recall_count')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN recall_count INTEGER NOT NULL DEFAULT 0');
-      } catch (err: any) {
+      } catch (err: unknown) {
         // 컬럼이 이미 존재하는 경우 무시 (다른 프로세스에서 추가했을 수 있음)
-        if (!err.message?.includes('duplicate column name')) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }
@@ -223,8 +223,8 @@ export class ConsolidationScoreFieldsMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'last_accessed_at')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN last_accessed_at TIMESTAMP');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) {
+      } catch (err: unknown) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }
@@ -233,8 +233,8 @@ export class ConsolidationScoreFieldsMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'consolidation_score')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN consolidation_score REAL');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) {
+      } catch (err: unknown) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }
@@ -243,8 +243,8 @@ export class ConsolidationScoreFieldsMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'g_value')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN g_value REAL');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) {
+      } catch (err: unknown) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts
@@ -174,7 +174,7 @@ export class AnchorTableMigration implements Migration {
     }
 
     // Verify table structure (check columns)
-    const columns = db.prepare(`PRAGMA table_info(anchor)`).all() as Array<{ name: string; type: string; notnull: number; dflt_value: any }>;
+    const columns = db.prepare(`PRAGMA table_info(anchor)`).all() as Array<{ name: string; type: string; notnull: number; dflt_value: unknown }>;
     const columnNames = columns.map(col => col.name);
     
     const requiredColumns = ['id', 'agent_id', 'slot', 'memory_id', 'created_at', 'updated_at'];

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.ts
@@ -254,7 +254,7 @@ export class RelationEngineSchemaMigration implements Migration {
       name: string;
       type: string;
       notnull: number;
-      dflt_value: any;
+      dflt_value: unknown;
     }>;
     const relationColumnNames = relationColumns.map(col => col.name);
     

--- a/packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts
@@ -159,9 +159,9 @@ export class ProceduralMemoryEnhancementMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'workflow_name')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN workflow_name TEXT');
-      } catch (err: any) {
+      } catch (err: unknown) {
         // 컬럼이 이미 존재하는 경우 무시 (다른 프로세스에서 추가했을 수 있음)
-        if (!err.message?.includes('duplicate column name')) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }
@@ -170,8 +170,8 @@ export class ProceduralMemoryEnhancementMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'skill_name')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN skill_name TEXT');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) {
+      } catch (err: unknown) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }
@@ -180,8 +180,8 @@ export class ProceduralMemoryEnhancementMigration implements Migration {
     if (!this.columnExists(db, 'memory_item', 'trigger_conditions')) {
       try {
         db.exec('ALTER TABLE memory_item ADD COLUMN trigger_conditions TEXT');
-      } catch (err: any) {
-        if (!err.message?.includes('duplicate column name')) {
+      } catch (err: unknown) {
+        if (!(err instanceof Error && err.message?.includes('duplicate column name'))) {
           throw err;
         }
       }

--- a/packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts
+++ b/packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.ts
@@ -73,7 +73,7 @@ export class SchemaVersionManager {
         ORDER BY applied_at ASC
       `);
 
-      return results.map((r: any) => r.version);
+      return results.map((r) => (r as { version: string }).version);
     } catch (error) {
       return [];
     }
@@ -153,13 +153,16 @@ export class SchemaVersionManager {
         ORDER BY applied_at ASC
       `);
 
-      return results.map((r: any) => ({
-        version: r.version,
-        appliedAt: new Date(r.applied_at),
-        migrationName: r.migration_name,
-        checksum: r.checksum || undefined,
-        appliedBy: r.applied_by || 'system'
-      }));
+      return results.map((r) => {
+        const row = r as { version: string; applied_at: string; migration_name: string; checksum?: string; applied_by?: string };
+        return {
+          version: row.version,
+          appliedAt: new Date(row.applied_at),
+          migrationName: row.migration_name,
+          checksum: row.checksum || undefined,
+          appliedBy: row.applied_by || 'system'
+        };
+      });
     } catch (error) {
       return [];
     }

--- a/packages/memento-core/src/infrastructure/database/migration-history-service.ts
+++ b/packages/memento-core/src/infrastructure/database/migration-history-service.ts
@@ -8,6 +8,7 @@ import type {
   MigrationResult,
   MigrationRollbackEntry
 } from '../../shared/types/migration.types.js';
+import type { EmbeddingProvider, ProjectionType, VectorNormalization } from '../../shared/types/embedding.types.js';
 import { PIIMasker } from '../../shared/utils/pii-masker.js';
 import { logger } from '../../shared/utils/logger.js';
 
@@ -291,7 +292,32 @@ class MigrationHistoryService {
     logger.info(summary);
   }
 
-  private mapRow(row: any): MigrationHistoryRecord {
+  private mapRow(rowUnknown: unknown): MigrationHistoryRecord {
+    type MigrationRow = {
+      id: number | bigint;
+      plan_provider_from: EmbeddingProvider;
+      plan_provider_to: EmbeddingProvider;
+      plan_target_dimensions: number;
+      plan_projection_type: ProjectionType;
+      plan_normalization: VectorNormalization;
+      plan_batch_size: number;
+      plan_dry_run: number;
+      plan_resume_from_id: string | null;
+      plan_target_model: string | null;
+      plan_created_by: string | null;
+      success: number;
+      processed: number;
+      succeeded: number;
+      failed: number;
+      start_time: string | null;
+      end_time: string | null;
+      next_resume_from_id: string | null;
+      errors_json: string | null;
+      rollback_entries_json: string | null;
+      created_at: string;
+      error_count: number;
+    };
+    const row = rowUnknown as MigrationRow;
     let rollbackEntries: MigrationRollbackEntry[] = [];
     let rolledBack = false;
 
@@ -332,8 +358,8 @@ class MigrationHistoryService {
         processed: row.processed,
         succeeded: row.succeeded,
         failed: row.failed,
-        startTime: normalizeDate(row.start_time) ?? new Date(row.start_time),
-        endTime: normalizeDate(row.end_time) ?? new Date(row.end_time),
+        startTime: normalizeDate(row.start_time) ?? new Date(row.start_time ?? ''),
+        endTime: normalizeDate(row.end_time) ?? new Date(row.end_time ?? ''),
         nextResumeFromId: row.next_resume_from_id ?? undefined,
         errors: row.errors_json ? JSON.parse(row.errors_json) : undefined,
         rollbackEntries,

--- a/packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts
+++ b/packages/memento-core/src/infrastructure/database/repositories/core-memory-repository-sqlite.impl.ts
@@ -14,10 +14,11 @@ import type { CoreMemoryDatabaseConnection } from '../../../domains/memory/repos
 /**
  * always_load 불리언 변환 헬퍼 함수
  */
-function convertAlwaysLoad(record: any): CoreMemoryRecord {
+function convertAlwaysLoad(record: unknown): CoreMemoryRecord {
+  const r = record as CoreMemoryRecord;
   return {
-    ...record,
-    always_load: Boolean(record.always_load)
+    ...r,
+    always_load: Boolean(r.always_load)
   };
 }
 
@@ -184,7 +185,7 @@ export class CoreMemoryRepositorySqliteImpl implements CoreMemoryRepository {
    */
   async update(core_id: string, input: UpdateCoreMemoryInput): Promise<CoreMemoryRecord | null> {
     const updates: string[] = [];
-    const values: any[] = [];
+    const values: unknown[] = [];
 
     if (input.value !== undefined) {
       updates.push('value = ?');
@@ -228,7 +229,7 @@ export class CoreMemoryRepositorySqliteImpl implements CoreMemoryRepository {
     input: UpdateCoreMemoryInput
   ): Promise<CoreMemoryRecord | null> {
     const updates: string[] = [];
-    const values: any[] = [];
+    const values: unknown[] = [];
 
     if (input.value !== undefined) {
       updates.push('value = ?');

--- a/packages/memento-core/src/infrastructure/scheduler/file-logger.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/file-logger.ts
@@ -21,7 +21,7 @@ export interface LogEntry {
   service: string;
   level: 'info' | 'warn' | 'error';
   message: string;
-  data?: any;
+  data?: unknown;
   uptime?: number;
   activeJobs?: number;
   queueSize?: number;
@@ -127,7 +127,7 @@ export class FileLogger {
    */
   async logWarn(
     message: string,
-    data?: any,
+    data?: Record<string, unknown>,
     context?: {
       uptime?: number;
       activeJobs?: number;
@@ -159,7 +159,7 @@ export class FileLogger {
    */
   async logError(
     message: string,
-    data?: any,
+    data?: Record<string, unknown>,
     context?: {
       uptime?: number;
       activeJobs?: number;
@@ -191,7 +191,7 @@ export class FileLogger {
    * @param data 원본 데이터
    * @returns 정제된 데이터 (PII 마스킹 적용)
    */
-  private sanitizeData(data?: any): Record<string, any> {
+  private sanitizeData(data?: unknown): Record<string, unknown> {
     if (data instanceof Error) {
       // 공통 유틸리티 함수 사용
       return PIIMasker.maskError(data);

--- a/packages/memento-core/src/shared/config/index.ts
+++ b/packages/memento-core/src/shared/config/index.ts
@@ -166,10 +166,10 @@ export function validateConfig(): void {
   // console.warn/error는 이미 오버라이드되었지만, 명시적으로 stderr logger 전달
   validateConfiguration(mementoConfig, {
     logger: {
-      warn: (message?: any, ...optionalParams: any[]) => {
+      warn: (message?: unknown, ...optionalParams: unknown[]) => {
         process.stderr.write(`[CONFIG WARN] ${String(message)} ${optionalParams.map(String).join(' ')}\n`);
       },
-      error: (message?: any, ...optionalParams: any[]) => {
+      error: (message?: unknown, ...optionalParams: unknown[]) => {
         process.stderr.write(`[CONFIG ERROR] ${String(message)} ${optionalParams.map(String).join(' ')}\n`);
       }
     }

--- a/packages/memento-core/src/shared/interfaces/database.interface.ts
+++ b/packages/memento-core/src/shared/interfaces/database.interface.ts
@@ -4,9 +4,9 @@
  */
 
 export interface PreparedStatement {
-  all(...params: any[]): any[];
-  get(...params: any[]): any;
-  run(...params: any[]): { changes: number; lastInsertRowid: number };
+  all(...params: unknown[]): unknown[];
+  get(...params: unknown[]): unknown;
+  run(...params: unknown[]): { changes: number; lastInsertRowid: number };
 }
 
 export interface DatabaseConnection {

--- a/packages/memento-core/src/shared/types/relation-graph.ts
+++ b/packages/memento-core/src/shared/types/relation-graph.ts
@@ -57,7 +57,7 @@ export interface RelationMetadata {
   /**
    * 기타 메타데이터
    */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/memento-core/src/shared/utils/fts5-migration-status.ts
+++ b/packages/memento-core/src/shared/utils/fts5-migration-status.ts
@@ -131,7 +131,7 @@ export function setMigrationStatus(
     // 상태 업데이트
     const now = new Date().toISOString();
     let updateSql = '';
-    let params: any[] = [];
+    let params: unknown[] = [];
 
     if (status === 'in_progress') {
       updateSql = `
@@ -309,7 +309,7 @@ export function forceSetMigrationStatus(
   // 상태 전이 검증 없이 강제 업데이트
   const now = new Date().toISOString();
   let updateSql = '';
-  let params: any[] = [];
+  let params: unknown[] = [];
 
   if (status === 'in_progress') {
     updateSql = `

--- a/packages/memento-core/src/shared/utils/pii-masker.ts
+++ b/packages/memento-core/src/shared/utils/pii-masker.ts
@@ -290,18 +290,18 @@ export class PIIMasker {
    * @param obj 마스킹할 객체
    * @returns 마스킹된 객체
    */
-  static maskObject(obj: any, visited: WeakSet<any> = new WeakSet()): any {
+  static maskObject(obj: unknown, visited: WeakSet<object> = new WeakSet()): Record<string, unknown> {
     // 환경 변수로 마스킹 비활성화된 경우 원본 반환
     if (!isPIIMaskingEnabled()) {
-      return obj;
+      return obj as Record<string, unknown>;
     }
     if (!obj || typeof obj !== 'object') {
-      return obj;
+      return obj as Record<string, unknown>;
     }
 
     // 순환 참조 감지
     if (visited.has(obj)) {
-      return '[Circular Reference]';
+      return { _circular: '[Circular Reference]' };
     }
     visited.add(obj);
 
@@ -310,11 +310,12 @@ export class PIIMasker {
       const serialized = JSON.stringify(obj);
       const masked = this.mask(serialized).masked;
       // 역직렬화하여 객체로 복원
-      return JSON.parse(masked);
+      return JSON.parse(masked) as Record<string, unknown>;
     } catch {
       // 직렬화/역직렬화 실패 시 개별 필드에 마스킹 적용 시도
-      const masked: any = Array.isArray(obj) ? [] : {};
-      for (const [key, value] of Object.entries(obj)) {
+      const objRecord = obj as Record<string, unknown>;
+      const masked: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(objRecord)) {
         if (typeof value === 'string') {
           masked[key] = this.mask(value).masked;
         } else if (typeof value === 'object' && value !== null) {

--- a/packages/memento-core/src/shared/utils/reflection-notes-normalize.ts
+++ b/packages/memento-core/src/shared/utils/reflection-notes-normalize.ts
@@ -95,7 +95,7 @@ function normalizeReflectionNoteObject(note: unknown): string {
  * @param reflectionNotes - 정규화할 reflection_notes (JSON 문자열, 객체, 또는 배열)
  * @returns 정규화된 텍스트 문자열 (FTS5 인덱싱용)
  */
-export function normalizeReflectionNotes(reflectionNotes: string | null | undefined | any): string {
+export function normalizeReflectionNotes(reflectionNotes: unknown): string {
   // NULL 또는 빈 값 처리
   if (!reflectionNotes || reflectionNotes === '') {
     return '';

--- a/packages/memento-core/src/shared/utils/reflection-notes-normalize.ts
+++ b/packages/memento-core/src/shared/utils/reflection-notes-normalize.ts
@@ -37,18 +37,19 @@ const KEY_TOKEN_PREFIXES: Record<string, string> = {
  * @param note - 정규화할 Reflection Note 객체
  * @returns 정규화된 텍스트 문자열
  */
-function normalizeReflectionNoteObject(note: any): string {
+function normalizeReflectionNoteObject(note: unknown): string {
   if (!note || typeof note !== 'object') {
     return '';
   }
 
+  const noteObj = note as Record<string, unknown>;
   const tokens: string[] = [];
 
   // 키 토큰 포함 (failure_type, phase)
   for (const key of KEY_TOKEN_FIELDS) {
-    if (note[key] !== undefined && note[key] !== null) {
+    if (noteObj[key] !== undefined && noteObj[key] !== null) {
       const prefix = KEY_TOKEN_PREFIXES[key] || key;
-      const value = String(note[key]).trim();
+      const value = String(noteObj[key]).trim();
       if (value.length > 0) {
         tokens.push(`${prefix}:${value}`);
       }
@@ -56,7 +57,7 @@ function normalizeReflectionNoteObject(note: any): string {
   }
 
   // 값 필드 토큰화 (모든 값 필드 추출)
-  for (const [key, value] of Object.entries(note)) {
+  for (const [key, value] of Object.entries(noteObj)) {
     // 키 토큰 필드와 제외 필드는 이미 처리했거나 제외
     if (KEY_TOKEN_FIELDS.includes(key as any) || EXCLUDED_FIELDS.includes(key as any)) {
       continue;
@@ -101,7 +102,7 @@ export function normalizeReflectionNotes(reflectionNotes: string | null | undefi
   }
 
   // 문자열인 경우 JSON 파싱
-  let parsed: any;
+  let parsed: unknown;
   if (typeof reflectionNotes === 'string') {
     try {
       parsed = JSON.parse(reflectionNotes);

--- a/packages/memento-core/src/shared/utils/reflection-notes-schema.ts
+++ b/packages/memento-core/src/shared/utils/reflection-notes-schema.ts
@@ -95,7 +95,7 @@ export interface ValidationResult {
   errors?: Array<{
     field: string;
     expected: string;
-    actual: any;
+    actual: unknown;
     message: string;
   }>;
 }
@@ -121,7 +121,7 @@ export function validateReflectionNote(data: unknown): ValidationResult {
             : err.code === z.ZodIssueCode.invalid_type
             ? err.expected
             : '유효한 값',
-          actual: err.path.length > 0 ? err.path.reduce((obj: any, key) => obj?.[key], data) : data,
+          actual: err.path.length > 0 ? err.path.reduce((obj: unknown, key) => (obj as Record<string | number, unknown>)?.[key], data) : data,
           message: err.message
         };
       });
@@ -188,7 +188,7 @@ export function validateReflectionNotes(jsonString: string): ValidationResult {
     }
 
     // 배열의 각 요소 검증
-    const allErrors: Array<{ field: string; expected: string; actual: any; message: string }> = [];
+    const allErrors: Array<{ field: string; expected: string; actual: unknown; message: string }> = [];
     parsed.forEach((item, index) => {
       const result = validateReflectionNote(item);
       if (!result.isValid && result.errors) {

--- a/packages/memento-core/src/tools/base-tool.ts
+++ b/packages/memento-core/src/tools/base-tool.ts
@@ -91,7 +91,7 @@ export abstract class BaseTool {
   /**
    * 안전한 문자열 검증
    */
-  protected validateString(value: any, fieldName: string, maxLength: number = 1000): string {
+  protected validateString(value: unknown, fieldName: string, maxLength: number = 1000): string {
     if (typeof value !== 'string') {
       throw new Error(`${fieldName}은 문자열이어야 합니다`);
     }
@@ -110,7 +110,7 @@ export abstract class BaseTool {
   /**
    * 안전한 숫자 검증
    */
-  protected validateNumber(value: any, fieldName: string, min?: number, max?: number): number {
+  protected validateNumber(value: unknown, fieldName: string, min?: number, max?: number): number {
     const num = Number(value);
     
     if (isNaN(num)) {

--- a/packages/memento-core/src/tools/migrate-embeddings-tool.ts
+++ b/packages/memento-core/src/tools/migrate-embeddings-tool.ts
@@ -11,6 +11,7 @@ import type { EmbeddingProvider } from '../shared/types/index.js';
 import { DatabaseUtils } from '../shared/utils/database.js';
 import { vectorCompatibilityService } from '../domains/embedding/services/vector-compatibility-service.js';
 import { logger } from '../shared/utils/logger.js';
+import type Database from 'better-sqlite3';
 
 const MigrationSchema = z.object({
   source_provider: z.enum(['tfidf', 'lightweight', 'minilm', 'openai', 'gemini']).optional(),
@@ -79,7 +80,7 @@ export class MigrateEmbeddingsTool extends BaseTool {
   /**
    * sqlite-vec 확장 로드
    */
-  private async loadVecExtension(db: any): Promise<void> {
+  private async loadVecExtension(db: Database.Database): Promise<void> {
     try {
       const { getLoadablePath } = await import('sqlite-vec');
       const extensionPath = getLoadablePath();
@@ -93,7 +94,7 @@ export class MigrateEmbeddingsTool extends BaseTool {
    * 특정 provider로 임베딩 생성 및 저장
    */
   private async createAndStoreEmbeddingForProvider(
-    db: any,
+    db: Database.Database,
     memoryId: string,
     content: string,
     targetProvider: EmbeddingProvider
@@ -180,7 +181,7 @@ export class MigrateEmbeddingsTool extends BaseTool {
     ]);
   }
 
-  async handle(params: any, context: ToolContext): Promise<ToolResult> {
+  async handle(params: unknown, context: ToolContext): Promise<ToolResult> {
     this.logInfo('Migrate Embeddings 도구 호출됨', { params });
 
     try {
@@ -216,7 +217,7 @@ export class MigrateEmbeddingsTool extends BaseTool {
           AND me.embedding_provider != ''
       `;
 
-      const queryParams: any[] = [];
+      const queryParams: unknown[] = [];
 
       if (source_provider) {
         memoryQuery += ` AND me.embedding_provider = ?`;

--- a/packages/memento-core/src/workers/consolidation-score-worker.ts
+++ b/packages/memento-core/src/workers/consolidation-score-worker.ts
@@ -561,7 +561,7 @@ export class ConsolidationScoreWorker {
   /**
    * 로깅
    */
-  private log(message: string, data?: any, level: 'info' | 'warn' | 'error' = 'info'): void {
+  private log(message: string, data?: unknown, level: 'info' | 'warn' | 'error' = 'info'): void {
     if (!this.config.enableLogging) return;
 
     const timestamp = new Date().toISOString();


### PR DESCRIPTION
## Summary

프로덕션 코드에서 `: any` 타입을 117개 → 0개로 제거.

- **Wave 4**: Tool `handle(params: any)` → `handle(params: unknown)` (14개 파일, Zod parse로 타입 안전성 유지)
- **Wave 5**: DB 인터페이스 `any[]` → `unknown[]` (`PreparedStatement`, `CoreMemoryPreparedStatement`, SQLite 어댑터)
- **Wave 6**: Logger `data?: any` → `data?: Record<string, unknown>` (migration-logger, file-logger, performance-monitor, consolidation-score-worker)
- **Wave 7**: `catch (err: any)` → `catch (err: unknown)` + `instanceof Error` 타입 가드 (5개 파일)
- **Wave 8**: `isValidTriple(triple: any)`, `maskObject(obj: any)`, `search-strategy-interfaces`, `performance-alerts` 등

## Test plan

- [x] `grep -rn ": any" packages/memento-core/src --include="*.ts" | grep -v "__tests__|\\.spec\\.|\\.test\\.|/src/test/" | wc -l` → 0
- [x] `npm run type-check` 통과 (전체 workspace)
- [x] `npm run lint` 에러 없음 (기존 warning만)
- [ ] `npm test` (CI)

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)