### PR TITLE
fix(기술부채): llm-client-initializer 테스트 TODO 10건 정리

### DIFF
--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts
@@ -27,6 +27,7 @@ describe('LLMClientInitializer', () => {
       // Given: process.env['LLM_PROVIDER']가 'openai'로 설정되고, mementoConfig.llmProvider는 'gemini'로 설정됨
       process.env.LLM_PROVIDER = 'openai';
       mockMementoConfig.llmProvider = 'gemini';
+      mockMementoConfig.openaiApiKey = 'test-openai-api-key';
       
       // getRawEnvValue 함수를 스파이로 모킹하여 호출 여부 확인
       const envModule = await import('../../../config/environment.js');
@@ -40,8 +41,7 @@ describe('LLMClientInitializer', () => {
       // Then: getRawEnvValue('LLM_PROVIDER')가 호출되어야 함
       // 현재 구현에서는 provider 선택 로직이 없으므로 이 검증은 실패할 것임 (RED 단계)
       expect(getRawEnvValueSpy).toHaveBeenCalledWith('LLM_PROVIDER');
-      // TODO: 실제 구현 후에는 선택된 provider가 'openai'인지 확인해야 함
-      // 예: expect(selectedProvider).toBe('openai');
+      expect(result.preferredProvider).toBe('openai');
       
       getRawEnvValueSpy.mockRestore();
     });
@@ -57,6 +57,7 @@ describe('LLMClientInitializer', () => {
       // Given: process.env['LLM_PROVIDER']가 설정되지 않고, mementoConfig.llmProvider는 'gemini'로 설정됨
       delete process.env.LLM_PROVIDER;
       mockMementoConfig.llmProvider = 'gemini';
+      mockMementoConfig.geminiApiKey = 'test-gemini-api-key';
       
       const initializer = new LLMClientInitializer();
 
@@ -66,8 +67,7 @@ describe('LLMClientInitializer', () => {
       // Then: mementoConfig.llmProvider 값이 사용되어야 함
       // 현재 구현에서는 provider 선택 로직이 없으므로 이 검증은 실패할 것임
       expect(process.env.LLM_PROVIDER).toBeUndefined();
-      // TODO: 실제 구현 후에는 선택된 provider가 'gemini'인지 확인해야 함
-      // 예: expect(selectedProvider).toBe('gemini');
+      expect(result.preferredProvider).toBe('gemini');
     });
 
     /**
@@ -81,6 +81,7 @@ describe('LLMClientInitializer', () => {
       // Given: process.env['LLM_PROVIDER']와 mementoConfig.llmProvider 모두 설정되지 않음
       delete process.env.LLM_PROVIDER;
       mockMementoConfig.llmProvider = 'auto';
+      mockMementoConfig.openaiApiKey = 'test-openai-api-key';
       
       const initializer = new LLMClientInitializer();
 
@@ -90,8 +91,7 @@ describe('LLMClientInitializer', () => {
       // Then: 기본값 'auto'가 사용되어야 함
       // 현재 구현에서는 provider 선택 로직이 없으므로 이 검증은 실패할 것임
       expect(process.env.LLM_PROVIDER).toBeUndefined();
-      // TODO: 실제 구현 후에는 선택된 provider가 'auto'인지 확인해야 함
-      // 예: expect(selectedProvider).toBe('auto');
+      expect(result.preferredProvider).toBe('openai');
     });
   });
 });

--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts
@@ -65,9 +65,8 @@ describe('LLMClientInitializer', () => {
       // Then: geminiClient는 null이고 경고가 추가되어야 함
       // 현재 구현에서는 Gemini 초기화 로직이 없으므로 이 검증은 실패할 것임 (RED 단계)
       expect(result.geminiClient).toBeNull();
-      expect(result.warnings.length).toBeGreaterThan(0);
-      // TODO: 실제 구현 후에는 경고 메시지 내용도 확인해야 함
-      // 예: expect(result.warnings.some(w => w.includes('GEMINI_API_KEY'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('GEMINI_API_KEY'))).toBe(true);
+      expect(loggerWarnSpy).toHaveBeenCalled();
       
       loggerWarnSpy.mockRestore();
     });
@@ -102,8 +101,11 @@ describe('LLMClientInitializer', () => {
       // Then: geminiClient는 null이고 경고가 추가되어야 함
       // 현재 구현에서는 Gemini 초기화 로직이 없으므로 이 검증은 실패할 것임 (RED 단계)
       expect(result.geminiClient).toBeNull();
-      expect(loggerWarnSpy).toHaveBeenCalled();
-      // TODO: 실제 구현 후에는 경고 메시지 내용도 확인해야 함
+      expect(result.warnings.some((w) => w.includes('Gemini 클라이언트 초기화 실패'))).toBe(true);
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'Gemini 클라이언트 초기화 중 오류가 발생했습니다.',
+        expect.objectContaining({ requestedProvider: expect.any(String) })
+      );
       
       vi.mocked(MockGoogleGenAI).mockRestore();
       loggerWarnSpy.mockRestore();

--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts
@@ -113,8 +113,7 @@ describe('LLMClientInitializer', () => {
         expect(result.openaiClient).toBeNull();
         expect(result.initializedProviders.length).toBe(0);
         expect(result.warnings.length).toBeGreaterThan(0);
-        // TODO: 실제 구현 후에는 모든 provider 실패 시 logger.error()가 호출되어야 함
-        // expect(loggerErrorSpy).toHaveBeenCalled();
+        expect(loggerErrorSpy).toHaveBeenCalled();
         
         loggerWarnSpy.mockRestore();
         loggerErrorSpy.mockRestore();

--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts
@@ -238,8 +238,7 @@ describe('LLMClientInitializer', () => {
         expect(result.openaiClient).toBeNull();
         expect(result.geminiClient).toBeNull();
         expect(result.warnings.length).toBeGreaterThan(0);
-        // TODO: 실제 구현 후에는 모든 provider 실패 시 logger.error()가 호출되어야 함
-        // expect(loggerErrorSpy).toHaveBeenCalled();
+        expect(loggerErrorSpy).toHaveBeenCalled();
         
         loggerWarnSpy.mockRestore();
         loggerErrorSpy.mockRestore();

--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts
@@ -113,8 +113,7 @@ describe('LLMClientInitializer', () => {
         expect(result.geminiClient).toBeNull();
         expect(result.initializedProviders.length).toBe(0);
         expect(result.warnings.length).toBeGreaterThan(0);
-        // TODO: 실제 구현 후에는 모든 provider 실패 시 logger.error()가 호출되어야 함
-        // expect(loggerErrorSpy).toHaveBeenCalled();
+        expect(loggerErrorSpy).toHaveBeenCalled();
         
         loggerWarnSpy.mockRestore();
         loggerErrorSpy.mockRestore();

--- a/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts
+++ b/packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts
@@ -65,9 +65,8 @@ describe('LLMClientInitializer', () => {
       // Then: openaiClient는 null이고 경고가 추가되어야 함
       // 현재 구현에서는 OpenAI 초기화 로직이 없으므로 이 검증은 실패할 것임 (RED 단계)
       expect(result.openaiClient).toBeNull();
-      expect(result.warnings.length).toBeGreaterThan(0);
-      // TODO: 실제 구현 후에는 경고 메시지 내용도 확인해야 함
-      // 예: expect(result.warnings[0]).toContain('OPENAI_API_KEY');
+      expect(result.warnings.some((w) => w.includes('OPENAI_API_KEY'))).toBe(true);
+      expect(loggerWarnSpy).toHaveBeenCalled();
       
       loggerWarnSpy.mockRestore();
     });
@@ -102,8 +101,11 @@ describe('LLMClientInitializer', () => {
       // Then: openaiClient는 null이고 경고가 추가되어야 함
       // 현재 구현에서는 OpenAI 초기화 로직이 없으므로 이 검증은 실패할 것임 (RED 단계)
       expect(result.openaiClient).toBeNull();
-      expect(loggerWarnSpy).toHaveBeenCalled();
-      // TODO: 실제 구현 후에는 경고 메시지 내용도 확인해야 함
+      expect(result.warnings.some((w) => w.includes('OpenAI 클라이언트 초기화 실패'))).toBe(true);
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'OpenAI 클라이언트 초기화 중 오류가 발생했습니다.',
+        expect.objectContaining({ requestedProvider: expect.any(String) })
+      );
       
       MockOpenAI.mockRestore();
       loggerWarnSpy.mockRestore();


### PR DESCRIPTION
## 기술 부채

Fixes #641

## 요약

llm-client-initializer 테스트 TODO 10건 정리

## 검증

- [x] `harness.sh fix-verify` 테스트 통과
- [ ] Simplify 게이트 (스킬 또는 harness-rules 체크리스트)

## 감사(audit)

- 이슈 #641
