### PR TITLE
docs(deprecated): @google/generative-ai 마이그레이션 완료 기록

### DIFF
--- a/docs/architecture/core-deprecated-inventory.md
+++ b/docs/architecture/core-deprecated-inventory.md
@@ -8,7 +8,11 @@ Issue #586 · 부모 [#580](https://github.com/jee1/memento/issues/580)
 | Symbol / location | Replacement | Notes |
 |-------------------|-------------|-------|
 | `type-param-validator` runtime warning `[LEGACY TYPE]` | Always pass MCP `type` param | [type-param-rollout.md](../guides/ko/type-param-rollout.md) — 제거 조건: `MEMENTO_TYPE_PARAM_MODE` 기본값이 `error`로 전환된 후 |
-| `@google/generative-ai` (llm-client-initializer note) | `@google/genai` migration | 아직 광범위 사용 중; 마이그레이션 미완료 |
+## Removed in #628
+
+| Item | Reason |
+|------|--------|
+| `@google/generative-ai` SDK (전체 런타임 경로) | `@google/genai`로 통일 완료; package.json·package-lock.json에서 제거; root quality gate가 재유입 방지 |
 
 ## Removed in #617
 


### PR DESCRIPTION
Closes #632

## Summary

- #628에서 `@google/generative-ai` → `@google/genai` 런타임 마이그레이션 완료됨
- `core-deprecated-inventory.md`의 해당 항목을 active 테이블에서 **Removed in #628** 섹션으로 이동
- root quality gate (`tests/root-quality-gates.spec.ts`)가 재유입 방지 검증 포함

## 완료 기준 검증

- [x] 프로덕션 경로 `@google/generative-ai` import 0건 (`grep` 확인)
- [x] root quality gate 5개 테스트 통과
- [x] `npm run lint` — 에러 0건
- [x] `npm run type-check` — 통과
- [x] `npm test` — 399 파일, 4613 테스트 통과 (1 skipped)
- [x] `core-deprecated-inventory.md` 갱신

## Test plan

- [ ] PR CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)