### PR TITLE
refactor(static): anchor-map.js god function 분해 + dashboard-auth setAuthState 분리

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -508,6 +508,11 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
 
   <!-- Anchor Map 시각화 스크립트 -->
+  <script src="/static/js/anchor-map-shared.js"></script>
+  <script src="/static/js/anchor-map-render.js"></script>
+  <script src="/static/js/anchor-map-search.js"></script>
+  <script src="/static/js/anchor-map-data.js"></script>
+  <script src="/static/js/anchor-map-ws.js"></script>
   <script src="/static/js/anchor-map.js"></script>
   <script src="/static/js/memory-evolution-demo-shell-shared.js"></script>
   <script src="/static/js/memory-evolution-demo-shell-render-timeline.js"></script>

--- a/static/js/anchor-map-data.js
+++ b/static/js/anchor-map-data.js
@@ -1,0 +1,103 @@
+/**
+ * Anchor Map — data fetching: map data and agent ID options.
+ */
+(function (global) {
+  'use strict';
+
+  const ns = global.__MEMENTO_ANCHOR_MAP__;
+  if (!ns) return;
+
+  const state = ns.state;
+
+  function getSelectedAgentId() {
+    const select = document.getElementById('agent-id-select');
+    return (select && select.value) || 'default';
+  }
+
+  async function loadAgentIdOptions() {
+    const select = document.getElementById('agent-id-select');
+    if (!select) return;
+
+    const previousSelection = getSelectedAgentId();
+
+    try {
+      const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+      const response = await fetchFn('/api/anchors/agents');
+      if (!response.ok) throw new Error('HTTP error! status: ' + response.status);
+
+      const payload = await response.json();
+      const agents = Array.isArray(payload.agents) ? payload.agents : [];
+      select.innerHTML = '';
+
+      if (agents.length === 0) {
+        const option = document.createElement('option');
+        option.value = 'default';
+        option.textContent = 'default (앵커 없음)';
+        select.appendChild(option);
+      } else {
+        for (const entry of agents) {
+          const option = document.createElement('option');
+          option.value = entry.agent_id;
+          option.textContent = entry.agent_id + ' (' + entry.anchor_count + ' anchors)';
+          select.appendChild(option);
+        }
+      }
+
+      const validValues = Array.from(select.options).map(function (o) { return o.value; });
+      if (validValues.includes(previousSelection)) {
+        select.value = previousSelection;
+      } else if (agents.length > 0) {
+        select.value = agents[0].agent_id;
+      } else {
+        select.value = 'default';
+      }
+    } catch (error) {
+      ns.debugAnchorMap('agent-list-load-error', { message: error.message });
+      if (select.options.length === 0) {
+        const option = document.createElement('option');
+        option.value = 'default';
+        option.textContent = 'default (앵커 없음)';
+        select.appendChild(option);
+        select.value = 'default';
+      }
+    }
+  }
+
+  async function loadMapData() {
+    const agentId = getSelectedAgentId();
+
+    try {
+      const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+      const response = await fetchFn('/api/anchors/map?agent_id=' + encodeURIComponent(agentId));
+      if (!response.ok) throw new Error('HTTP error! status: ' + response.status);
+
+      const newMapData = ns.normalizeMapData(await response.json());
+      const hasChanged = !state.mapData ||
+        JSON.stringify(state.mapData.timestamp) !== JSON.stringify(newMapData.timestamp) ||
+        JSON.stringify(state.mapData.anchors) !== JSON.stringify(newMapData.anchors) ||
+        state.mapData.nodes.length !== newMapData.nodes.length ||
+        state.mapData.links.length !== newMapData.links.length;
+
+      if (hasChanged) {
+        state.mapData = newMapData;
+        ns.renderMap();
+        ns.updateAnchorList();
+        ns.debugAnchorMap('map-updated', { timestamp: newMapData.timestamp });
+      } else {
+        ns.debugAnchorMap('map-unchanged');
+      }
+
+      await loadAgentIdOptions();
+    } catch (error) {
+      ns.debugAnchorMap('load-error', { message: error.message });
+      if (!state.autoRefreshInterval) {
+        alert('맵 데이터를 불러올 수 없습니다: ' + error.message);
+      }
+    }
+  }
+
+  ns.getSelectedAgentId = getSelectedAgentId;
+  ns.loadAgentIdOptions = loadAgentIdOptions;
+  ns.loadMapData = loadMapData;
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/anchor-map-render.js
+++ b/static/js/anchor-map-render.js
@@ -1,0 +1,299 @@
+/**
+ * Anchor Map — D3 rendering: map, nodes, links, labels, detail panel.
+ */
+(function (global) {
+  'use strict';
+
+  const ns = global.__MEMENTO_ANCHOR_MAP__;
+  if (!ns) return;
+
+  const escapeHtml = ns.escapeHtml;
+  const state = ns.state;
+
+  function focusOnNode(node, scale) {
+    const s = scale || 1.5;
+    if (!node || node.x == null || node.y == null || !state.zoomBehavior || !state.svg) return;
+    const width = parseFloat(state.svg.attr('width'));
+    const height = parseFloat(state.svg.attr('height'));
+    const transform = d3.zoomIdentity
+      .translate(width / 2 - node.x * s, height / 2 - node.y * s)
+      .scale(s);
+    state.svg.transition().duration(750).call(state.zoomBehavior.transform, transform);
+  }
+
+  function buildAnchorDetailHtml(node) {
+    const slot = escapeHtml(node.slot);
+    const id = escapeHtml(node.id);
+    const content = escapeHtml(node.content);
+    const importance = escapeHtml(node.importance != null ? node.importance : 'N/A');
+    const created = node.created_at ? escapeHtml(new Date(node.created_at).toLocaleString()) : 'N/A';
+    return [
+      '<div class="memory-detail-item"><label>Type:</label><div class="value">Anchor (Slot ' + slot + ')</div></div>',
+      '<div class="memory-detail-item"><label>Memory ID:</label><div class="value">' + id + '</div></div>',
+      '<div class="memory-detail-item"><label>Content:</label><div class="value">' + content + '</div></div>',
+      '<div class="memory-detail-item"><label>Hop Distance:</label><div class="value">0 (Anchor)</div></div>',
+      '<div class="memory-detail-item"><label>Similarity:</label><div class="value">1.0 (100.0%)</div></div>',
+      '<div class="memory-detail-item"><label>Importance:</label><div class="value">' + importance + '</div></div>',
+      '<div class="memory-detail-item"><label>Created:</label><div class="value">' + created + '</div></div>',
+      '<button type="button" class="anchor-change-btn js-change-anchor m-button m-button--primary" data-slot="' + slot + '">Change Anchor</button>',
+    ].join('');
+  }
+
+  function buildMemoryDetailHtml(node) {
+    const id = escapeHtml(node.id);
+    const content = escapeHtml(node.content);
+    const hopDistance = escapeHtml(node.hop_distance != null ? node.hop_distance : 'N/A');
+    const similarity = node.similarity != null ? escapeHtml((node.similarity * 100).toFixed(1) + '%') : 'N/A';
+    const importance = escapeHtml(node.importance != null ? node.importance : 'N/A');
+    const created = node.created_at ? escapeHtml(new Date(node.created_at).toLocaleString()) : 'N/A';
+    return [
+      '<div class="memory-detail-item"><label>Type:</label><div class="value">Memory</div></div>',
+      '<div class="memory-detail-item"><label>Memory ID:</label><div class="value">' + id + '</div></div>',
+      '<div class="memory-detail-item"><label>Content:</label><div class="value">' + content + '</div></div>',
+      '<div class="memory-detail-item"><label>Hop Distance:</label><div class="value">' + hopDistance + '</div></div>',
+      '<div class="memory-detail-item"><label>Similarity:</label><div class="value">' + similarity + '</div></div>',
+      '<div class="memory-detail-item"><label>Importance:</label><div class="value">' + importance + '</div></div>',
+      '<div class="memory-detail-item"><label>Created:</label><div class="value">' + created + '</div></div>',
+    ].join('');
+  }
+
+  function displayMemoryDetails(node) {
+    const detailsContainer = document.getElementById('memory-details');
+    if (!detailsContainer) return;
+    detailsContainer.innerHTML = node.type === 'anchor'
+      ? buildAnchorDetailHtml(node)
+      : buildMemoryDetailHtml(node);
+  }
+
+  function layoutNodesByHop() {
+    const nodes = state.nodes;
+    const links = state.links;
+    const width = state.svg.attr('width');
+    const height = state.svg.attr('height');
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const anchorNodes = nodes.filter(function (n) { return n.type === 'anchor'; });
+
+    anchorNodes.forEach(function (anchor, anchorIndex) {
+      const angle = (anchorIndex / anchorNodes.length) * 2 * Math.PI;
+      const radius = 150;
+      anchor.fx = centerX + Math.cos(angle) * radius;
+      anchor.fy = centerY + Math.sin(angle) * radius;
+
+      const relatedMemories = nodes.filter(function (n) {
+        return n.type === 'memory' && links.some(function (l) {
+          return (l.source.id === anchor.id && l.target.id === n.id) ||
+                 (l.target.id === anchor.id && l.source.id === n.id);
+        });
+      });
+
+      relatedMemories.forEach(function (memory, memIndex) {
+        const hop = memory.hop_distance || 1;
+        const layerRadius = 100 + (hop - 1) * 80;
+        const memAngle = (memIndex / relatedMemories.length) * 2 * Math.PI + angle;
+        memory.fx = anchor.fx + Math.cos(memAngle) * layerRadius;
+        memory.fy = anchor.fy + Math.sin(memAngle) * layerRadius;
+      });
+    });
+
+    nodes.forEach(function (node) {
+      if (!node.fx && !node.fy && node.type === 'memory') {
+        node.fx = null;
+        node.fy = null;
+      }
+    });
+  }
+
+  function makeDragBehavior(simulation) {
+    function dragstarted(event, d) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      d.fx = d.x;
+      d.fy = d.y;
+    }
+    function dragged(event, d) { d.fx = event.x; d.fy = event.y; }
+    function dragended(event, d) {
+      if (!event.active) simulation.alphaTarget(0);
+      d.fx = null;
+      d.fy = null;
+    }
+    return d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended);
+  }
+
+  function buildLinkSelection(g, links) {
+    return g.append('g')
+      .selectAll('line')
+      .data(links)
+      .enter()
+      .append('line')
+      .attr('class', function (d) { return 'link ' + d.type; })
+      .attr('stroke-width', function (d) { return d.type === 'hop' ? 2 : 1.5; });
+  }
+
+  function buildNodeSelection(g, nodes, palette, simulation) {
+    return g.append('g')
+      .selectAll('circle')
+      .data(nodes)
+      .enter()
+      .append('circle')
+      .attr('class', function (d) {
+        let classes = 'node ' + d.type;
+        if (d.type === 'anchor' && d.slot) classes += ' slot-' + d.slot.toLowerCase();
+        return classes;
+      })
+      .attr('r', function (d) { return d.radius; })
+      .attr('fill', function (d) {
+        return (d.type === 'anchor' && d.slot) ? palette.slotColors[d.slot].fill : palette.memoryFill;
+      })
+      .attr('stroke', function (d) {
+        return (d.type === 'anchor' && d.slot) ? palette.slotColors[d.slot].stroke : palette.memoryStroke;
+      })
+      .attr('stroke-width', function (d) { return d.type === 'anchor' ? 3 : 2; })
+      .attr('stroke-dasharray', function (d) { return d.embedding_missing ? '5,3' : null; })
+      .attr('opacity', function (d) { return d.embedding_missing ? 0.6 : 1.0; })
+      .call(makeDragBehavior(simulation))
+      .on('click', function (event, d) { event.stopPropagation(); ns.selectNode(d); });
+  }
+
+  function buildLabelSelection(g, nodes, palette) {
+    return g.append('g')
+      .selectAll('text')
+      .data(nodes)
+      .enter()
+      .append('text')
+      .attr('class', 'node-label')
+      .attr('dx', function (d) { return d.radius + 5; })
+      .attr('dy', 4)
+      .text(function (d) {
+        if (d.type === 'anchor' && d.slot) return 'Slot ' + d.slot;
+        return d.content.substring(0, 20) + (d.content.length > 20 ? '...' : '');
+      })
+      .style('font-size', '12px')
+      .style('fill', palette.labelFill)
+      .style('pointer-events', 'none');
+  }
+
+  function addNodeTooltips(nodeSelection) {
+    nodeSelection.append('title').text(function (d) {
+      if (d.type === 'anchor') {
+        const warning = d.embedding_missing ? '\n⚠ 임베딩 없음 — 연결 메모리 검색 불가' : '';
+        return 'Anchor ' + d.slot + '\n' + d.content + warning;
+      }
+      return 'Memory\n' + d.content + '\nHop: ' + (d.hop_distance || 'N/A');
+    });
+  }
+
+  function runSimulation(link, node, label) {
+    const simulation = state.simulation;
+    const nodes = state.nodes;
+    const links = state.links;
+    simulation.nodes(nodes).on('tick', function () {
+      link.attr('x1', function (d) { return d.source.x; })
+          .attr('y1', function (d) { return d.source.y; })
+          .attr('x2', function (d) { return d.target.x; })
+          .attr('y2', function (d) { return d.target.y; });
+      node.attr('cx', function (d) { return d.x; }).attr('cy', function (d) { return d.y; });
+      label.attr('x', function (d) { return d.x; }).attr('y', function (d) { return d.y; });
+    });
+    simulation.force('link').links(links);
+    simulation.alpha(1).restart();
+  }
+
+  function renderMap() {
+    if (!state.svg || !state.simulation) return;
+
+    state.mapData = ns.normalizeMapData(state.mapData);
+    const mapData = state.mapData;
+
+    if (!mapData || !mapData.nodes || mapData.nodes.length === 0) {
+      state.nodes = [];
+      state.links = [];
+      const g = state.svg.select('g');
+      if (g.node()) g.selectAll('*').remove();
+      else state.svg.selectAll('*').remove();
+      return;
+    }
+
+    const g = state.svg.select('g');
+    g.selectAll('*').remove();
+
+    const palette = ns.getAnchorMapPalette();
+
+    state.nodes = mapData.nodes.map(function (d) { return { ...d, radius: d.type === 'anchor' ? 12 : 8 }; });
+    state.links = mapData.links
+      .map(function (d) {
+        return {
+          ...d,
+          source: typeof d.source === 'string' ? state.nodes.find(function (n) { return n.id === d.source; }) : d.source,
+          target: typeof d.target === 'string' ? state.nodes.find(function (n) { return n.id === d.target; }) : d.target,
+        };
+      })
+      .filter(function (d) { return d.source && d.target; });
+
+    layoutNodesByHop();
+
+    const link = buildLinkSelection(g, state.links);
+    const node = buildNodeSelection(g, state.nodes, palette, state.simulation);
+    buildLabelSelection(g, state.nodes, palette);
+    addNodeTooltips(node);
+    runSimulation(link, node, state.svg.selectAll('.node-label'));
+
+    if (state.searchResults && state.searchResults.items && state.searchResults.items.length) {
+      ns.highlightSearchResults();
+    }
+  }
+
+  function selectNode(node) {
+    state.svg.selectAll('.node').classed('selected', function (d) { return d.id === node.id; });
+    displayMemoryDetails(node);
+  }
+
+  function selectAnchorNode(memoryId) {
+    if (!Array.isArray(state.nodes)) return;
+    const node = state.nodes.find(function (n) { return n.id === memoryId; });
+    if (node) {
+      selectNode(node);
+      focusOnNode(node, 2);
+    }
+  }
+
+  function changeAnchor(slot) {
+    alert('앙커 변경 기능은 향후 구현 예정입니다. Slot: ' + slot);
+  }
+
+  function updateAnchorList() {
+    const anchorListContainer = document.getElementById('anchor-list');
+    if (!anchorListContainer) return;
+    state.mapData = ns.normalizeMapData(state.mapData);
+    const mapData = state.mapData;
+
+    if (!mapData || !mapData.anchors || mapData.anchors.length === 0) {
+      anchorListContainer.innerHTML = '<p class="no-data">No anchors set</p>';
+      return;
+    }
+
+    anchorListContainer.innerHTML = mapData.anchors
+      .map(function (anchor) {
+        if (!anchor.memory_id) return '';
+        const memory = mapData.nodes.find(function (n) { return n.id === anchor.memory_id; });
+        const slot = escapeHtml(anchor.slot);
+        const slotClass = /^[ABC]$/i.test(anchor.slot) ? slot.toLowerCase() : 'a';
+        const memoryId = escapeHtml(anchor.memory_id);
+        const contentPreview = memory ? escapeHtml(memory.content.substring(0, 50)) + '...' : '';
+        return '<div class="anchor-item slot-' + slotClass + ' js-select-anchor" data-memory-id="' + memoryId + '">' +
+          '<div class="slot-label">Slot ' + slot + '</div>' +
+          '<div class="memory-id">' + memoryId + '</div>' +
+          (memory ? '<div class="anchor-item-preview">' + contentPreview + '</div>' : '') +
+          '</div>';
+      })
+      .join('');
+  }
+
+  ns.renderMap = renderMap;
+  ns.selectNode = selectNode;
+  ns.selectAnchorNode = selectAnchorNode;
+  ns.changeAnchor = changeAnchor;
+  ns.updateAnchorList = updateAnchorList;
+  ns.displayMemoryDetails = displayMemoryDetails;
+  ns.focusOnNode = focusOnNode;
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/anchor-map-search.js
+++ b/static/js/anchor-map-search.js
@@ -1,0 +1,187 @@
+/**
+ * Anchor Map — search, highlight, and results panel.
+ */
+(function (global) {
+  'use strict';
+
+  const ns = global.__MEMENTO_ANCHOR_MAP__;
+  if (!ns) return;
+
+  const escapeHtml = ns.escapeHtml;
+  const state = ns.state;
+
+  function renderSearchResultsList() {
+    const container = document.getElementById('anchor-search-results');
+    if (!container) return;
+
+    if (!state.searchResults || !state.searchResults.items || !state.searchResults.items.length) {
+      container.innerHTML = '<p class="no-data">No search results</p>';
+      return;
+    }
+
+    const mapIds = new Set(Array.isArray(state.nodes) ? state.nodes.map(function (n) { return n.id; }) : []);
+    container.innerHTML = state.searchResults.items
+      .map(function (item, index) {
+        const id = ns.getSearchItemId(item);
+        if (!id) return '';
+        const onMap = mapIds.has(id);
+        const preview = escapeHtml((item.content || '').substring(0, 80));
+        const suffix = item.content && item.content.length > 80 ? '...' : '';
+        const similarity = item.similarity != null
+          ? escapeHtml((item.similarity * 100).toFixed(1) + '%')
+          : 'N/A';
+        const titleText = onMap ? '맵에 표시됨 — 클릭하여 포커스' : '맵 밖 결과 — 클릭하여 상세 보기';
+        return '<div class="anchor-search-result-item' + (onMap ? ' is-on-map' : '') + ' js-search-result-item"' +
+          ' data-memory-id="' + escapeHtml(id) + '"' +
+          ' title="' + escapeHtml(titleText) + '">' +
+          '<div class="search-result-meta">#' + (index + 1) + ' · ' + escapeHtml(id) + ' · ' + similarity + '</div>' +
+          '<div class="search-result-preview">' + preview + suffix + '</div>' +
+          '</div>';
+      })
+      .join('');
+  }
+
+  function updateNodeHighlight() {
+    if (!state.svg) return;
+    const nodeElements = state.svg.selectAll('.node');
+    const mapMatchCount = Array.isArray(state.nodes)
+      ? state.nodes.filter(function (n) { return state.highlightedNodeIds.has(n.id); }).length
+      : 0;
+    const shouldDimOthers = state.highlightedNodeIds.size > 0 && mapMatchCount > 0;
+
+    nodeElements
+      .classed('highlighted', function (d) { return state.highlightedNodeIds.has(d.id); })
+      .attr('stroke-width', function (d) {
+        if (state.highlightedNodeIds.has(d.id)) return d.type === 'anchor' ? 5 : 4;
+        return d.type === 'anchor' ? 3 : 2;
+      })
+      .attr('opacity', function (d) {
+        if (shouldDimOthers && !state.highlightedNodeIds.has(d.id)) return 0.3;
+        return d.embedding_missing ? 0.6 : 1.0;
+      });
+
+    const linkElements = state.svg.selectAll('.link');
+    linkElements
+      .attr('opacity', function (d) {
+        if (!shouldDimOthers) return 0.6;
+        const sourceHighlighted = state.highlightedNodeIds.has(ns.getLinkNodeId(d.source));
+        const targetHighlighted = state.highlightedNodeIds.has(ns.getLinkNodeId(d.target));
+        return (sourceHighlighted || targetHighlighted) ? 1.0 : 0.2;
+      })
+      .attr('stroke-width', function (d) {
+        if (state.highlightedNodeIds.size === 0) return d.type === 'hop' ? 2 : 1.5;
+        const sh = state.highlightedNodeIds.has(ns.getLinkNodeId(d.source));
+        const th = state.highlightedNodeIds.has(ns.getLinkNodeId(d.target));
+        if (sh && th) return 3;
+        if (sh || th) return 2;
+        return d.type === 'hop' ? 2 : 1.5;
+      });
+
+    const labelElements = state.svg.selectAll('.node-label');
+    labelElements
+      .style('font-weight', function (d) { return state.highlightedNodeIds.has(d.id) ? 'bold' : 'normal'; })
+      .style('font-size', function (d) { return state.highlightedNodeIds.has(d.id) ? '14px' : '12px'; });
+  }
+
+  function highlightSearchResults() {
+    if (!state.searchResults || !state.searchResults.items) {
+      ns.updateSearchStatus('검색 결과가 없습니다.', false);
+      renderSearchResultsList();
+      return;
+    }
+
+    state.highlightedNodeIds.clear();
+    state.searchResults.items.forEach(function (item) {
+      const id = ns.getSearchItemId(item);
+      if (id) state.highlightedNodeIds.add(id);
+    });
+
+    updateNodeHighlight();
+
+    const mapMatchCount = ns.countSearchMapMatches(state.searchResults.items, state.nodes);
+    ns.updateSearchStatus(ns.buildSearchStatusMessage(state.searchResults, mapMatchCount), true);
+    renderSearchResultsList();
+
+    if (state.searchResults.items.length > 0 && Array.isArray(state.nodes)) {
+      const firstOnMap = state.searchResults.items
+        .map(function (item) { return state.nodes.find(function (n) { return n.id === ns.getSearchItemId(item); }); })
+        .find(Boolean);
+      if (firstOnMap) {
+        ns.selectNode(firstOnMap);
+        ns.focusOnNode(firstOnMap, 1.5);
+      }
+    }
+  }
+
+  async function performSearch() {
+    const queryEl = document.getElementById('search-query-input');
+    const slotSelect = document.getElementById('search-slot-select');
+    const query = queryEl ? queryEl.value.trim() : '';
+    const slot = slotSelect ? slotSelect.value : 'A';
+    const agentId = ns.getSelectedAgentId();
+
+    if (!query) {
+      alert('검색어를 입력해주세요.');
+      return;
+    }
+    if (!slot || !['A', 'B', 'C'].includes(slot)) {
+      alert('슬롯을 선택해주세요. (A, B, C 중 하나)');
+      return;
+    }
+
+    try {
+      ns.updateSearchStatus('검색 중...', false);
+      const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
+      const response = await fetchFn('/api/anchors/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, slot, agent_id: agentId, limit: 100 }),
+      });
+      if (!response.ok) throw new Error('HTTP error! status: ' + response.status);
+
+      state.searchResults = ns.normalizeSearchResults(await response.json());
+      highlightSearchResults();
+
+      const resultCount = state.searchResults.items ? state.searchResults.items.length : 0;
+      ns.debugAnchorMap('search-complete', { resultCount });
+    } catch (error) {
+      ns.updateSearchStatus('검색 실패: ' + error.message, false);
+      ns.debugAnchorMap('search-error', { message: error.message });
+      alert('검색 중 오류가 발생했습니다: ' + error.message);
+    }
+  }
+
+  function clearSearch() {
+    state.searchResults = null;
+    state.highlightedNodeIds.clear();
+    const queryEl = document.getElementById('search-query-input');
+    const slotSelect = document.getElementById('search-slot-select');
+    if (queryEl) queryEl.value = '';
+    if (slotSelect) slotSelect.value = 'A';
+
+    ns.updateSearchStatus('검색 후 결과가 여기에 표시됩니다.', false);
+    renderSearchResultsList();
+    updateNodeHighlight();
+    ns.debugAnchorMap('search-cleared');
+  }
+
+  function displaySearchResultDetails(item) {
+    ns.displayMemoryDetails({
+      id: ns.getSearchItemId(item),
+      type: 'memory',
+      content: item.content || '',
+      hop_distance: item.hop_distance,
+      similarity: item.similarity,
+      importance: item.importance,
+      created_at: item.created_at,
+    });
+  }
+
+  ns.performSearch = performSearch;
+  ns.clearSearch = clearSearch;
+  ns.highlightSearchResults = highlightSearchResults;
+  ns.updateNodeHighlight = updateNodeHighlight;
+  ns.renderSearchResultsList = renderSearchResultsList;
+  ns.displaySearchResultDetails = displaySearchResultDetails;
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/anchor-map-shared.js
+++ b/static/js/anchor-map-shared.js
@@ -1,0 +1,130 @@
+/**
+ * Anchor Map — shared state, utilities, and DOM helpers.
+ */
+(function (global) {
+  'use strict';
+
+  const ns = (global.__MEMENTO_ANCHOR_MAP__ = global.__MEMENTO_ANCHOR_MAP__ || {});
+
+  // Mutable rendering state — every assignment must write back via ns.state.*
+  ns.state = ns.state || {
+    svg: null,
+    simulation: null,
+    zoomBehavior: null,
+    nodes: [],
+    links: [],
+    mapData: null,
+    searchResults: null,
+    highlightedNodeIds: new Set(),
+    autoRefreshInterval: null,
+    websocket: null,
+  };
+
+  // CSS token definitions for anchor slots
+  ns.slotColorTokens = {
+    A: { fill: '--color-anchor-a', stroke: '--color-anchor-a-stroke' },
+    B: { fill: '--color-anchor-b', stroke: '--color-anchor-b-stroke' },
+    C: { fill: '--color-anchor-c', stroke: '--color-anchor-c-stroke' },
+  };
+
+  ns.readAnchorMapToken = function readAnchorMapToken(name, fallback) {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    if (value) return value;
+    if (fallback) return fallback;
+    throw new Error('Missing CSS token: ' + name);
+  };
+
+  ns.getAnchorMapPalette = function getAnchorMapPalette() {
+    return {
+      slotColors: Object.fromEntries(
+        Object.entries(ns.slotColorTokens).map(function ([slot, tokenNames]) {
+          return [slot, {
+            fill: ns.readAnchorMapToken(tokenNames.fill),
+            stroke: ns.readAnchorMapToken(tokenNames.stroke),
+          }];
+        })
+      ),
+      memoryFill: ns.readAnchorMapToken('--color-memory-neutral'),
+      memoryStroke: ns.readAnchorMapToken('--color-memory-neutral-stroke'),
+      labelFill: ns.readAnchorMapToken('--color-text-main'),
+    };
+  };
+
+  /** XSS: escape HTML special chars */
+  ns.escapeHtml = function escapeHtml(str) {
+    if (str == null) return '';
+    const s = String(str);
+    return s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+
+  ns.getSearchItemId = function getSearchItemId(item) {
+    if (!item) return '';
+    return item.id || item.memory_id || '';
+  };
+
+  ns.countSearchMapMatches = function countSearchMapMatches(items, mapNodes) {
+    if (!Array.isArray(items) || !Array.isArray(mapNodes)) return 0;
+    const mapIds = new Set(mapNodes.map(function (n) { return n.id; }));
+    let matched = 0;
+    for (const item of items) {
+      if (mapIds.has(ns.getSearchItemId(item))) matched += 1;
+    }
+    return matched;
+  };
+
+  ns.buildSearchStatusMessage = function buildSearchStatusMessage(searchResult, mapMatchCount) {
+    const total = (searchResult && searchResult.items && searchResult.items.length) || 0;
+    if (total === 0) return '검색 결과가 없습니다.';
+    const parts = [total + '건 검색됨', '맵 ' + mapMatchCount + '건 표시'];
+    if (searchResult.fallback_used) parts.push('전역 검색 사용');
+    if (searchResult.local_results_count != null && !searchResult.fallback_used) {
+      parts.push('국소 ' + searchResult.local_results_count + '건');
+    }
+    return parts.join(' · ');
+  };
+
+  ns.normalizeMapData = function normalizeMapData(data) {
+    return {
+      ...(data || {}),
+      anchors: Array.isArray(data && data.anchors) ? data.anchors : [],
+      nodes: Array.isArray(data && data.nodes) ? data.nodes : [],
+      links: Array.isArray(data && data.links) ? data.links : [],
+      timestamp: (data && data.timestamp) || new Date().toISOString(),
+    };
+  };
+
+  ns.normalizeSearchResults = function normalizeSearchResults(payload) {
+    const candidate = (payload && payload.result) || payload || {};
+    return {
+      ...candidate,
+      items: Array.isArray(candidate.items) ? candidate.items : [],
+    };
+  };
+
+  ns.getLinkNodeId = function getLinkNodeId(value) {
+    return value && typeof value === 'object' ? value.id : value;
+  };
+
+  ns.debugAnchorMap = function debugAnchorMap(eventName, detail) {
+    if (window.localStorage.getItem('memento.debug') !== '1') return;
+    document.dispatchEvent(new CustomEvent('memento:debug', {
+      bubbles: true,
+      composed: true,
+      detail: { scope: 'anchor-map', eventName, detail },
+    }));
+  };
+
+  ns.updateSearchStatus = function updateSearchStatus(message, isActive) {
+    const statusEl = document.getElementById('anchor-search-status');
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.classList.toggle('is-active', Boolean(isActive));
+    statusEl.classList.toggle('no-data', !isActive);
+  };
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/anchor-map-shared.js
+++ b/static/js/anchor-map-shared.js
@@ -27,11 +27,11 @@
     C: { fill: '--color-anchor-c', stroke: '--color-anchor-c-stroke' },
   };
 
-  ns.readAnchorMapToken = function readAnchorMapToken(name, fallback) {
+  ns.readAnchorMapToken = function readAnchorMapToken(name, fallback = '') {
     const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
     if (value) return value;
     if (fallback) return fallback;
-    throw new Error('Missing CSS token: ' + name);
+    throw new Error(`Missing CSS token: ${name}`);
   };
 
   ns.getAnchorMapPalette = function getAnchorMapPalette() {

--- a/static/js/anchor-map-ws.js
+++ b/static/js/anchor-map-ws.js
@@ -1,0 +1,109 @@
+/**
+ * Anchor Map — WebSocket connection and auto-refresh polling.
+ */
+(function (global) {
+  'use strict';
+
+  const ns = global.__MEMENTO_ANCHOR_MAP__;
+  if (!ns) return;
+
+  const state = ns.state;
+
+  function startAutoRefresh() {
+    stopAutoRefresh();
+    const intervalSelect = document.getElementById('refresh-interval-select');
+    const interval = parseInt(intervalSelect ? intervalSelect.value : '30000', 10);
+    state.autoRefreshInterval = setInterval(function () { ns.loadMapData(); }, interval);
+    ns.debugAnchorMap('auto-refresh-started', { intervalMs: interval });
+  }
+
+  function stopAutoRefresh() {
+    if (state.autoRefreshInterval) {
+      clearInterval(state.autoRefreshInterval);
+      state.autoRefreshInterval = null;
+      ns.debugAnchorMap('auto-refresh-stopped');
+    }
+  }
+
+  function resubscribeWebSocket() {
+    if (state.websocket && state.websocket.readyState === WebSocket.OPEN) {
+      state.websocket.send(JSON.stringify({
+        method: 'subscribe',
+        params: { type: 'anchor_map_updates', agent_id: ns.getSelectedAgentId() },
+      }));
+    }
+  }
+
+  function disconnectWebSocket() {
+    if (state.websocket) {
+      state.websocket.close();
+      state.websocket = null;
+    }
+  }
+
+  function handleWsMessage(event) {
+    try {
+      const message = JSON.parse(event.data);
+      if (message.type === 'anchor_map_update') {
+        ns.debugAnchorMap('websocket-update', { hasData: Boolean(message.data) });
+        if (message.data) {
+          state.mapData = message.data;
+          ns.renderMap();
+          ns.updateAnchorList();
+        }
+      } else if (message.type === 'ping') {
+        state.websocket.send(JSON.stringify({ type: 'pong' }));
+      }
+    } catch (error) {
+      ns.debugAnchorMap('websocket-parse-error', { message: error.message });
+    }
+  }
+
+  function fallbackToPolling() {
+    const toggle = document.getElementById('auto-refresh-toggle');
+    if (!state.autoRefreshInterval && toggle && toggle.checked) {
+      startAutoRefresh();
+    }
+  }
+
+  function tryConnectWebSocket() {
+    if (typeof WebSocket === 'undefined') {
+      ns.debugAnchorMap('websocket-unsupported');
+      return;
+    }
+
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = protocol + '//' + window.location.host;
+
+    try {
+      state.websocket = new WebSocket(wsUrl);
+      state.websocket.onopen = function () {
+        ns.debugAnchorMap('websocket-open');
+        resubscribeWebSocket();
+      };
+      state.websocket.onmessage = handleWsMessage;
+      state.websocket.onerror = function (error) {
+        ns.debugAnchorMap('websocket-error', { type: (error && error.type) || 'unknown' });
+        fallbackToPolling();
+      };
+      state.websocket.onclose = function () {
+        ns.debugAnchorMap('websocket-closed');
+        state.websocket = null;
+        const toggle = document.getElementById('auto-refresh-toggle');
+        if (toggle && toggle.checked) {
+          setTimeout(function () { if (!state.websocket) tryConnectWebSocket(); }, 5000);
+        }
+      };
+    } catch (error) {
+      ns.debugAnchorMap('websocket-connect-failed', { message: error.message });
+      fallbackToPolling();
+    }
+  }
+
+  ns.startAutoRefresh = startAutoRefresh;
+  ns.stopAutoRefresh = stopAutoRefresh;
+  ns.tryConnectWebSocket = tryConnectWebSocket;
+  ns.resubscribeWebSocket = resubscribeWebSocket;
+  ns.disconnectWebSocket = disconnectWebSocket;
+
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/anchor-map.js
+++ b/static/js/anchor-map.js
@@ -1,1089 +1,133 @@
 /**
- * Anchor Map Visualization
- * D3.js를 사용한 네트워크 그래프 시각화
+ * Anchor Map — initialization, event wiring, and public API.
+ * Depends on: anchor-map-shared.js, anchor-map-render.js, anchor-map-search.js,
+ *             anchor-map-data.js, anchor-map-ws.js (loaded before this file).
  */
+(function (global) {
+  'use strict';
 
-// 전역 변수 (맵 미렌더/빈 데이터에서도 .find/.filter 호출 시 TypeError 방지)
-let svg, simulation, zoomBehavior;
-let nodes = [];
-let links = [];
-let mapData = null;
-let searchResults = null; // 검색 결과 저장
-const highlightedNodeIds = new Set(); // 하이라이트된 노드 ID 집합
-let autoRefreshInterval = null; // 자동 새로고침 인터벌
-let websocket = null; // WebSocket 연결
+  const ns = global.__MEMENTO_ANCHOR_MAP__;
+  if (!ns) return;
 
-// 슬롯별 색상 토큰 정의
-const slotColorTokens = {
-  'A': { fill: '--color-anchor-a', stroke: '--color-anchor-a-stroke' },
-  'B': { fill: '--color-anchor-b', stroke: '--color-anchor-b-stroke' },
-  'C': { fill: '--color-anchor-c', stroke: '--color-anchor-c-stroke' }
-};
+  const state = ns.state;
 
-function readAnchorMapToken(name, fallback = '') {
-  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  if (value) {
-    return value;
-  }
-  if (fallback) {
-    return fallback;
-  }
-  throw new Error(`Missing CSS token: ${name}`);
-}
-
-function getAnchorMapPalette() {
-  return {
-    slotColors: Object.fromEntries(
-      Object.entries(slotColorTokens).map(([slot, tokenNames]) => [slot, {
-        fill: readAnchorMapToken(tokenNames.fill),
-        stroke: readAnchorMapToken(tokenNames.stroke),
-      }])
-    ),
-    memoryFill: readAnchorMapToken('--color-memory-neutral'),
-    memoryStroke: readAnchorMapToken('--color-memory-neutral-stroke'),
-    labelFill: readAnchorMapToken('--color-text-main'),
-  };
-}
-
-/** XSS 방지: HTML 특수문자 이스케이프 */
-function escapeHtml(str) {
-  if (str == null) return '';
-  const s = String(str);
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-/** 검색 결과 item에서 memory ID 추출 */
-function getSearchItemId(item) {
-  if (!item) return '';
-  return item.id || item.memory_id || '';
-}
-
-/** 검색 결과 중 맵에 표시된 노드와 일치하는 개수 */
-function countSearchMapMatches(items, mapNodes) {
-  if (!Array.isArray(items) || !Array.isArray(mapNodes)) {
-    return 0;
-  }
-  const mapIds = new Set(mapNodes.map(n => n.id));
-  let matched = 0;
-  for (const item of items) {
-    if (mapIds.has(getSearchItemId(item))) {
-      matched += 1;
+  function initializeMap() {
+    if (typeof d3 === 'undefined') {
+      const fallbackContainer = document.getElementById('anchor-map');
+      if (fallbackContainer) {
+        fallbackContainer.innerHTML = '<p class="no-data">Anchor Map renderer is unavailable.</p>';
+      }
+      ns.debugAnchorMap('d3-unavailable');
+      return;
     }
-  }
-  return matched;
-}
 
-/** 검색 상태 메시지 생성 */
-function buildSearchStatusMessage(searchResult, mapMatchCount) {
-  const total = searchResult?.items?.length ?? 0;
-  if (total === 0) {
-    return '검색 결과가 없습니다.';
-  }
-  const parts = [`${total}건 검색됨`, `맵 ${mapMatchCount}건 표시`];
-  if (searchResult.fallback_used) {
-    parts.push('전역 검색 사용');
-  }
-  if (searchResult.local_results_count != null && !searchResult.fallback_used) {
-    parts.push(`국소 ${searchResult.local_results_count}건`);
-  }
-  return parts.join(' · ');
-}
+    const container = d3.select('#anchor-map');
+    const width = container.node().getBoundingClientRect().width;
+    const height = container.node().getBoundingClientRect().height;
 
-function normalizeMapData(data) {
-  return {
-    ...(data || {}),
-    anchors: Array.isArray(data?.anchors) ? data.anchors : [],
-    nodes: Array.isArray(data?.nodes) ? data.nodes : [],
-    links: Array.isArray(data?.links) ? data.links : [],
-    timestamp: data?.timestamp || new Date().toISOString(),
-  };
-}
+    state.svg = container.append('svg').attr('width', width).attr('height', height);
 
-function normalizeSearchResults(payload) {
-  const candidate = payload?.result || payload || {};
-  return {
-    ...candidate,
-    items: Array.isArray(candidate.items) ? candidate.items : [],
-  };
-}
+    state.zoomBehavior = d3.zoom()
+      .scaleExtent([0.1, 4])
+      .on('zoom', function (event) { state.svg.select('g').attr('transform', event.transform); });
 
-function getLinkNodeId(value) {
-  return value && typeof value === 'object' ? value.id : value;
-}
+    state.svg.call(state.zoomBehavior);
+    state.svg.append('g');
 
-function updateSearchStatus(message, isActive = false) {
-  const statusEl = document.getElementById('anchor-search-status');
-  if (!statusEl) return;
-  statusEl.textContent = message;
-  statusEl.classList.toggle('is-active', isActive);
-  statusEl.classList.toggle('no-data', !isActive);
-}
+    state.simulation = d3.forceSimulation()
+      .force('link', d3.forceLink().id(function (d) { return d.id; }).distance(100))
+      .force('charge', d3.forceManyBody().strength(-300))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collision', d3.forceCollide().radius(30));
 
-function renderSearchResultsList() {
-  const container = document.getElementById('anchor-search-results');
-  if (!container) return;
-
-  if (!searchResults?.items?.length) {
-    container.innerHTML = '<p class="no-data">No search results</p>';
-    return;
-  }
-
-  const mapIds = new Set(Array.isArray(nodes) ? nodes.map(n => n.id) : []);
-  container.innerHTML = searchResults.items
-    .map((item, index) => {
-      const id = getSearchItemId(item);
-      if (!id) return '';
-      const onMap = mapIds.has(id);
-      const preview = escapeHtml((item.content || '').substring(0, 80));
-      const suffix = item.content && item.content.length > 80 ? '...' : '';
-      const similarity = item.similarity != null
-        ? escapeHtml((item.similarity * 100).toFixed(1) + '%')
-        : 'N/A';
-      return `
-        <div class="anchor-search-result-item${onMap ? ' is-on-map' : ''} js-search-result-item"
-             data-memory-id="${escapeHtml(id)}"
-             title="${onMap ? '맵에 표시됨 — 클릭하여 포커스' : '맵 밖 결과 — 클릭하여 상세 보기'}">
-          <div class="search-result-meta">#${index + 1} · ${escapeHtml(id)} · ${similarity}</div>
-          <div class="search-result-preview">${preview}${suffix}</div>
-        </div>
-      `;
-    })
-    .join('');
-}
-
-function focusOnNode(node, scale = 1.5) {
-  if (!node || node.x == null || node.y == null || !zoomBehavior || !svg) {
-    return;
-  }
-  const width = parseFloat(svg.attr('width'));
-  const height = parseFloat(svg.attr('height'));
-  const transform = d3.zoomIdentity
-    .translate(width / 2 - node.x * scale, height / 2 - node.y * scale)
-    .scale(scale);
-  svg.transition().duration(750).call(zoomBehavior.transform, transform);
-}
-
-function displaySearchResultDetails(item) {
-  displayMemoryDetails({
-    id: getSearchItemId(item),
-    type: 'memory',
-    content: item.content || '',
-    hop_distance: item.hop_distance,
-    similarity: item.similarity,
-    importance: item.importance,
-    created_at: item.created_at,
-  });
-}
-
-function debugAnchorMap(eventName, detail) {
-  if (window.localStorage.getItem('memento.debug') !== '1') {
-    return;
-  }
-
-  document.dispatchEvent(new CustomEvent('memento:debug', {
-    bubbles: true,
-    composed: true,
-    detail: { scope: 'anchor-map', eventName, detail },
-  }));
-}
-
-// 초기화
-document.addEventListener('DOMContentLoaded', async () => {
-  initializeMap();
-  setupEventListeners();
-  await loadAgentIdOptions();
-  loadMapData();
-});
-
-/**
- * 맵 초기화
- */
-function initializeMap() {
-  if (typeof d3 === 'undefined') {
-    const fallbackContainer = document.getElementById('anchor-map');
-    if (fallbackContainer) {
-      fallbackContainer.innerHTML = '<p class="no-data">Anchor Map renderer is unavailable.</p>';
-    }
-    debugAnchorMap('d3-unavailable');
-    return;
-  }
-
-  const container = d3.select('#anchor-map');
-  const width = container.node().getBoundingClientRect().width;
-  const height = container.node().getBoundingClientRect().height;
-
-  // SVG 생성
-  svg = container
-    .append('svg')
-    .attr('width', width)
-    .attr('height', height);
-
-  // Zoom 패닝 기능
-  zoomBehavior = d3.zoom()
-    .scaleExtent([0.1, 4])
-    .on('zoom', (event) => {
-      svg.select('g').attr('transform', event.transform);
+    window.addEventListener('resize', function () {
+      const newWidth = container.node().getBoundingClientRect().width;
+      const newHeight = container.node().getBoundingClientRect().height;
+      state.svg.attr('width', newWidth).attr('height', newHeight);
+      state.simulation.force('center', d3.forceCenter(newWidth / 2, newHeight / 2));
+      state.simulation.alpha(1).restart();
     });
+  }
 
-  svg.call(zoomBehavior);
-
-  // 그룹 생성 (zoom 적용)
-  svg.append('g');
-
-  // Force simulation 설정
-  simulation = d3.forceSimulation()
-    .force('link', d3.forceLink().id(d => d.id).distance(100))
-    .force('charge', d3.forceManyBody().strength(-300))
-    .force('center', d3.forceCenter(width / 2, height / 2))
-    .force('collision', d3.forceCollide().radius(30));
-
-  // 창 크기 변경 시 SVG 크기 조정
-  window.addEventListener('resize', () => {
-    const newWidth = container.node().getBoundingClientRect().width;
-    const newHeight = container.node().getBoundingClientRect().height;
-    svg.attr('width', newWidth).attr('height', newHeight);
-    simulation.force('center', d3.forceCenter(newWidth / 2, newHeight / 2));
-    simulation.alpha(1).restart();
-  });
-}
-
-/**
- * 이벤트 리스너 설정
- */
-function setupEventListeners() {
-  document.getElementById('load-map-btn').addEventListener('click', loadMapData);
-  document.getElementById('refresh-btn').addEventListener('click', loadMapData);
-  document.getElementById('search-btn').addEventListener('click', performSearch);
-  document.getElementById('clear-search-btn').addEventListener('click', clearSearch);
-
-  document.getElementById('memory-details')?.addEventListener('click', (e) => {
-    const btn = e.target.closest('.js-change-anchor');
-    if (btn && btn.dataset.slot) changeAnchor(btn.dataset.slot);
-  });
-  document.getElementById('anchor-list')?.addEventListener('click', (e) => {
-    const el = e.target.closest('.js-select-anchor');
-    if (el && el.dataset.memoryId) selectAnchorNode(el.dataset.memoryId);
-  });
-
-  document.getElementById('anchor-search-results')?.addEventListener('click', (e) => {
+  function onSearchResultClick(e) {
     const el = e.target.closest('.js-search-result-item');
-    if (!el?.dataset.memoryId || !searchResults?.items) return;
-    const item = searchResults.items.find(i => getSearchItemId(i) === el.dataset.memoryId);
+    if (!el || !el.dataset.memoryId || !state.searchResults || !state.searchResults.items) return;
+    const item = state.searchResults.items.find(function (i) { return ns.getSearchItemId(i) === el.dataset.memoryId; });
     if (!item) return;
-    if (Array.isArray(nodes)) {
-      const node = nodes.find(n => n.id === el.dataset.memoryId);
+    if (Array.isArray(state.nodes)) {
+      const node = state.nodes.find(function (n) { return n.id === el.dataset.memoryId; });
       if (node) {
-        selectNode(node);
-        focusOnNode(node, 1.5);
+        ns.selectNode(node);
+        ns.focusOnNode(node, 1.5);
         return;
       }
     }
-    displaySearchResultDetails(item);
-  });
-  
-  // 자동 새로고침 토글
-  document.getElementById('auto-refresh-toggle').addEventListener('change', (e) => {
-    if (e.target.checked) {
-      startAutoRefresh();
-    } else {
-      stopAutoRefresh();
-    }
-  });
-  
-  // 새로고침 간격 변경
-  document.getElementById('refresh-interval-select').addEventListener('change', () => {
-    if (document.getElementById('auto-refresh-toggle').checked) {
-      stopAutoRefresh();
-      startAutoRefresh();
-    }
-  });
-  
-  document.getElementById('agent-id-select').addEventListener('change', () => {
-    loadMapData();
-    resubscribeWebSocket();
-  });
-  
-  document.getElementById('search-query-input').addEventListener('keypress', (e) => {
-    if (e.key === 'Enter') {
-      performSearch();
-    }
-  });
-  
-  // WebSocket 연결 시도 (선택적)
-  tryConnectWebSocket();
-}
-
-/**
- * 선택된 Agent ID 반환
- */
-function getSelectedAgentId() {
-  const select = document.getElementById('agent-id-select');
-  return select?.value || 'default';
-}
-
-/**
- * Agent ID 선택 목록 로드
- */
-async function loadAgentIdOptions() {
-  const select = document.getElementById('agent-id-select');
-  if (!select) return;
-
-  const previousSelection = getSelectedAgentId();
-
-  try {
-    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
-    const response = await fetchFn('/api/anchors/agents');
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const payload = await response.json();
-    const agents = Array.isArray(payload.agents) ? payload.agents : [];
-
-    select.innerHTML = '';
-
-    if (agents.length === 0) {
-      const option = document.createElement('option');
-      option.value = 'default';
-      option.textContent = 'default (앵커 없음)';
-      select.appendChild(option);
-    } else {
-      for (const entry of agents) {
-        const option = document.createElement('option');
-        option.value = entry.agent_id;
-        option.textContent = `${entry.agent_id} (${entry.anchor_count} anchors)`;
-        select.appendChild(option);
-      }
-    }
-
-    const validValues = Array.from(select.options).map(option => option.value);
-    if (validValues.includes(previousSelection)) {
-      select.value = previousSelection;
-    } else if (agents.length > 0) {
-      select.value = agents[0].agent_id;
-    } else {
-      select.value = 'default';
-    }
-  } catch (error) {
-    debugAnchorMap('agent-list-load-error', { message: error.message });
-    if (select.options.length === 0) {
-      const option = document.createElement('option');
-      option.value = 'default';
-      option.textContent = 'default (앵커 없음)';
-      select.appendChild(option);
-      select.value = 'default';
-    }
-  }
-}
-
-/**
- * 맵 데이터 로드
- */
-async function loadMapData() {
-  const agentId = getSelectedAgentId();
-  
-  try {
-    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
-    const response = await fetchFn(`/api/anchors/map?agent_id=${encodeURIComponent(agentId)}`);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    const newMapData = normalizeMapData(await response.json());
-    
-    // 데이터 변경 감지
-    const hasChanged = !mapData || 
-      JSON.stringify(mapData.timestamp) !== JSON.stringify(newMapData.timestamp) ||
-      JSON.stringify(mapData.anchors) !== JSON.stringify(newMapData.anchors) ||
-      mapData.nodes.length !== newMapData.nodes.length ||
-      mapData.links.length !== newMapData.links.length;
-    
-    if (hasChanged) {
-      mapData = newMapData;
-      renderMap();
-      updateAnchorList();
-      debugAnchorMap('map-updated', { timestamp: newMapData.timestamp });
-    } else {
-      debugAnchorMap('map-unchanged');
-    }
-
-    await loadAgentIdOptions();
-  } catch (error) {
-    debugAnchorMap('load-error', { message: error.message });
-    // 에러 알림은 자동 새로고침 시에는 표시하지 않음
-    if (!autoRefreshInterval) {
-      alert(`맵 데이터를 불러올 수 없습니다: ${error.message}`);
-    }
-  }
-}
-
-/**
- * 맵 렌더링
- */
-function renderMap() {
-  if (!svg || !simulation) {
-    return;
+    ns.displaySearchResultDetails(item);
   }
 
-  mapData = normalizeMapData(mapData);
+  function setupEventListeners() {
+    document.getElementById('load-map-btn').addEventListener('click', ns.loadMapData);
+    document.getElementById('refresh-btn').addEventListener('click', ns.loadMapData);
+    document.getElementById('search-btn').addEventListener('click', ns.performSearch);
+    document.getElementById('clear-search-btn').addEventListener('click', ns.clearSearch);
 
-  if (!mapData || !mapData.nodes || mapData.nodes.length === 0) {
-    nodes = [];
-    links = [];
-    const g = svg.select('g');
-    if (g.node()) {
-      g.selectAll('*').remove();
-    } else {
-      svg.selectAll('*').remove();
+    const memDetails = document.getElementById('memory-details');
+    if (memDetails) {
+      memDetails.addEventListener('click', function (e) {
+        const btn = e.target.closest('.js-change-anchor');
+        if (btn && btn.dataset.slot) ns.changeAnchor(btn.dataset.slot);
+      });
     }
-    return;
-  }
 
-  const g = svg.select('g');
-  g.selectAll('*').remove();
+    const anchorList = document.getElementById('anchor-list');
+    if (anchorList) {
+      anchorList.addEventListener('click', function (e) {
+        const el = e.target.closest('.js-select-anchor');
+        if (el && el.dataset.memoryId) ns.selectAnchorNode(el.dataset.memoryId);
+      });
+    }
 
-  const palette = getAnchorMapPalette();
+    const searchResults = document.getElementById('anchor-search-results');
+    if (searchResults) searchResults.addEventListener('click', onSearchResultClick);
 
-  // 노드와 링크 데이터 준비
-  nodes = mapData.nodes.map(d => ({
-    ...d,
-    radius: d.type === 'anchor' ? 12 : 8
-  }));
-
-  links = mapData.links
-    .map(d => ({
-      ...d,
-      source: typeof d.source === 'string' ? nodes.find(n => n.id === d.source) : d.source,
-      target: typeof d.target === 'string' ? nodes.find(n => n.id === d.target) : d.target
-    }))
-    .filter(d => d.source && d.target);
-
-  // Hop 거리에 따른 원형 레이어 배치 (초기 위치)
-  layoutNodesByHop();
-
-  // 링크 그리기
-  const link = g.append('g')
-    .selectAll('line')
-    .data(links)
-    .enter()
-    .append('line')
-    .attr('class', d => `link ${d.type}`)
-    .attr('stroke-width', d => d.type === 'hop' ? 2 : 1.5);
-
-  // 노드 그리기
-  const node = g.append('g')
-    .selectAll('circle')
-    .data(nodes)
-    .enter()
-    .append('circle')
-    .attr('class', d => {
-      let classes = `node ${d.type}`;
-      if (d.type === 'anchor' && d.slot) {
-        classes += ` slot-${d.slot.toLowerCase()}`;
-      }
-      return classes;
-    })
-    .attr('r', d => d.radius)
-    .attr('fill', d => {
-      if (d.type === 'anchor' && d.slot) {
-        return palette.slotColors[d.slot].fill;
-      }
-      return palette.memoryFill;
-    })
-    .attr('stroke', d => {
-      if (d.type === 'anchor' && d.slot) {
-        return palette.slotColors[d.slot].stroke;
-      }
-      return palette.memoryStroke;
-    })
-    .attr('stroke-width', d => d.type === 'anchor' ? 3 : 2)
-    .attr('stroke-dasharray', d => d.embedding_missing ? '5,3' : null)
-    .attr('opacity', d => d.embedding_missing ? 0.6 : 1.0)
-    .call(drag(simulation))
-    .on('click', (event, d) => {
-      event.stopPropagation();
-      selectNode(d);
+    document.getElementById('auto-refresh-toggle').addEventListener('change', function (e) {
+      if (e.target.checked) ns.startAutoRefresh();
+      else ns.stopAutoRefresh();
     });
 
-  // 노드 라벨 추가
-  const label = g.append('g')
-    .selectAll('text')
-    .data(nodes)
-    .enter()
-    .append('text')
-    .attr('class', 'node-label')
-    .attr('dx', d => d.radius + 5)
-    .attr('dy', 4)
-    .text(d => {
-      if (d.type === 'anchor' && d.slot) {
-        return `Slot ${d.slot}`;
-      }
-      return d.content.substring(0, 20) + (d.content.length > 20 ? '...' : '');
-    })
-    .style('font-size', '12px')
-    .style('fill', palette.labelFill)
-    .style('pointer-events', 'none');
-
-  // Tooltip 추가
-  node.append('title')
-    .text(d => {
-      if (d.type === 'anchor') {
-        const warning = d.embedding_missing ? '\n⚠ 임베딩 없음 — 연결 메모리 검색 불가' : '';
-        return `Anchor ${d.slot}\n${d.content}${warning}`;
-      }
-      return `Memory\n${d.content}\nHop: ${d.hop_distance || 'N/A'}`;
-    });
-
-  // Force simulation 업데이트
-  simulation.nodes(nodes).on('tick', () => {
-    link
-      .attr('x1', d => d.source.x)
-      .attr('y1', d => d.source.y)
-      .attr('x2', d => d.target.x)
-      .attr('y2', d => d.target.y);
-
-    node
-      .attr('cx', d => d.x)
-      .attr('cy', d => d.y);
-
-    label
-      .attr('x', d => d.x)
-      .attr('y', d => d.y);
-  });
-
-  simulation.force('link').links(links);
-  simulation.alpha(1).restart();
-
-  if (searchResults?.items?.length) {
-    highlightSearchResults();
-  }
-}
-
-/**
- * Hop 거리에 따른 원형 레이어 배치
- */
-function layoutNodesByHop() {
-  const width = svg.attr('width');
-  const height = svg.attr('height');
-  const centerX = width / 2;
-  const centerY = height / 2;
-
-  // 앵커 노드 찾기
-  const anchorNodes = nodes.filter(n => n.type === 'anchor');
-  
-  anchorNodes.forEach((anchor, anchorIndex) => {
-    // 각 앵커를 중심으로 배치
-    const angle = (anchorIndex / anchorNodes.length) * 2 * Math.PI;
-    const radius = 150;
-    anchor.fx = centerX + Math.cos(angle) * radius;
-    anchor.fy = centerY + Math.sin(angle) * radius;
-
-    // 해당 앵커와 연결된 메모리들을 hop 거리별로 원형 레이어에 배치
-    const relatedMemories = nodes.filter(n => 
-      n.type === 'memory' && 
-      links.some(l => 
-        (l.source.id === anchor.id && l.target.id === n.id) ||
-        (l.target.id === anchor.id && l.source.id === n.id)
-      )
-    );
-
-    relatedMemories.forEach((memory, memIndex) => {
-      const hop = memory.hop_distance || 1;
-      const layerRadius = 100 + (hop - 1) * 80;
-      const memAngle = (memIndex / relatedMemories.length) * 2 * Math.PI + angle;
-      
-      memory.fx = anchor.fx + Math.cos(memAngle) * layerRadius;
-      memory.fy = anchor.fy + Math.sin(memAngle) * layerRadius;
-    });
-  });
-
-  // 연결되지 않은 메모리들은 자유롭게 배치
-  nodes.forEach(node => {
-    if (!node.fx && !node.fy && node.type === 'memory') {
-      node.fx = null;
-      node.fy = null;
-    }
-  });
-}
-
-/**
- * 노드 드래그 핸들러
- */
-function drag(simulation) {
-  function dragstarted(event, d) {
-    if (!event.active) simulation.alphaTarget(0.3).restart();
-    d.fx = d.x;
-    d.fy = d.y;
-  }
-
-  function dragged(event, d) {
-    d.fx = event.x;
-    d.fy = event.y;
-  }
-
-  function dragended(event, d) {
-    if (!event.active) simulation.alphaTarget(0);
-    d.fx = null;
-    d.fy = null;
-  }
-
-  return d3.drag()
-    .on('start', dragstarted)
-    .on('drag', dragged)
-    .on('end', dragended);
-}
-
-/**
- * 노드 선택
- */
-function selectNode(node) {
-  
-  // 노드 하이라이트
-  svg.selectAll('.node')
-    .classed('selected', d => d.id === node.id);
-  
-  // 메모리 상세 정보 표시
-  displayMemoryDetails(node);
-}
-
-/**
- * 메모리 상세 정보 표시
- */
-function displayMemoryDetails(node) {
-  const detailsContainer = document.getElementById('memory-details');
-  
-  if (node.type === 'anchor') {
-    const slot = escapeHtml(node.slot);
-    const id = escapeHtml(node.id);
-    const content = escapeHtml(node.content);
-    const importance = escapeHtml(node.importance != null ? node.importance : 'N/A');
-    const created = node.created_at ? escapeHtml(new Date(node.created_at).toLocaleString()) : 'N/A';
-    detailsContainer.innerHTML = `
-      <div class="memory-detail-item">
-        <label>Type:</label>
-        <div class="value">Anchor (Slot ${slot})</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Memory ID:</label>
-        <div class="value">${id}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Content:</label>
-        <div class="value">${content}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Hop Distance:</label>
-        <div class="value">0 (Anchor)</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Similarity:</label>
-        <div class="value">1.0 (100.0%)</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Importance:</label>
-        <div class="value">${importance}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Created:</label>
-        <div class="value">${created}</div>
-      </div>
-      <button type="button" class="anchor-change-btn js-change-anchor m-button m-button--primary" data-slot="${slot}">
-        Change Anchor
-      </button>
-    `;
-  } else {
-    const id = escapeHtml(node.id);
-    const content = escapeHtml(node.content);
-    const hopDistance = escapeHtml(node.hop_distance != null ? node.hop_distance : 'N/A');
-    const similarity = node.similarity != null ? escapeHtml((node.similarity * 100).toFixed(1) + '%') : 'N/A';
-    const importance = escapeHtml(node.importance != null ? node.importance : 'N/A');
-    const created = node.created_at ? escapeHtml(new Date(node.created_at).toLocaleString()) : 'N/A';
-    detailsContainer.innerHTML = `
-      <div class="memory-detail-item">
-        <label>Type:</label>
-        <div class="value">Memory</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Memory ID:</label>
-        <div class="value">${id}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Content:</label>
-        <div class="value">${content}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Hop Distance:</label>
-        <div class="value">${hopDistance}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Similarity:</label>
-        <div class="value">${similarity}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Importance:</label>
-        <div class="value">${importance}</div>
-      </div>
-      <div class="memory-detail-item">
-        <label>Created:</label>
-        <div class="value">${created}</div>
-      </div>
-    `;
-  }
-}
-
-/**
- * 앵커 목록 업데이트
- */
-function updateAnchorList() {
-  const anchorListContainer = document.getElementById('anchor-list');
-  mapData = normalizeMapData(mapData);
-  
-  if (!mapData || !mapData.anchors || mapData.anchors.length === 0) {
-    anchorListContainer.innerHTML = '<p class="no-data">No anchors set</p>';
-    return;
-  }
-
-  anchorListContainer.innerHTML = mapData.anchors
-    .map(anchor => {
-      if (!anchor.memory_id) return '';
-      const memory = mapData.nodes.find(n => n.id === anchor.memory_id);
-      const slot = escapeHtml(anchor.slot);
-      const slotClass = /^[ABC]$/i.test(anchor.slot) ? slot.toLowerCase() : 'a';
-      const memoryId = escapeHtml(anchor.memory_id);
-      const contentPreview = memory ? escapeHtml(memory.content.substring(0, 50)) + '...' : '';
-      return `
-        <div class="anchor-item slot-${slotClass} js-select-anchor" data-memory-id="${memoryId}">
-          <div class="slot-label">Slot ${slot}</div>
-          <div class="memory-id">${memoryId}</div>
-          ${memory ? `<div class="anchor-item-preview">${contentPreview}</div>` : ''}
-        </div>
-      `;
-    })
-    .join('');
-}
-
-/**
- * 앵커 노드 선택
- */
-function selectAnchorNode(memoryId) {
-  if (!Array.isArray(nodes)) {
-    return;
-  }
-  const node = nodes.find(n => n.id === memoryId);
-  if (node) {
-    selectNode(node);
-    focusOnNode(node, 2);
-  }
-}
-
-/**
- * 앵커 변경 (향후 구현)
- */
-function changeAnchor(slot) {
-  // TODO: 앵커 변경 UI 구현
-  alert(`앵커 변경 기능은 향후 구현 예정입니다. Slot: ${slot}`);
-}
-
-/**
- * 검색 수행
- */
-async function performSearch() {
-  const query = document.getElementById('search-query-input').value.trim();
-  const slotSelect = document.getElementById('search-slot-select');
-  const slot = slotSelect ? slotSelect.value : 'A'; // 기본값: A
-  const agentId = getSelectedAgentId();
-  
-  if (!query) {
-    alert('검색어를 입력해주세요.');
-    return;
-  }
-  
-  // slot이 필수이므로 반드시 설정
-  if (!slot || !['A', 'B', 'C'].includes(slot)) {
-    alert('슬롯을 선택해주세요. (A, B, C 중 하나)');
-    return;
-  }
-  
-  try {
-    updateSearchStatus('검색 중...', false);
-
-    const fetchFn = typeof mementoAdminFetch === 'function' ? mementoAdminFetch : fetch;
-    const response = await fetchFn(`/api/anchors/search`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        query: query,
-        slot: slot, // 필수 파라미터
-        agent_id: agentId,
-        limit: 100
-      })
-    });
-    
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-    
-    searchResults = normalizeSearchResults(await response.json());
-    
-    highlightSearchResults();
-    
-    const resultCount = searchResults.items ? searchResults.items.length : 0;
-    debugAnchorMap('search-complete', { resultCount });
-    
-  } catch (error) {
-    updateSearchStatus(`검색 실패: ${error.message}`, false);
-    debugAnchorMap('search-error', { message: error.message });
-    alert(`검색 중 오류가 발생했습니다: ${error.message}`);
-  }
-}
-
-/**
- * 검색 결과 하이라이트
- */
-function highlightSearchResults() {
-  if (!searchResults || !searchResults.items) {
-    updateSearchStatus('검색 결과가 없습니다.', false);
-    renderSearchResultsList();
-    return;
-  }
-  
-  highlightedNodeIds.clear();
-  searchResults.items.forEach(item => {
-    const id = getSearchItemId(item);
-    if (id) highlightedNodeIds.add(id);
-  });
-  
-  updateNodeHighlight();
-
-  const mapMatchCount = countSearchMapMatches(searchResults.items, nodes);
-  updateSearchStatus(buildSearchStatusMessage(searchResults, mapMatchCount), true);
-  renderSearchResultsList();
-  
-  if (searchResults.items.length > 0 && Array.isArray(nodes)) {
-    const firstOnMap = searchResults.items
-      .map(item => nodes.find(n => n.id === getSearchItemId(item)))
-      .find(Boolean);
-    if (firstOnMap) {
-      selectNode(firstOnMap);
-      focusOnNode(firstOnMap, 1.5);
-    }
-  }
-}
-
-/**
- * 노드 하이라이트 업데이트
- */
-function updateNodeHighlight() {
-  if (!svg) {
-    return;
-  }
-
-  const nodeElements = svg.selectAll('.node');
-  const mapMatchCount = Array.isArray(nodes)
-    ? nodes.filter(n => highlightedNodeIds.has(n.id)).length
-    : 0;
-  const shouldDimOthers = highlightedNodeIds.size > 0 && mapMatchCount > 0;
-  
-  nodeElements
-    .classed('highlighted', d => highlightedNodeIds.has(d.id))
-    .attr('stroke-width', d => {
-      if (highlightedNodeIds.has(d.id)) {
-        return d.type === 'anchor' ? 5 : 4;
-      }
-      return d.type === 'anchor' ? 3 : 2;
-    })
-    .attr('opacity', d => {
-      if (shouldDimOthers && !highlightedNodeIds.has(d.id)) {
-        return 0.3;
-      }
-      return d.embedding_missing ? 0.6 : 1.0;
-    });
-  
-  const linkElements = svg.selectAll('.link');
-  linkElements
-    .attr('opacity', d => {
-      if (shouldDimOthers) {
-        const sourceHighlighted = highlightedNodeIds.has(getLinkNodeId(d.source));
-        const targetHighlighted = highlightedNodeIds.has(getLinkNodeId(d.target));
-        if (sourceHighlighted || targetHighlighted) {
-          return 1.0;
-        }
-        return 0.2;
-      }
-      return 0.6;
-    })
-    .attr('stroke-width', d => {
-      if (highlightedNodeIds.size > 0) {
-        const sourceHighlighted = highlightedNodeIds.has(getLinkNodeId(d.source));
-        const targetHighlighted = highlightedNodeIds.has(getLinkNodeId(d.target));
-        if (sourceHighlighted && targetHighlighted) {
-          return 3;
-        } else if (sourceHighlighted || targetHighlighted) {
-          return 2;
-        }
-      }
-      return d.type === 'hop' ? 2 : 1.5;
-    });
-  
-  // 라벨도 하이라이트
-  const labelElements = svg.selectAll('.node-label');
-  labelElements
-    .style('font-weight', d => highlightedNodeIds.has(d.id) ? 'bold' : 'normal')
-    .style('font-size', d => highlightedNodeIds.has(d.id) ? '14px' : '12px');
-}
-
-/**
- * 검색 하이라이트 제거
- */
-function clearSearch() {
-  searchResults = null;
-  highlightedNodeIds.clear();
-  document.getElementById('search-query-input').value = '';
-  document.getElementById('search-slot-select').value = 'A';
-  
-  updateSearchStatus('검색 후 결과가 여기에 표시됩니다.', false);
-  renderSearchResultsList();
-  updateNodeHighlight();
-  
-  debugAnchorMap('search-cleared');
-}
-
-/**
- * 자동 새로고침 시작
- */
-function startAutoRefresh() {
-  stopAutoRefresh(); // 기존 인터벌 정리
-  
-  const interval = parseInt(document.getElementById('refresh-interval-select').value, 10);
-  autoRefreshInterval = setInterval(() => {
-    loadMapData();
-  }, interval);
-  
-  debugAnchorMap('auto-refresh-started', { intervalMs: interval });
-}
-
-/**
- * 자동 새로고침 중지
- */
-function stopAutoRefresh() {
-  if (autoRefreshInterval) {
-    clearInterval(autoRefreshInterval);
-    autoRefreshInterval = null;
-    debugAnchorMap('auto-refresh-stopped');
-  }
-}
-
-/**
- * WebSocket 연결 시도
- */
-function tryConnectWebSocket() {
-  // WebSocket이 지원되는 경우에만 시도
-  if (typeof WebSocket === 'undefined') {
-    debugAnchorMap('websocket-unsupported');
-    return;
-  }
-  
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  const wsUrl = `${protocol}//${window.location.host}`;
-  
-  try {
-    websocket = new WebSocket(wsUrl);
-    
-    websocket.onopen = () => {
-      debugAnchorMap('websocket-open');
-      resubscribeWebSocket();
-    };
-    
-    websocket.onmessage = (event) => {
-      try {
-        const message = JSON.parse(event.data);
-        
-        if (message.type === 'anchor_map_update') {
-          // Anchor Map 업데이트 수신
-          debugAnchorMap('websocket-update', { hasData: Boolean(message.data) });
-          if (message.data) {
-            mapData = message.data;
-            renderMap();
-            updateAnchorList();
-          }
-        } else if (message.type === 'ping') {
-          // Keep-alive ping 응답
-          websocket.send(JSON.stringify({ type: 'pong' }));
-        }
-      } catch (error) {
-        debugAnchorMap('websocket-parse-error', { message: error.message });
-      }
-    };
-    
-    websocket.onerror = (error) => {
-      debugAnchorMap('websocket-error', { type: error?.type ?? 'unknown' });
-      // WebSocket 실패 시 polling으로 fallback
-      if (!autoRefreshInterval && document.getElementById('auto-refresh-toggle').checked) {
-        startAutoRefresh();
-      }
-    };
-    
-    websocket.onclose = () => {
-      debugAnchorMap('websocket-closed');
-      websocket = null;
-      
-      // 자동 재연결 시도 (5초 후)
+    document.getElementById('refresh-interval-select').addEventListener('change', function () {
       if (document.getElementById('auto-refresh-toggle').checked) {
-        setTimeout(() => {
-          if (!websocket) {
-            tryConnectWebSocket();
-          }
-        }, 5000);
+        ns.stopAutoRefresh();
+        ns.startAutoRefresh();
       }
-    };
-  } catch (error) {
-    debugAnchorMap('websocket-connect-failed', { message: error.message });
-    // WebSocket 실패 시 polling으로 fallback
-    if (!autoRefreshInterval && document.getElementById('auto-refresh-toggle').checked) {
-      startAutoRefresh();
-    }
+    });
+
+    document.getElementById('agent-id-select').addEventListener('change', function () {
+      ns.loadMapData();
+      ns.resubscribeWebSocket();
+    });
+
+    document.getElementById('search-query-input').addEventListener('keypress', function (e) {
+      if (e.key === 'Enter') ns.performSearch();
+    });
+
+    ns.tryConnectWebSocket();
   }
-}
 
-/**
- * WebSocket 재구독
- */
-function resubscribeWebSocket() {
-  if (websocket && websocket.readyState === WebSocket.OPEN) {
-    websocket.send(JSON.stringify({
-      method: 'subscribe',
-      params: {
-        type: 'anchor_map_updates',
-        agent_id: getSelectedAgentId()
-      }
-    }));
-  }
-}
+  document.addEventListener('DOMContentLoaded', async function () {
+    initializeMap();
+    setupEventListeners();
+    await ns.loadAgentIdOptions();
+    ns.loadMapData();
+  });
 
-/**
- * WebSocket 연결 종료
- */
-function disconnectWebSocket() {
-  if (websocket) {
-    websocket.close();
-    websocket = null;
-  }
-}
+  window.addEventListener('beforeunload', function () {
+    ns.stopAutoRefresh();
+    ns.disconnectWebSocket();
+  });
 
-// 페이지 언로드 시 정리
-window.addEventListener('beforeunload', () => {
-  stopAutoRefresh();
-  disconnectWebSocket();
-});
+  // Public API
+  window.selectAnchorNode = ns.selectAnchorNode;
+  window.changeAnchor = ns.changeAnchor;
 
-// 전역 함수로 노출 (HTML에서 호출 가능)
-window.selectAnchorNode = selectAnchorNode;
-window.changeAnchor = changeAnchor;
-
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/static/js/dashboard-auth.js
+++ b/static/js/dashboard-auth.js
@@ -108,39 +108,42 @@
     messageEl.dataset.tone = tone || 'neutral';
   }
 
-  function setAuthState(nextState, message) {
-    authState = nextState;
-    if (rootEl) {
-      rootEl.dataset.authState = nextState;
-    }
+  function updateFormVisibility(nextState) {
+    if (formEl) formEl.hidden = nextState === 'signed-in';
+    if (sessionBoxEl) sessionBoxEl.hidden = nextState !== 'signed-in';
+  }
 
-    if (formEl) {
-      formEl.hidden = nextState === 'signed-in';
-    }
-    if (sessionBoxEl) {
-      sessionBoxEl.hidden = nextState !== 'signed-in';
-    }
-    if (keyInputEl) {
-      keyInputEl.disabled = nextState === 'checking' || nextState === 'signing-in';
-    }
+  function updateInputElements(nextState) {
+    const busy = nextState === 'checking' || nextState === 'signing-in';
+    if (keyInputEl) keyInputEl.disabled = busy;
     if (signInButtonEl) {
-      signInButtonEl.disabled = nextState === 'checking' || nextState === 'signing-in';
+      signInButtonEl.disabled = busy;
       signInButtonEl.textContent = nextState === 'signing-in' ? 'Signing in…' : 'Sign in';
     }
     if (signOutButtonEl) {
       signOutButtonEl.disabled = nextState === 'signing-out';
       signOutButtonEl.textContent = nextState === 'signing-out' ? 'Signing out…' : 'Sign out';
     }
+  }
 
-    if (statusEl) {
-      if (nextState === 'signed-in') {
-        statusEl.textContent = 'Session active';
-      } else if (nextState === 'checking') {
-        statusEl.textContent = 'Checking session…';
-      } else {
-        statusEl.textContent = 'Session required';
-      }
+  function updateStatusLabel(nextState) {
+    if (!statusEl) return;
+    if (nextState === 'signed-in') {
+      statusEl.textContent = 'Session active';
+    } else if (nextState === 'checking') {
+      statusEl.textContent = 'Checking session…';
+    } else {
+      statusEl.textContent = 'Session required';
     }
+  }
+
+  function setAuthState(nextState, message) {
+    authState = nextState;
+    if (rootEl) rootEl.dataset.authState = nextState;
+
+    updateFormVisibility(nextState);
+    updateInputElements(nextState);
+    updateStatusLabel(nextState);
 
     setMessage(message, nextState === 'signed-out' ? 'error' : 'neutral');
     maybeActivateTabForAuth(nextState);

--- a/tests/static-design-contracts.spec.ts
+++ b/tests/static-design-contracts.spec.ts
@@ -8,22 +8,31 @@ function readStaticFile(relativePath: string): string {
 
 describe('static design contracts', () => {
   it('anchor-map.js avoids console calls, hex colors, and inline html styles', () => {
-    const source = readStaticFile('static/js/anchor-map.js');
+    const anchorMapFiles = [
+      'static/js/anchor-map-shared.js',
+      'static/js/anchor-map-render.js',
+      'static/js/anchor-map-search.js',
+      'static/js/anchor-map-data.js',
+      'static/js/anchor-map-ws.js',
+      'static/js/anchor-map.js',
+    ].map(readStaticFile).join('\n');
 
-    expect(source).not.toContain('console.');
-    expect(source).not.toMatch(/#[0-9A-Fa-f]{3,8}(?![0-9A-Za-z_-])/);
-    expect(source).not.toMatch(/style\s*=/);
+    expect(anchorMapFiles).not.toContain('console.');
+    expect(anchorMapFiles).not.toMatch(/#[0-9A-Fa-f]{3,8}(?![0-9A-Za-z_-])/);
+    expect(anchorMapFiles).not.toMatch(/style\s*=/);
   });
 
   it('anchor-map.js uses session-protected /api/anchors/search instead of /tools/search_local', () => {
-    const source = readStaticFile('static/js/anchor-map.js');
+    // /api/anchors/search lives in the search module after the god-function split (#596)
+    const source = readStaticFile('static/js/anchor-map-search.js');
 
     expect(source).toContain('/api/anchors/search');
     expect(source).not.toContain('/tools/search_local');
   });
 
   it('anchor-map.js emits observable debug events for document-level listeners', () => {
-    const source = readStaticFile('static/js/anchor-map.js');
+    // debugAnchorMap lives in the shared module after the god-function split (#596)
+    const source = readStaticFile('static/js/anchor-map-shared.js');
 
     expect(source).toMatch(/document\.dispatchEvent\(new CustomEvent\('memento:debug', \{/);
     expect(source).toMatch(/bubbles:\s*true/);
@@ -31,7 +40,8 @@ describe('static design contracts', () => {
   });
 
   it('token readers fail in a bounded way when a required token is missing', () => {
-    const anchorMapSource = readStaticFile('static/js/anchor-map.js');
+    // readAnchorMapToken lives in the shared module after the god-function split (#596)
+    const anchorMapSource = readStaticFile('static/js/anchor-map-shared.js');
     const graphSource = readStaticFile('static/js/graph.js');
 
     expect(anchorMapSource).toMatch(/function readAnchorMapToken\(name, fallback = ''\)/);


### PR DESCRIPTION
Closes #596

## Summary

- `anchor-map.js` (1,089줄) → 5개 모듈로 분리, 각 ≤ 299줄
  - `anchor-map-shared.js` — 네임스페이스(`__MEMENTO_ANCHOR_MAP__`), 공유 상태, 유틸리티
  - `anchor-map-render.js` — D3 렌더링: `renderMap`을 `buildLinks/Nodes/Labels/Tooltips/runSimulation`으로 분해
  - `anchor-map-search.js` — 검색, 하이라이트, 결과 패널
  - `anchor-map-data.js` — API 데이터 로딩 (`loadMapData`, `loadAgentIdOptions`)
  - `anchor-map-ws.js` — WebSocket + 자동 새로고침
  - `anchor-map.js` — 초기화, 이벤트 와이어링, public API (코디네이터, 133줄)
- `dashboard-auth.js` `setAuthState` complexity **17 → 5**:
  - `updateFormVisibility`, `updateInputElements`, `updateStatusLabel` 분리
- `dashboard.html` 스크립트 로딩 순서 업데이트

## 완료 기준 체크

- [x] 모든 파일 ≤ 500줄 (최대 299줄)
- [x] ESLint `complexity` 규칙 기준 모든 함수 ≤ 15 (`setAuthState`: 17→5, 기타 모두 통과)
- [x] e2e anchor-map 회귀 없음 (1 passed)
- [ ] `review-candidates-panel-poll.js` (complexity 71) — 후속 이슈에서 처리 (#596 범위 외)

## Test plan

- [x] `npm run lint:js` — 0 errors
- [x] `npm run test:e2e:dashboard -- tests/e2e/dashboard/anchor-map.e2e.ts` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)