### PR TITLE
chore(ci): search-quality PR gate 및 nightly 테스트 (#665)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,29 @@ jobs:
           path: test-results/
           retention-days: 7
         continue-on-error: true
+
+  test-search-quality:
+    needs: [ lint-typecheck ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install SQLite (optional)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3 libsqlite3-dev build-essential
+      - run: npm ci
+      - name: Run vector search quality benchmark (CI)
+        run: npm run test:vector-search-quality:ci
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-results-search-quality
+          path: test-results/
+          retention-days: 7
+        continue-on-error: true

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,77 @@
+# Weekly: CI에서 스킵되는 무거운·통합 테스트 subset 복원 (SKIP_*=false)
+# PR gate(search-quality)는 ci.yml test-search-quality job 참고
+
+name: Nightly Tests
+
+on:
+  schedule:
+    # 매주 일요일 02:00 UTC (한국 11:00)
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+env:
+  CI: true
+  NODE_ENV: test
+  SKIP_DB_TESTS: false
+  SKIP_INTEGRATION_TESTS: false
+  DB_PATH: /tmp/memento-nightly-test.db
+
+jobs:
+  test-search-quality:
+    name: Vector search quality (full env)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install SQLite
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3 libsqlite3-dev build-essential
+      - run: npm ci
+      - name: Run vector search quality benchmark
+        run: npm run test:vector-search-quality:ci
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-search-quality-results
+          path: test-results/
+          retention-days: 14
+        continue-on-error: true
+
+  test-integration-subset:
+    name: Integration subset (vitest CI exclude 복원)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install SQLite
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3 libsqlite3-dev build-essential
+      - run: npm ci
+      - name: Build @memento/core
+        run: npm run build -w @memento/core
+      # vitest CI exclude 대상 중 핵심 integration·migration만 직접 실행 (전체 test:ci는 wall-clock 과다)
+      - name: Run integration subset
+        run: |
+          npx vitest --run \
+            packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts \
+            packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts \
+            packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.integration.spec.ts
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-integration-results
+          path: test-results/
+          retention-days: 14
+        continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- **CI search-quality PR gate** (#665): `.github/workflows/ci.yml`에 `test-search-quality` job 추가 — `npm run test:vector-search-quality:ci`로 랭킹·벡터 검색 benchmark 회귀를 PR에서 차단.
+- **Weekly nightly tests** (#665): `.github/workflows/nightly-tests.yml` — `SKIP_DB_TESTS=false`, `SKIP_INTEGRATION_TESTS=false`로 search-quality 전체 env 및 integration subset( migration-runner, lock-scenarios, memory-embedding ) 실행.
+- **CI exclude inventory** (#665): `docs/reference/ko/ci-test-timeout-guide.md`에 Vitest CI exclude 패턴 표·만료 정책(2026-09-01) 문서화.
+
 ### Removed
 
 - **[BREAKING] MCP `type` 파라미터 기본 필수화** (#636): `MEMENTO_TYPE_PARAM_MODE` 기본값이 `warn`에서 `error`로 변경됩니다. `remember` / `recall` 호출 시 `type`을 생략하면 거절됩니다. 레거시 클라이언트는 `MEMENTO_TYPE_PARAM_MODE=warn` 또는 `deprecate`로 완화할 수 있습니다.

--- a/docs/reference/ko/ci-test-timeout-guide.md
+++ b/docs/reference/ko/ci-test-timeout-guide.md
@@ -14,9 +14,10 @@ GitHub Actions에서 테스트가 오래 걸리거나 타임아웃으로 통과�
 
 - **현재**: 
   - **lint-typecheck**: lint + 콘솔/retry 검사 + type-check (한 job).
-  - **test-root**, **test-core**, **test-server**, **test-client**: 위 job 통과 후 **동시에** 4개 테스트 job 실행.
-  - 각 테스트 job은 **해당 영역만** 실행 (`test:ci:root`, `test:ci:core`, `test:ci:server`, `test:ci -w @memento/client`).
+  - **test-root**, **test-core**, **test-server**, **test-client**, **test-search-quality**: 위 job 통과 후 **동시에** 5개 테스트 job 실행.
+  - 각 테스트 job은 **해당 영역만** 실행 (`test:ci:root`, `test:ci:core`, `test:ci:server`, `test:ci -w @memento/client`, `test:vector-search-quality:ci`).
   - **중복 제거**: 루트 test:ci로 “전체”를 한 번에 돌리지 않고, 영역별로 나눠 한 번씩만 실행.
+  - **test-search-quality** (#665): 랭킹·벡터 검색 benchmark 회귀 감지. 랭킹 가중치 변경 PR에서 실패 시 merge 차단.
 
 - **효과**:  
   - 총 소요 시간 ≈ **lint-typecheck 시간 + max(test-root, test-core, test-server, test-client)**.  
@@ -36,8 +37,34 @@ GitHub Actions에서 테스트가 오래 걸리거나 타임아웃으로 통과�
 - test-root / test-core: 각 45분  
 - test-server: 20분  
 - test-client: 25분 (build 포함)  
+- test-search-quality: 45분 (`test:vector-search-quality:ci`, JUnit/JSON 리포트)
 
 필요 시 각 job의 `timeout-minutes`만 조정하면 됨.
+
+### 4. Vitest CI exclude inventory (`vitest.config.ts` L49–62)
+
+PR job(`test:ci:*`)은 `CI=true`일 때 아래 패턴을 **자동 제외**합니다.  
+**만료 정책**: 2026-09-01까지 분기별(또는 exclude 변경 시) 재검토. 만료 전에 PR gate 복원 또는 nightly subset 확대 여부를 결정합니다.
+
+| 패턴 | 제외 대상 | 사유 | 대체 job / 실행 경로 | 검토 만료 |
+|------|-----------|------|----------------------|-----------|
+| `**/test/**/*db*.{test,spec}.{js,ts}` | DB 직접 접근 테스트 | wall-clock·SQLite 의존 | `nightly-tests.yml` → `test-integration-subset` | 2026-09-01 |
+| `**/test/**/*database*.{test,spec}.{js,ts}` | database 명명 테스트 | 동일 | nightly integration subset | 2026-09-01 |
+| `**/test/**/*integration*.{test,spec}.{js,ts}` | 통합 테스트 | 느림·환경 의존 | nightly `test-integration-subset` (핵심 3건 직접 실행) | 2026-09-01 |
+| `**/test/**/*m1*.{test,spec}.{js,ts}` | M1 마일스톤 스위트 | 레거시·무거움 | nightly 확대 후보 (미포함) | 2026-09-01 |
+| `**/test/**/*performance*.{test,spec}.{js,ts}` | 성능 벤치마크 | 변동·시간 | 로컬 / 수동 benchmark | 2026-09-01 |
+| `**/test/**/*error-handling*.{test,spec}.{js,ts}` | 에러 핸들링 E2E | 긴 tail 시나리오 | nightly 확대 후보 | 2026-09-01 |
+| `packages/memento-core/src/domains/monitoring/services/quality-assurance/*.spec.ts` | QA 모니터링 스위트 | CI wall-clock | 로컬 `vitest` 직접 실행 | 2026-09-01 |
+| `**/migration-runner.integration.spec.ts` | 마이그레이션 통합 | DB·스키마 전체 | nightly `test-integration-subset` | 2026-09-01 |
+
+**환경 변수 스킵** (workflow `env`, PR 기본값):
+
+| 변수 | PR (`ci.yml`) | Weekly (`nightly-tests.yml`) |
+|------|---------------|------------------------------|
+| `SKIP_DB_TESTS` | `true` | `false` |
+| `SKIP_INTEGRATION_TESTS` | `true` | `false` |
+
+**검색 품질 benchmark**는 exclude 대상이 아니며, PR gate **`test-search-quality`** job에서 `npm run test:vector-search-quality:ci`로 항상 실행합니다 (#665).
 
 ---
 

--- a/specs/047-ci-search-quality-gate/plan.md
+++ b/specs/047-ci-search-quality-gate/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: Issue #665
+
+**Branch**: `issue-665-ci-search-quality`
+
+## Changes
+
+| File | Change |
+|------|--------|
+| `.github/workflows/ci.yml` | `test-search-quality` job 추가 (lint-typecheck needs, sqlite, `test:vector-search-quality:ci`, artifact) |
+| `.github/workflows/nightly-tests.yml` | 신규 — weekly cron `0 2 * * 0`, SKIP_*=false, search-quality + integration subset |
+| `docs/reference/ko/ci-test-timeout-guide.md` | exclude inventory 표, job 타임아웃, nightly 대체 경로 |
+| `CHANGELOG.md` | Unreleased Added (#665) |
+| `specs/047-ci-search-quality-gate/` | spec·plan·tasks |
+
+## ci.yml — test-search-quality
+
+- `needs: [ lint-typecheck ]` — 다른 test-* job과 병렬
+- `timeout-minutes: 45`
+- SQLite apt install (test-core와 동일)
+- `npm run test:vector-search-quality:ci` — JUnit/JSON → `test-results/`
+- failure artifact: `test-results-search-quality`
+
+## nightly-tests.yml
+
+- **schedule**: 일요일 02:00 UTC
+- **workflow_dispatch**: 수동 실행
+- **env**: `SKIP_DB_TESTS=false`, `SKIP_INTEGRATION_TESTS=false`
+- **Job 1** `test-search-quality`: PR gate와 동일 benchmark, skip flags off
+- **Job 2** `test-integration-subset`: vitest CI exclude 대상 중 3건 직접 실행
+  - `migration-runner.integration.spec.ts`
+  - `database-lock-scenarios.integration.spec.ts`
+  - `memory-embedding-service.integration.spec.ts`
+
+## Documentation
+
+- Vitest exclude 8행 inventory + env SKIP 표
+- 만료 정책: **2026-09-01** 분기별 재검토
+
+## Verification
+
+- YAML syntax: `python3 -c "import yaml; ..."`
+- TS 변경 없음 — lint/type-check 생략 가능
+- (선택) 로컬 `npm run test:vector-search-quality:ci` — CI와 동일 스크립트

--- a/specs/047-ci-search-quality-gate/spec.md
+++ b/specs/047-ci-search-quality-gate/spec.md
@@ -1,0 +1,56 @@
+# Feature Specification: CI Search Quality Gate
+
+**Feature Branch**: `issue-665-ci-search-quality`  
+**Created**: 2026-07-05  
+**Issue**: [#665](https://github.com/jee1/memento/issues/665) — chore(ci): 중요 테스트 스킵 해소 및 search-quality CI 게이트  
+**Parent epic**: [#661](https://github.com/jee1/memento/issues/661)
+
+## Problem
+
+PR CI는 `SKIP_DB_TESTS`, `SKIP_INTEGRATION_TESTS`, `vitest.config.ts` CI exclude(db/integration/performance/quality-assurance)로 무거운 테스트를 생략한다.  
+그러나 `npm run test:vector-search-quality:ci`(벡터·하이브리드 랭킹 benchmark)는 workflow에 포함되지 않아, 랭킹 가중치 변경 PR에서 검색 품질 회귀를 자동으로 잡지 못한다.
+
+## Goals
+
+1. PR gate: `test-search-quality` job에서 `test:vector-search-quality:ci` 실행
+2. Weekly workflow: `SKIP_*=false` 환경에서 search-quality + integration subset 복원
+3. exclude inventory를 `docs/reference/ko/ci-test-timeout-guide.md`에 명시하고 만료 정책(2026-09-01) 부여
+
+## User Scenarios
+
+### User Story 1 — 랭킹 가중치 PR 회귀 차단 (P1)
+
+개발자가 hybrid search 랭킹 가중치를 변경하면 CI benchmark가 실패하고 PR merge가 차단된다.
+
+**Acceptance**: `test-search-quality` job 실패 시 PR gate red.
+
+### User Story 2 — 스킵 테스트 가시성 (P2)
+
+운영·리뷰어가 CI에서 제외된 Vitest 패턴과 대체 실행 경로(nightly/로컬)를 문서에서 확인한다.
+
+**Acceptance**: ci-test-timeout-guide.md에 패턴·사유·대체 job·만료일 표.
+
+### User Story 3 — Weekly integration 복원 (P3)
+
+매주 integration subset이 `SKIP_*=false`로 실행되어 PR에서 스킵된 핵심 DB·migration 테스트가 회귀를 잡는다.
+
+**Acceptance**: `nightly-tests.yml` schedule + workflow_dispatch.
+
+## Requirements
+
+- **FR-001**: `.github/workflows/ci.yml` — `test-search-quality` job (`needs: lint-typecheck`, timeout 45m, sqlite deps, artifact upload).
+- **FR-002**: `.github/workflows/nightly-tests.yml` — weekly cron, `SKIP_DB_TESTS=false`, `SKIP_INTEGRATION_TESTS=false`.
+- **FR-003**: `docs/reference/ko/ci-test-timeout-guide.md` — Vitest CI exclude inventory + `test-search-quality` job 설명.
+- **FR-004**: `CHANGELOG.md` Unreleased 항목.
+
+## Out of Scope
+
+- vitest CI exclude 전면 제거 (wall-clock)
+- benchmark fixture v3 corpus 확장 (별도 이슈)
+- relation-engine 품질 리포트 CI 복원
+
+## Success Criteria (Issue #665 Acceptance)
+
+- [x] `.github/workflows/ci.yml`에 search-quality job
+- [x] 스킵 테스트 inventory 표 (파일·대체 job)
+- [x] 랭킹 가중치 변경 PR에서 benchmark 회귀 감지 (`test-search-quality`)

--- a/specs/047-ci-search-quality-gate/tasks.md
+++ b/specs/047-ci-search-quality-gate/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Issue #665
+
+- [x] spec.md / plan.md / tasks.md 작성 (`specs/047-ci-search-quality-gate/`)
+- [x] `.github/workflows/ci.yml` — `test-search-quality` job 추가
+- [x] `.github/workflows/nightly-tests.yml` — weekly + SKIP_*=false + integration subset
+- [x] `docs/reference/ko/ci-test-timeout-guide.md` — exclude inventory 표 + 만료 정책
+- [x] `CHANGELOG.md` Unreleased Added (#665)
+- [x] YAML 유효성 검증
+- [x] 커밋 (push 제외)


### PR DESCRIPTION
## Summary

Epic #661 Phase 0 — 랭킹 가중치 변경 시 benchmark-v3 회귀를 PR에서 잡기 위해 CI 게이트를 추가합니다.

- `.github/workflows/ci.yml`에 `test-search-quality` job 추가 (`npm run test:vector-search-quality:ci`)
- `.github/workflows/nightly-tests.yml` 신규 — 주간 integration/search-quality 확장 실행
- `docs/reference/ko/ci-test-timeout-guide.md` — Vitest CI exclude inventory 표 + 만료 정책 (2026-09-01)
- Spec Kit: `specs/047-ci-search-quality-gate/`

Closes #665

## Test plan

- [ ] CI `test-search-quality` job green
- [ ] `npm run test:vector-search-quality:ci` 로컬 실행 (선택)
- [ ] nightly workflow YAML 검증


Made with [Cursor](https://cursor.com)