### PR TITLE
feat(security): HTTP scoped API tokens 및 tools/admin RBAC (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **HTTP scoped API tokens (#662)**: `MEMENTO_API_TOKENS` JSON env로 `tools:invoke` / `admin:destructive` 스코프 분리. Legacy `ADMIN_API_KEY`는 synthetic `legacy-admin` 토큰으로 양쪽 스코프 유지(deprecation warn once). tools-only 토큰은 `/api/v1/quality/*` 403.
+
 ### Removed
 
 - **[BREAKING] MCP `type` 파라미터 기본 필수화** (#636): `MEMENTO_TYPE_PARAM_MODE` 기본값이 `warn`에서 `error`로 변경됩니다. `remember` / `recall` 호출 시 `type`을 생략하면 거절됩니다. 레거시 클라이언트는 `MEMENTO_TYPE_PARAM_MODE=warn` 또는 `deprecate`로 완화할 수 있습니다.

--- a/docs/integrations/_shared/auth.md
+++ b/docs/integrations/_shared/auth.md
@@ -2,169 +2,89 @@
 
 이 문서는 **HTTP 트랙** 사용자를 대상으로 합니다. stdio 트랙은 비서가 Memento를 자식 프로세스로 spawn하므로 인증이 필요 없습니다 ([`./transports.md`](./transports.md) 참조).
 
-Memento HTTP 서버의 핵심 사실 한 가지를 먼저 짚고 시작합니다.
+Memento HTTP 서버의 핵심 사실:
 
-> **현재 구현은 단일 공유 비밀(`ADMIN_API_KEY`) 모델입니다.** 사용자별·비서별로 다른 토큰을 발급하는 메커니즘은 아직 없습니다. 이 비밀 하나가 `Authorization: Bearer …`와 `X-API-Key: …` 양쪽 헤더로 동일하게 받아들여지며, 모든 비서가 같은 값을 공유합니다. 자세한 신뢰 모델은 [`../../reference/ko/security.md`](../../reference/ko/security.md)를 참조하세요.
+> **Programmatic HTTP는 스코프드 API 토큰(`MEMENTO_API_TOKENS`)을 사용합니다.** 최소 스코프는 `tools:invoke`(도구/MCP/agent API)와 `admin:destructive`(quality API)입니다. Legacy `ADMIN_API_KEY`만 설정된 경우 synthetic `legacy-admin` 토큰으로 양쪽 스코프가 부여되며 deprecation 경고가 기록됩니다. 자세한 신뢰 모델은 [`../../reference/ko/security.md`](../../reference/ko/security.md)를 참조하세요.
 
-이 문서는 그 단일 비밀을 **어떻게 만들고, 어디에 저장하고, 언제 갈아끼울지**에 대한 가이드입니다.
+이 문서는 토큰을 **어떻게 만들고, 어디에 저장하고, 언제 갈아끼울지**에 대한 가이드입니다.
 
 ---
 
 ## Bearer 토큰 vs X-API-Key
 
-코드 상 두 헤더는 **동일한 비밀(`ADMIN_API_KEY`)을 받는 별칭**입니다. 다른 권한·다른 토큰이 아니라, 클라이언트가 어느 헤더로 보내느냐의 차이일 뿐입니다.
+코드 상 두 헤더는 **동일한 secret**을 받는 별칭입니다.
 
-| 항목 | `Authorization: Bearer <key>` | `X-API-Key: <key>` |
+| 항목 | `Authorization: Bearer <secret>` | `X-API-Key: <secret>` |
 |---|---|---|
-| 받는 비밀 | `ADMIN_API_KEY` | `ADMIN_API_KEY` (동일 값) |
-| 적용 라우트 | `/mcp`, `/messages`, `/tools/*`, `/api/v1/quality/*` | 동일 |
-| MCP 비서 통합 | **권장** (대부분 MCP HTTP 클라이언트의 표준) | 가능하지만 비표준 |
-| `curl`/스크립트 | 가능 | 가능 |
-| 브라우저 대시보드 | 사용하지 않음 (`/auth/session`로 쿠키 발급) | 사용하지 않음 |
+| 적용 라우트 | 스코프에 따라 `/tools`, `/mcp`, `/api/v1/agent`, `/api/v1/quality` | 동일 |
+| MCP 비서 통합 | **권장** | 가능 (비표준) |
+| 브라우저 대시보드 | `/auth/session` (legacy `ADMIN_API_KEY` 또는 admin secret) | 동일 |
 
-**권장**: 비서 등록은 `Authorization: Bearer`를 사용하세요. `transports.md`의 등록 스니펫과 일치하고, 대부분의 MCP HTTP 구현이 `headers.Authorization` 키로 토큰을 주입합니다. `X-API-Key`는 임시 디버깅이나 사용자 정의 스크립트에서 편할 때만 쓰세요.
+**권장**: 비서 등록은 `Authorization: Bearer` + **`tools:invoke` 전용 secret**을 사용하세요.
 
 ---
 
 ## 토큰 발급
 
-### 현재 구현의 한계
-
-- Admin UI에 **"토큰 발급" 페이지는 존재하지 않습니다**. `/admin` 대시보드는 telemetry·graph·relations 조회용이며, 토큰 목록 화면이 없습니다.
-- 토큰 발급/관리 **CLI 서브커맨드는 없습니다**. `memento` CLI는 `recall|remember|forget|memory_injection`만 지원하고, `memento-setup` 스크립트도 `ADMIN_API_KEY`를 다루지 않습니다.
-- 토큰은 SQLite에 저장되지 않습니다. 환경변수 한 슬롯에서 직접 읽습니다.
-
-따라서 "발급"은 **운영자가 임의의 강력한 랜덤 문자열을 만들고, 서버 환경변수에 넣는 것**을 의미합니다.
-
-### 발급 절차
+### `MEMENTO_API_TOKENS` (권장)
 
 ```bash
-# 1) 32바이트(=64 hex 문자) 랜덤 비밀 생성
+# 예: 도구 전용 + ops admin
+export MEMENTO_API_TOKENS='[
+  {"id":"agent-1","secret":"'"$(openssl rand -hex 32)"'","scopes":["tools:invoke"]},
+  {"id":"ops-1","secret":"'"$(openssl rand -hex 32)"'","scopes":["admin:destructive","tools:invoke"]}
+]'
+```
+
+Docker `.env` 또는 compose `environment:`에 JSON 한 줄로 넣고 컨테이너를 재시작합니다.
+
+### Legacy `ADMIN_API_KEY`
+
+`MEMENTO_API_TOKENS`가 없을 때만 사용합니다. 단일 secret이 **모든 programmatic 표면**에 접근합니다(양쪽 스코프). 신규 배포는 스코프드 토큰으로 이전하세요.
+
+```bash
 openssl rand -hex 32
-# 예시 출력: 7c2b9e1a... (실제로는 64자)
+# ADMIN_API_KEY=<값>
 ```
 
-다른 옵션도 동등합니다.
+Admin UI·CLI에 토큰 발급 화면/명령은 없습니다. secret은 환경변수에서만 읽습니다.
+
+---
+
+## 검증
 
 ```bash
-# Node.js
-node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# tools 스코프 — /tools OK
+curl -i -H "Authorization: Bearer $TOOLS_SECRET" http://localhost:9001/tools
 
-# Python
-python3 -c "import secrets; print(secrets.token_hex(32))"
-```
+# tools 스코프 — quality 403
+curl -i -H "Authorization: Bearer $TOOLS_SECRET" http://localhost:9001/api/v1/quality/metrics
 
-**최소 길이 권장**: 32바이트(256비트). 추측 공격에 충분히 안전한 엔트로피.
-
-### 서버에 적용
-
-#### Docker compose (권장)
-
-`docker-compose.prod.yml`이 읽는 `.env` 파일(또는 `docker-compose.override.yml`의 `environment:`)에 추가:
-
-```bash
-ADMIN_API_KEY=7c2b9e1a...  # openssl로 생성한 값
-```
-
-그리고 컨테이너를 재시작합니다.
-
-```bash
-docker compose -f docker-compose.prod.yml up -d
-```
-
-#### 베어메탈/직접 실행
-
-서버 프로세스의 환경에 `ADMIN_API_KEY=…`를 export한 뒤 `npm run start:http`로 띄웁니다. systemd unit이라면 `Environment=` 또는 `EnvironmentFile=` 지시자를 사용하세요.
-
-### 발급 검증
-
-```bash
-curl -i -H "Authorization: Bearer 7c2b9e1a..." http://localhost:9001/health
-```
-
-`200 OK`가 나오면 서버가 살아 있습니다. (`/health`는 인증을 요구하지 않으므로 더 정확한 검증은 `/mcp` 또는 `/api/v1/quality/*`로 하세요.)
-
-```bash
-# 잘못된 토큰
-curl -i -H "Authorization: Bearer wrong" http://localhost:9001/api/v1/quality/snapshot
-# → 401 Unauthorized
+# admin 스코프 — quality OK
+curl -i -H "Authorization: Bearer $ADMIN_SECRET" http://localhost:9001/api/v1/quality/metrics
 ```
 
 ---
 
-## 비서별 secret 저장 위치
+## 회전·폐기
 
-토큰은 **서버에 한 번**, **각 비서 설정에 한 번씩** 들어갑니다. 비서 측 저장은 가능한 한 평문 파일을 피하고 비밀 저장소를 쓰세요. 정확한 경로·키 이름은 비서별 가이드에서 다루며, 여기서는 위치만 정리합니다.
-
-| 비서 | 권장 저장 위치 | 비고 |
-|---|---|---|
-| **OpenClaw** | OS 환경변수 (`MEMENTO_TOKEN`) 또는 OS keychain | 데스크톱 클라이언트. 평문 config에 직접 넣지 마세요. |
-| **NanoClaw** | 컨테이너에 마운트되는 `.env.local` | git ignore 필수. 컨테이너 secret 매니저(예: Docker secrets)도 가능. |
-| **ZeroClaw** | OS keychain (macOS Keychain / Windows Credential Manager / libsecret) 또는 HashiCorp Vault | 무인 24/7 봇이므로 disk persistence 필요 시 Vault 권장. |
-| 임의 MCP 클라이언트 | 환경변수 → `${MEMENTO_TOKEN}` 형태로 config에서 참조 | config JSON에 토큰을 하드코딩하지 마세요. |
-
-`transports.md`의 등록 스니펫이 `${MEMENTO_TOKEN}`을 참조하는 형태인 이유가 이것입니다. 비서 config 파일을 git에 올리거나 백업하더라도 비밀이 새지 않게 하세요.
-
----
-
-## 회전
-
-`ADMIN_API_KEY`는 **단일 슬롯**이므로 "이전 키와 새 키가 동시에 유효한 회전"은 지원하지 않습니다. 회전 동안 **모든 비서를 새 키로 같이 갈아야** 인증 단절이 없습니다.
-
-권장 절차:
-
-1. 회전 시간을 정합니다(비서 수가 많으면 짧은 점검창을 알리세요).
-2. 새 비밀을 생성합니다.
-   ```bash
-   NEW_KEY=$(openssl rand -hex 32)
-   echo "$NEW_KEY"
-   ```
-3. 서버 환경(`.env` 또는 compose env)의 `ADMIN_API_KEY`를 새 값으로 교체합니다.
-4. 서버를 재시작합니다.
-   ```bash
-   docker compose -f docker-compose.prod.yml up -d
-   ```
-   재시작 직후 기존 토큰을 가진 비서들은 401을 받기 시작합니다.
-5. 각 비서의 secret store(위 표 참조)에서 토큰을 새 값으로 갱신하고 비서를 재시작·재로드합니다.
-6. 검증: 비서가 한 차례 `recall` 또는 `remember`를 호출해 200을 받는지 확인합니다.
-
-> **팁**: 비서 수가 늘면 회전 비용이 선형으로 커집니다. 다중 토큰 모델은 향후 작업 항목입니다 (현재 미구현).
-
----
-
-## 폐기
-
-단일 슬롯 모델이므로 폐기 = 회전과 같은 동작입니다.
-
-- **하나의 비서만 폐기하고 싶을 때**: 현재 모델로는 **불가능**합니다. 모든 비서가 같은 비밀을 공유하므로, 한 비서를 차단하려면 회전을 돌리고 *그 비서를 빼고 다시 배포*해야 합니다.
-- **전체 폐기**: 서버의 `ADMIN_API_KEY`를 비우거나(`ADMIN_API_KEY=`) 새 값으로 교체한 뒤 재시작합니다. 빈 값으로 두면 programmatic 라우트는 모든 요청에 `401 Unauthorized: Programmatic API is disabled: ADMIN_API_KEY is not configured.` 응답을 줍니다.
-- **API를 통한 폐기 엔드포인트는 없습니다**. 환경변수 + 재시작이 유일한 메커니즘입니다.
-
-폐기가 필요한 흔한 시나리오는 비서 호스트(노트북·VPS) 분실입니다. 이 경우 즉시 회전을 돌리고 분실한 디바이스 외 모든 비서에 새 키를 배포하세요.
+- **스코프드 토큰**: `MEMENTO_API_TOKENS` JSON에서 해당 `id` 항목을 교체/삭제 후 재시작. 여러 키를 동시에 둘 수 있어 **한 비서만** 갈아끼우기 쉽습니다.
+- **Legacy 단일 키**: 이전과 같이 `ADMIN_API_KEY` 교체 + 모든 클라이언트 동시 갱신.
+- **API 폐기 엔드포인트 없음** — 환경변수 + 재시작만 지원.
 
 ---
 
 ## TLS 검증
 
-### 운영 (외부 노출)
+(이하 동일 — [`../../reference/ko/security.md`](../../reference/ko/security.md) 및 transports 문서 참조)
 
-집 밖에서 비서가 접속한다면 TLS는 필수입니다. compose 파일 안의 nginx에 Let's Encrypt 인증서를 마운트하거나, Caddy/Cloudflare Tunnel을 reverse proxy로 두세요. 이 경우 비서의 base URL은 `https://memory.example.com/mcp`가 되며, 비서는 시스템 신뢰 저장소로 인증서를 검증합니다. 추가 설정 없이 동작합니다.
-
-### 개발 (로컬·자체 서명)
-
-루프백/내부망에서만 접속한다면 일반적으로 평문 HTTP로 충분합니다 ([`../../reference/ko/security.md`](../../reference/ko/security.md)는 `MEMENTO_HTTP_BIND_HOST`를 루프백으로 유지하라고 권합니다).
-
-자체 서명 인증서를 쓰는 경우:
-
-- 인증서를 OS 신뢰 저장소에 추가하는 것이 **항상 우선** 옵션입니다. 비서 측에서 검증을 끄지 마세요.
-- 부득이 검증을 끄는 경우, 끄는 위치는 **비서 클라이언트 한 군데**여야 하며, **로컬 개발 한정**으로 옵트인하세요. Memento 서버 자체는 검증 비활성 모드를 별도로 노출하지 않습니다.
-- 운영 환경에 `NODE_TLS_REJECT_UNAUTHORIZED=0` 같은 전역 비활성화 플래그를 두지 마세요. 토큰이 평문으로 새어 나갈 위험을 만듭니다.
+운영 외부 노출 시 TLS 필수. 로컬 루프백은 평문 HTTP로 충분합니다.
 
 ---
 
 ## 다음 단계
 
-- [`./transports.md`](./transports.md) — HTTP 서버 셋업·엔드포인트·트랙 마이그레이션
-- [`./troubleshooting.md`](./troubleshooting.md) — 401, 토큰 누락, 헤더 잘림 등 트러블슈팅
-- [`../README.md`](../README.md) — 비서별 통합 가이드 허브 (OpenClaw / NanoClaw / ZeroClaw)
-- [`../../reference/ko/security.md`](../../reference/ko/security.md) — HTTP 신뢰 모델·CORS·바인드 호스트 권장
+- [`./transports.md`](./transports.md)
+- [`./troubleshooting.md`](./troubleshooting.md)
+- [`../../reference/ko/security.md`](../../reference/ko/security.md)
+

--- a/docs/reference/ko/security.md
+++ b/docs/reference/ko/security.md
@@ -2,8 +2,21 @@
 
 ## HTTP API 인증·인가
 
-- **현재 상태**: HTTP 서버는 **분리된 신뢰 모델**을 사용합니다. `/auth/session`은 쿠키 기반 브라우저 세션을 시작합니다. `/admin/*`, `/api/*`는 해당 브라우저 세션이 필요합니다. `/api/v1/quality/*`, `/tools/*`, `/mcp`, `/messages`는 `Authorization: Bearer <ADMIN_API_KEY>` 또는 `X-API-Key: <ADMIN_API_KEY>`가 필요합니다.
+- **현재 상태**: HTTP 서버는 **분리된 신뢰 모델**을 사용합니다.
+  - `/auth/session` — 쿠키 기반 브라우저 세션 시작
+  - `/admin/*`, `/api/*` — **브라우저 세션이 필요합니다**
+  - `/tools/*`, `/mcp`, `/messages`, `/api/v1/agent` — **`tools:invoke` 스코프** 토큰 (`Authorization: Bearer` 또는 `X-API-Key`)
+  - `/api/v1/quality/*` — **`admin:destructive` 스코프** 토큰 (programmatic quality API)
+- **스코프드 토큰 (`MEMENTO_API_TOKENS`)**: JSON 배열로 여러 키를 설정합니다. 예:
+  ```json
+  [
+    { "id": "agent-tools", "secret": "<hex>", "scopes": ["tools:invoke"] },
+    { "id": "ops-admin", "secret": "<hex>", "scopes": ["admin:destructive", "tools:invoke"] }
+  ]
+  ```
+  `tools:invoke`만 있는 토큰은 quality API에 **403 Forbidden** 됩니다.
+- **Legacy `ADMIN_API_KEY`**: `MEMENTO_API_TOKENS`가 없을 때만 synthetic `legacy-admin` 토큰(양쪽 스코프)으로 동작하며, 기동 시 deprecation 경고가 1회 기록됩니다. 신규 배포는 `MEMENTO_API_TOKENS`로 이전하세요.
 - **권장 사용**: 특별한 이유가 없다면 HTTP 서버는 **루프백 또는 내부망**에만 두세요. 브라우저 대시보드/그래프는 서버와 동일 출처에서 열어 세션 쿠키가 다른 오리진으로 퍼지지 않게 유지하세요.
-- **운영 환경**: `ADMIN_API_KEY`를 설정하고, 의도적으로 노출하는 경우가 아니면 `MEMENTO_HTTP_BIND_HOST`를 루프백으로 유지하세요. `/api/v1/quality`, `/tools/*`, `/mcp`, `/messages`는 키 기반 프로그램용 표면이며, `/admin/*`, `/api/*`는 브라우저 세션 전용입니다.
-- **브라우저 비밀 처리**: 서버는 브라우저 자산에 `ADMIN_API_KEY`를 전달하지 않습니다. 운영자는 `/auth/session`으로 로그인하고, 서버는 입력된 키를 HTTP-only 세션 쿠키로 교환합니다. `/dashboard`가 권장 진입점이며, `/graph`를 직접 열어도 같은 세션 모델로 로그인/재인증할 수 있습니다. 브라우저 세션이 생긴 뒤에만 그래프 화면이 열립니다. 두 정적 페이지 모두 키를 JavaScript로 부트스트랩하지 않습니다.
+- **운영 환경**: programmatic 접근에는 스코프드 토큰을 사용하고, 의도적으로 노출하는 경우가 아니면 `MEMENTO_HTTP_BIND_HOST`를 루프백으로 유지하세요.
+- **브라우저 비밀 처리**: 서버는 브라우저 자산에 API secret을 전달하지 않습니다. 운영자는 `/auth/session`으로 로그인하고(legacy `ADMIN_API_KEY` 또는 admin 스코프 secret), 서버는 HTTP-only 세션 쿠키로 교환합니다. **`/dashboard`가 권장 진입점**이며, **`/graph`를 직접 열어도 같은 세션 모델로 로그인/재인증**할 수 있습니다. **브라우저 세션이 생긴 뒤에만 그래프 화면이 열립니다.** 두 정적 페이지 모두 secret을 JavaScript로 부트스트랩하지 않습니다.
 - **CORS**: `CORS_ALLOWED_ORIGINS` 환경 변수로 허용 오리진을 제한할 수 있습니다. 비어 있으면 크로스 오리진 요청을 허용하지 않습니다.

--- a/env.example
+++ b/env.example
@@ -14,7 +14,8 @@ LOG_FILE=
 # CORS 허용 오리진 (쉼표 구분, 비어 있으면 크로스 오리진 미허용). MCP SSE 수동 CORS 헤더도 동일 목록 사용.
 # CORS_ALLOWED_ORIGINS=http://localhost:3000,https://app.example.com
 # Admin/API/Quality 라우트 인증 (설정 시 /admin, /api, /api/v1/quality에 Authorization: Bearer <key> 또는 X-API-Key: <key> 필요)
-# ADMIN_API_KEY=  # [REQUIRED in production] 비어 있으면 admin/API/quality 엔드포인트는 fail-closed(401)
+# ADMIN_API_KEY=  # [REQUIRED in production] Legacy 단일 키 — MEMENTO_API_TOKENS 미설정 시 synthetic legacy-admin(양쪽 스코프). 신규는 아래 JSON 권장.
+# MEMENTO_API_TOKENS=[{"id":"agent-tools","secret":"<hex>","scopes":["tools:invoke"]},{"id":"ops-admin","secret":"<hex>","scopes":["admin:destructive","tools:invoke"]}]
 # HTTP 리슨 주소 (미설정 시 기본 127.0.0.1 — 로컬 개발·ADMIN 미설정과 호환). 모든 인터페이스에 노출하려면 예: 0.0.0.0 + ADMIN_API_KEY
 # MEMENTO_HTTP_BIND_HOST=0.0.0.0
 # (개발 전용) 루프백이 아닌 바인딩에서도 API 키 없이 기동 — 무인증 노출 위험, 프로덕션/공용망 사용 금지

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-07-04)
+# Graph Report - .  (2026-07-05)
 
 ## Corpus Check
-- 1327 files · ~1,529,404 words
+- 1327 files · ~1,529,144 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6202 nodes · 7234 edges · 1319 communities detected
+- 6206 nodes · 7240 edges · 1319 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2241,168 +2241,168 @@ Cohesion: 0.36
 Nodes (4): deleteServerInfo(), readServerInfo(), serverInfoPath(), writeServerInfo()
 
 ### Community 221 - "Community 221"
+Cohesion: 0.32
+Nodes (3): readApiKeyHeader(), readBearerToken(), resolveAuthenticatedToken()
+
+### Community 222 - "Community 222"
 Cohesion: 0.29
 Nodes (2): handleCaptureSessionEvent(), maybePreCompactInjection()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.43
 Nodes (6): buildRecentEvents(), handleGetOperationsStatus(), queryInjectionCounts(), queryInjectionRows(), queryObservationCounts(), queryObservationRows()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.25
 Nodes (0): 
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.39
 Nodes (5): handleGetProvenanceDetail(), loadProvenanceMemories(), loadProvenanceObservations(), loadProvenanceSessions(), resolveProvenanceFilter()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.43
 Nodes (7): applyMcpCorsHeaders(), handleMcpSseConnection(), handleSseMessagePost(), handleStreamableMcpPost(), registerSseCleanup(), sendMcpCorsPreflight(), writeSseJson()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.43
 Nodes (7): agentInjectionIntegrationFixture(), claudeCodeInjectionFixture(), codexInjectionFixture(), injectionBundleFixture(), isNonNegativeInteger(), isRecord(), validateInjectionBundle()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.39
 Nodes (1): ProcessAttributeTableMigration
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.39
 Nodes (1): AddProjectIdMigration
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.46
 Nodes (1): MemoryReviewCandidateSchemaMigration
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.39
 Nodes (1): TelemetryEventsEventTypeCreatedAtIndexMigration
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.39
 Nodes (1): FixTfidfDimensionTriggerMigration
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.43
 Nodes (1): FeedbackEventScoreBreakdownMigration
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.43
 Nodes (1): FeedbackEventCommentMigration
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.43
 Nodes (1): ProceduralVersionFieldsMigration
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.39
 Nodes (1): FeedbackEventMemoryCreatedAtIndexMigration
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.46
 Nodes (1): ReviewQueueHealthSnapshotMigration
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.32
 Nodes (1): BatchJobExecutionCoordinator
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.29
 Nodes (2): escapeDotString(), RelationVisualizer
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.46
 Nodes (6): getObjectSize(), limitArraySize(), mergeReflectionNotes(), normalizeNewReflectionNotes(), validateAndCleanupTotalSize(), validateSingleObjectSize()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.5
 Nodes (2): isPIIMaskingEnabled(), PIIMasker
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.25
 Nodes (0): 
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.25
 Nodes (1): LocalSearchService
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.32
 Nodes (1): ProceduralMemoryMatcher
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.32
 Nodes (1): VectorPerformanceRepositoryImpl
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.43
 Nodes (6): getDominantStoredDimensions(), getExpectedDimensions(), getTableName(), getVecTableSchemaDimensions(), resolveRuntimeVectorContext(), shouldUseDominantStoredDimensionsForTable()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.46
 Nodes (7): applyVersionFilter(), collectMetaMemoryStats(), enrichProceduralVersionInfo(), filterLatestOnly(), filterSpecificVersion(), runMemoryItemPostSearchPipeline(), updateConsolidationScoreMetadata()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.29
 Nodes (2): MemoryNeighborService, MemoryNotFoundError
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.29
 Nodes (1): SemanticMemoryUpdatePipeline
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.36
 Nodes (1): SemanticMemoryRelations
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.36
 Nodes (1): RelationExtractor
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.39
 Nodes (1): RelationGraphCache
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.32
 Nodes (1): TripleExtractionStatisticsService
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.36
 Nodes (3): deterministicHash(), generateMockEmbedding(), MockEmbeddingService
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.29
 Nodes (1): AlertNotificationService
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.32
 Nodes (1): QualityRecorder
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.39
 Nodes (1): QualityReporter
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.39
 Nodes (1): MultiProviderSearchBenchmark
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.39
 Nodes (4): expectExactScript(), normalizeCommand(), readScript(), splitSequentialCommands()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.39
 Nodes (5): checkCode(), checkDocumentation(), checkGitHistory(), checkLegacyScriptUsage(), checkPackageJson()
 
-### Community 260 - "Community 260"
-Cohesion: 0.46
-Nodes (7): assertRankingProfileFilesExist(), calcP95(), evaluateProfile(), main(), mean(), pairedPermutationPValue(), parseArgs()
-
 ### Community 261 - "Community 261"
 Cohesion: 0.46
-Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateMarkdownReport(), loadTestDataset(), main(), parseArgs()
+Nodes (7): assertRankingProfileFilesExist(), calcP95(), evaluateProfile(), main(), mean(), pairedPermutationPValue(), parseArgs()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.46
@@ -2410,247 +2410,247 @@ Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateM
 
 ### Community 263 - "Community 263"
 Cohesion: 0.46
-Nodes (7): checkAllFiles(), checkRetryUsage(), getAllTsFiles(), main(), printResultsCSV(), printResultsJSON(), printResultsText()
+Nodes (7): createBaseSchema(), createTestMemory(), extractRelations(), generateMarkdownReport(), loadTestDataset(), main(), parseArgs()
 
 ### Community 264 - "Community 264"
+Cohesion: 0.46
+Nodes (7): checkAllFiles(), checkRetryUsage(), getAllTsFiles(), main(), printResultsCSV(), printResultsJSON(), printResultsText()
+
+### Community 265 - "Community 265"
 Cohesion: 0.36
 Nodes (1): GitHubIssueClient
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.39
 Nodes (5): fallbackToPolling(), resubscribeWebSocket(), startAutoRefresh(), stopAutoRefresh(), tryConnectWebSocket()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.29
 Nodes (2): collectMatchingIds(), getSearchHaystack()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.29
 Nodes (1): RetryQueue
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.52
 Nodes (6): buildReviewQueueBootInjectionHtml(), clampIntervalMs(), injectReviewQueueBootIntoDashboardHtml(), parseBackoffCsv(), parsePositiveIntMs(), resolveReviewQueueDashboardBootFromEnv()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.43
 Nodes (4): jsonSafeDetails(), recordManualBatchRunFailure(), recordManualBatchRunSuccess(), trimEntries()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.48
 Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkLinks(), buildNetworkNodesAndLinks()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.38
 Nodes (3): optionalOwnerId(), optionalString(), optionalStringArray()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.33
 Nodes (2): exportObservationDto(), observationDto()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.48
 Nodes (6): createRequest(), defaultResolveEndpoint(), normalizeEndpoint(), parseOptions(), parsePositiveInteger(), runAgentOpsCommand()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (2): countSearchMapMatches(), getSearchItemId()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.52
 Nodes (6): increment(), metadata(), redactAgentEvent(), redactString(), redactValue(), scanBlocked()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.33
 Nodes (2): eventPriority(), PriorityEventQueue
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.48
 Nodes (5): addMissingColumn(), ensureLegacyEmbeddingModelRegistryProjectionType(), ensureLegacyMemoryEmbeddingColumns(), ensureLegacySchema(), reconcileMisalignedVecTables()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.43
 Nodes (1): MigrationDetector
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.43
 Nodes (2): AgentIntegrationSchemaMigration, objectExists()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.43
 Nodes (1): BackfillKgTripleFromMemoryItemMigration
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.43
 Nodes (2): AgentMemoryPromotionSchemaMigration, objectExists()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.38
 Nodes (3): parseJsonArray(), ProcessAttributeRepositorySqlite, stringifyJsonArray()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.29
 Nodes (1): AgentIntegrationProvenanceStore
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.43
 Nodes (4): isExcludedField(), isKeyTokenField(), normalizeReflectionNoteObject(), normalizeReflectionNotes()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.48
 Nodes (6): computeJsonHash(), computeReflectionNotesCount(), createProceduralMemorySnapshot(), hasProceduralMemoryChanged(), isEqual(), normalizeJson()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.43
 Nodes (5): isValidMemoryType(), validateProceduralMemoryFields(), validateTriggerConditions(), validateTypeParam(), validateWorkflowOrSkillName()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.48
 Nodes (5): containsPathTraversal(), getAllowedDirs(), isAbsolutePath(), isWithinAllowedDirs(), validateFilePath()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.38
 Nodes (1): PromptTemplateLoader
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.29
 Nodes (1): QueryFilterService
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.29
 Nodes (1): SearchLogger
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.38
 Nodes (1): VectorPerformanceTester
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (1): VectorIndexManager
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.43
 Nodes (3): FeedbackTool, findApprovedPromotionCandidate(), normalizeFeedbackCreatedAtToIso()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.38
 Nodes (1): SemanticMemoryStatisticsService
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.29
 Nodes (1): SemanticMemoryScoring
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.48
 Nodes (1): ClusteringService
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.43
 Nodes (4): ExtractTriplesTool, normalizeChunkOverlapForPipeline(), resolveExtractTriplesOwner(), toChatMessageInputs()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.29
 Nodes (3): CyclicRelationError, DuplicateRelationError, RelationGraphError
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (2): createMockEmbeddingService(), getMockEmbeddingFunctions()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.48
 Nodes (4): checkOllamaModelInstalled(), extractRawWithOllama(), getStringField(), isRecord()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.38
 Nodes (3): buildTripleLlmProviderAttemptOrder(), invokeTripleProviderRawOutput(), invokeTripleProviderWithFallback()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.33
 Nodes (2): createEmptyStats(), SearchMetricsStore
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.38
 Nodes (3): executeTool(), resolveTelemetryOwnerId(), telemetryParamsContext()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.71
 Nodes (6): createAnchorTable(), expect(), runAllTests(), testAnchorSystemWorkflow(), testFallbackMechanism(), testMultiClientScenario()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.52
 Nodes (6): calculateRecency(), generateRecencyData(), main(), printConsoleGraph(), printCSV(), printKeyPoints()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.57
 Nodes (6): compareWithAndWithoutConsolidation(), convertToSearchResults(), generateGroundTruth(), measureSearchQuality(), testConsolidationSearchQuality(), verifyRankingOrder()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.57
 Nodes (6): buildReviewChecklistMarkdown(), findGroundTruth(), loadLabelCandidates(), renderCandidate(), renderRelevantEntry(), summarizeContent()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.38
 Nodes (3): installDashboardRoutes(), observation(), session()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.48
 Nodes (5): buildMemoryIdToBenchmarkIdMap(), main(), parseArgs(), printHelp(), sampleDeterministicNegatives()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.52
 Nodes (6): extractKeywordsFromMemories(), generateGroundTruthFromSearch(), getMemoryIds(), main(), parseArgs(), printHelp()
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.52
 Nodes (6): compositeScore(), generateCandidate(), main(), mulberry32(), parseTuneArgs(), selectBest()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.48
 Nodes (6): callHttpTool(), checkServerHealth(), getHttpTools(), handleRequest(), main(), sendResponse()
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.57
 Nodes (6): detectAppLogEvent(), detectDockerAnomaly(), detectRuntimeAnomaly(), nowIso(), redactDockerInspectEnv(), truncateTitle()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.52
 Nodes (6): booleanFromEnv(), defaultLogsRoot(), labelsFromEnv(), loadMonitorConfig(), numberFromEnv(), optionalString()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (6): buildRequestOptions(), getDashboardAuth(), isProgrammaticToolsRequest(), mementoAdminFetch(), performFetch(), waitForSession()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.29
 Nodes (0): 
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (6): postBulkAction(), resetBulkSelection(), setAllVisibleSelected(), syncBulkControls(), wireBulkReviewActions(), wireBulkTableSelection()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.52
 Nodes (5): clearSearch(), highlightSearchResults(), performSearch(), renderSearchResultsList(), updateNodeHighlight()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.43
 Nodes (5): formatDurationMs(), formatHealthMetricCard(), ratioText(), renderBatchRunHistoryTable(), renderLiveHealthHtml()
 
-### Community 322 - "Community 322"
-Cohesion: 0.33
-Nodes (1): CircuitBreaker
-
 ### Community 323 - "Community 323"
 Cohesion: 0.33
-Nodes (0): 
+Nodes (1): CircuitBreaker
 
 ### Community 324 - "Community 324"
 Cohesion: 0.67
@@ -3661,16 +3661,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 576 - "Community 576"
-Cohesion: 1.0
-Nodes (2): loadEnv(), resolveEnvPath()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 578 - "Community 578"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): loadEnv(), resolveEnvPath()
 
 ### Community 579 - "Community 579"
 Cohesion: 0.67
@@ -3681,40 +3681,40 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 581 - "Community 581"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 582 - "Community 582"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 583 - "Community 583"
 Cohesion: 1.0
 Nodes (2): compareServices(), testServerSynchronization()
 
-### Community 582 - "Community 582"
+### Community 584 - "Community 584"
 Cohesion: 1.0
 Nodes (2): assert(), testMementoClient()
 
-### Community 583 - "Community 583"
+### Community 585 - "Community 585"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 584 - "Community 584"
+### Community 586 - "Community 586"
 Cohesion: 0.67
 Nodes (1): NoopSearchProvider
 
-### Community 585 - "Community 585"
+### Community 587 - "Community 587"
 Cohesion: 0.67
 Nodes (1): git()
 
-### Community 586 - "Community 586"
+### Community 588 - "Community 588"
 Cohesion: 1.0
 Nodes (2): invalid(), runClaudeCodeHook()
 
-### Community 587 - "Community 587"
-Cohesion: 1.0
-Nodes (2): log(), shouldLog()
-
-### Community 588 - "Community 588"
-Cohesion: 0.67
-Nodes (0): 
-
 ### Community 589 - "Community 589"
 Cohesion: 1.0
-Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
+Nodes (2): log(), shouldLog()
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
@@ -3722,7 +3722,7 @@ Nodes (0):
 
 ### Community 591 - "Community 591"
 Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
+Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -3730,15 +3730,15 @@ Nodes (0):
 
 ### Community 593 - "Community 593"
 Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 594 - "Community 594"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 595 - "Community 595"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 596 - "Community 596"
 Cohesion: 0.67
@@ -3749,16 +3749,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 598 - "Community 598"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 599 - "Community 599"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 600 - "Community 600"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
@@ -3797,52 +3797,52 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 610 - "Community 610"
-Cohesion: 1.0
-Nodes (2): isTransientCapacityError(), logExternalApiRetry()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 611 - "Community 611"
 Cohesion: 0.67
-Nodes (1): RuleBasedProceduralExtractor
+Nodes (0): 
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Nodes (2): isTransientCapacityError(), logExternalApiRetry()
 
 ### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Cohesion: 0.67
+Nodes (1): RuleBasedProceduralExtractor
 
 ### Community 614 - "Community 614"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 615 - "Community 615"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 617 - "Community 617"
-Cohesion: 1.0
-Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 619 - "Community 619"
-Cohesion: 0.67
-Nodes (1): SearchError
+Cohesion: 1.0
+Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 621 - "Community 621"
-Cohesion: 1.0
-Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
+Cohesion: 0.67
+Nodes (1): SearchError
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
@@ -3850,31 +3850,31 @@ Nodes (0):
 
 ### Community 623 - "Community 623"
 Cohesion: 1.0
-Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
+Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 627 - "Community 627"
-Cohesion: 1.0
-Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 629 - "Community 629"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
@@ -3882,23 +3882,23 @@ Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 632 - "Community 632"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 633 - "Community 633"
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
+
+### Community 634 - "Community 634"
 Cohesion: 1.0
 Nodes (2): generateMemoryId(), rollbackToVersion()
 
-### Community 633 - "Community 633"
+### Community 635 - "Community 635"
 Cohesion: 1.0
 Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
-
-### Community 634 - "Community 634"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 635 - "Community 635"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
@@ -3921,20 +3921,20 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 641 - "Community 641"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
-
-### Community 642 - "Community 642"
-Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
-
-### Community 643 - "Community 643"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 644 - "Community 644"
+### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): AgentIntegrationError
+Nodes (0): 
+
+### Community 643 - "Community 643"
+Cohesion: 1.0
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
+
+### Community 644 - "Community 644"
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
@@ -3942,27 +3942,27 @@ Nodes (0):
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): AgentIntegrationError
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 648 - "Community 648"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 649 - "Community 649"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 650 - "Community 650"
 Cohesion: 1.0
 Nodes (2): compareToolResults(), testToolConsistency()
 
-### Community 649 - "Community 649"
+### Community 651 - "Community 651"
 Cohesion: 1.0
 Nodes (2): createQualityTables(), testQualityAssuranceE2E()
-
-### Community 650 - "Community 650"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 651 - "Community 651"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
@@ -3973,8 +3973,8 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 654 - "Community 654"
-Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
@@ -3982,35 +3982,35 @@ Nodes (0):
 
 ### Community 656 - "Community 656"
 Cohesion: 1.0
-Nodes (2): fetchJson(), testDockerServer()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 657 - "Community 657"
-Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 658 - "Community 658"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fetchJson(), testDockerServer()
 
 ### Community 659 - "Community 659"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 660 - "Community 660"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 661 - "Community 661"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 662 - "Community 662"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 663 - "Community 663"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
@@ -4029,11 +4029,11 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 668 - "Community 668"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 669 - "Community 669"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 670 - "Community 670"
@@ -6635,49 +6635,45 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `TimeoutError`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 668`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 670`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 671`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 672`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 673`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 674`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 675`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 676`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 677`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 678`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 679`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
+- **Thin community `Community 680`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 681`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 682`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 683`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
+- **Thin community `Community 684`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `createAnchorSchema()`, `anchor-map.handler.spec.ts`
+- **Thin community `Community 685`** (2 nodes): `createAnchorSchema()`, `anchor-map.handler.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `makeMocks()`, `admin-auth.middleware.spec.ts`
+- **Thin community `Community 686`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 687`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 688`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `programmatic-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 689`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 690`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 668
+      "community": 670
     },
     {
       "label": "before-user-turn.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 669
+      "community": 671
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 670
+      "community": 672
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "createTransportFromEnv()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 671
+      "community": 673
     },
     {
       "label": "stdio-transport.ts",
@@ -561,7 +561,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_ts",
-      "community": 322
+      "community": 323
     },
     {
       "label": "CircuitBreaker",
@@ -569,7 +569,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L8",
       "id": "circuit_breaker_circuitbreaker",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".constructor()",
@@ -577,7 +577,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L12",
       "id": "circuit_breaker_circuitbreaker_constructor",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".canPass()",
@@ -585,7 +585,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L14",
       "id": "circuit_breaker_circuitbreaker_canpass",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".recordSuccess()",
@@ -593,7 +593,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L27",
       "id": "circuit_breaker_circuitbreaker_recordsuccess",
-      "community": 322
+      "community": 323
     },
     {
       "label": ".recordFailure()",
@@ -601,7 +601,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.ts",
       "source_location": "L32",
       "id": "circuit_breaker_circuitbreaker_recordfailure",
-      "community": 322
+      "community": 323
     },
     {
       "label": "logger.ts",
@@ -665,7 +665,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_ts",
-      "community": 267
+      "community": 268
     },
     {
       "label": "RetryQueue",
@@ -673,7 +673,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L13",
       "id": "retry_queue_retryqueue",
-      "community": 267
+      "community": 268
     },
     {
       "label": ".constructor()",
@@ -681,7 +681,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L16",
       "id": "retry_queue_retryqueue_constructor",
-      "community": 267
+      "community": 268
     },
     {
       "label": ".enqueue()",
@@ -689,7 +689,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L18",
       "id": "retry_queue_retryqueue_enqueue",
-      "community": 267
+      "community": 268
     },
     {
       "label": ".size()",
@@ -697,7 +697,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L30",
       "id": "retry_queue_retryqueue_size",
-      "community": 267
+      "community": 268
     },
     {
       "label": ".run()",
@@ -705,7 +705,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L34",
       "id": "retry_queue_retryqueue_run",
-      "community": 267
+      "community": 268
     },
     {
       "label": ".remove()",
@@ -713,7 +713,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.ts",
       "source_location": "L53",
       "id": "retry_queue_retryqueue_remove",
-      "community": 267
+      "community": 268
     },
     {
       "label": "degraded-fallback.e2e.spec.ts",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 672
+      "community": 674
     },
     {
       "label": "testBasicFunctionality()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 672
+      "community": 674
     },
     {
       "label": "performance-optimizer.js",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "basicUsageExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 673
+      "community": 675
     },
     {
       "label": "performance-examples.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "advancedUsageExample()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 674
+      "community": 676
     },
     {
       "label": "migration-guide.ts",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "makeNullRunner()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 675
+      "community": 677
     },
     {
       "label": "telemetry-cli.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "readShellSources()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L47",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 676
+      "community": 678
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -1961,7 +1961,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_programmatic_auth_integration_spec_ts",
-      "community": 268
+      "community": 269
     },
     {
       "label": "postJson()",
@@ -1969,7 +1969,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L21",
       "id": "programmatic_auth_integration_spec_postjson",
-      "community": 268
+      "community": 269
     },
     {
       "label": "getRequest()",
@@ -1977,7 +1977,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L62",
       "id": "programmatic_auth_integration_spec_getrequest",
-      "community": 268
+      "community": 269
     },
     {
       "label": "optionsRequest()",
@@ -1985,7 +1985,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L97",
       "id": "programmatic_auth_integration_spec_optionsrequest",
-      "community": 268
+      "community": 269
     },
     {
       "label": "openMcpStream()",
@@ -1993,7 +1993,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L132",
       "id": "programmatic_auth_integration_spec_openmcpstream",
-      "community": 268
+      "community": 269
     },
     {
       "label": "extractSessionPath()",
@@ -2001,7 +2001,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L192",
       "id": "programmatic_auth_integration_spec_extractsessionpath",
-      "community": 268
+      "community": 269
     },
     {
       "label": "startRealHttpServer()",
@@ -2009,7 +2009,7 @@
       "source_file": "packages/memento-server/src/server/programmatic-auth.integration.spec.ts",
       "source_location": "L202",
       "id": "programmatic_auth_integration_spec_startrealhttpserver",
-      "community": 268
+      "community": 269
     },
     {
       "label": "env-config.spec.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "createServerFactory()",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 677
+      "community": 679
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2289,7 +2289,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_websocket_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "setupWebSocketServer()",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L20",
       "id": "http_server_websocket_setupwebsocketserver",
-      "community": 678
+      "community": 680
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_ts",
-      "community": 269
+      "community": 270
     },
     {
       "label": "parsePositiveIntMs()",
@@ -2313,7 +2313,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L22",
       "id": "review_queue_dashboard_boot_parsepositiveintms",
-      "community": 269
+      "community": 270
     },
     {
       "label": "clampIntervalMs()",
@@ -2321,7 +2321,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L33",
       "id": "review_queue_dashboard_boot_clampintervalms",
-      "community": 269
+      "community": 270
     },
     {
       "label": "parseBackoffCsv()",
@@ -2329,7 +2329,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L37",
       "id": "review_queue_dashboard_boot_parsebackoffcsv",
-      "community": 269
+      "community": 270
     },
     {
       "label": "resolveReviewQueueDashboardBootFromEnv()",
@@ -2337,7 +2337,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L52",
       "id": "review_queue_dashboard_boot_resolvereviewqueuedashboardbootfromenv",
-      "community": 269
+      "community": 270
     },
     {
       "label": "buildReviewQueueBootInjectionHtml()",
@@ -2345,7 +2345,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L66",
       "id": "review_queue_dashboard_boot_buildreviewqueuebootinjectionhtml",
-      "community": 269
+      "community": 270
     },
     {
       "label": "injectReviewQueueBootIntoDashboardHtml()",
@@ -2353,7 +2353,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.ts",
       "source_location": "L71",
       "id": "review_queue_dashboard_boot_injectreviewqueuebootintodashboardhtml",
-      "community": 269
+      "community": 270
     },
     {
       "label": "stdio-server-impl.ts",
@@ -2361,7 +2361,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "startStdioServer()",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 679
+      "community": 681
     },
     {
       "label": "server-factory.spec.ts",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 680
+      "community": 682
     },
     {
       "label": "http-server-lifecycle.ts",
@@ -2855,7 +2855,7 @@
       "label": "setTestDependencies()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L76",
+      "source_location": "L77",
       "id": "http_server_settestdependencies",
       "community": 67
     },
@@ -2863,7 +2863,7 @@
       "label": "resolveStaticRoot()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L99",
+      "source_location": "L100",
       "id": "http_server_resolvestaticroot",
       "community": 67
     },
@@ -2871,7 +2871,7 @@
       "label": "isProtectedMcpProgrammaticPath()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L191",
+      "source_location": "L192",
       "id": "http_server_isprotectedmcpprogrammaticpath",
       "community": 67
     },
@@ -2879,7 +2879,7 @@
       "label": "getHttpAuthTrustModelNotice()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L195",
+      "source_location": "L196",
       "id": "http_server_gethttpauthtrustmodelnotice",
       "community": 67
     },
@@ -2887,7 +2887,7 @@
       "label": "getHttpAuthMissingAdminKeyWarning()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L199",
+      "source_location": "L200",
       "id": "http_server_gethttpauthmissingadminkeywarning",
       "community": 67
     },
@@ -2895,7 +2895,7 @@
       "label": "initializeCoreServices()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "id": "http_server_initializecoreservices",
       "community": 67
     },
@@ -2903,7 +2903,7 @@
       "label": "setupMiddleware()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L238",
+      "source_location": "L239",
       "id": "http_server_setupmiddleware",
       "community": 67
     },
@@ -2911,7 +2911,7 @@
       "label": "createContextInjectionService()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L247",
+      "source_location": "L248",
       "id": "http_server_createcontextinjectionservice",
       "community": 67
     },
@@ -2919,7 +2919,7 @@
       "label": "createAllRouters()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L262",
+      "source_location": "L263",
       "id": "http_server_createallrouters",
       "community": 67
     },
@@ -2927,7 +2927,7 @@
       "label": "registerRoutes()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L290",
+      "source_location": "L291",
       "id": "http_server_registerroutes",
       "community": 67
     },
@@ -2935,7 +2935,7 @@
       "label": "logEmbeddingProviderInfo()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L319",
+      "source_location": "L325",
       "id": "http_server_logembeddingproviderinfo",
       "community": 67
     },
@@ -2943,7 +2943,7 @@
       "label": "initializeServer()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L336",
+      "source_location": "L342",
       "id": "http_server_initializeserver",
       "community": 67
     },
@@ -2951,7 +2951,7 @@
       "label": "cleanup()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L360",
+      "source_location": "L366",
       "id": "http_server_cleanup",
       "community": 67
     },
@@ -2959,7 +2959,7 @@
       "label": "startServer()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L375",
+      "source_location": "L381",
       "id": "http_server_startserver",
       "community": 67
     },
@@ -2977,7 +2977,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_batch_run_history_ts",
-      "community": 270
+      "community": 271
     },
     {
       "label": "trimEntries()",
@@ -2985,7 +2985,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L26",
       "id": "batch_run_history_trimentries",
-      "community": 270
+      "community": 271
     },
     {
       "label": "jsonSafeDetails()",
@@ -2993,7 +2993,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L32",
       "id": "batch_run_history_jsonsafedetails",
-      "community": 270
+      "community": 271
     },
     {
       "label": "recordManualBatchRunSuccess()",
@@ -3001,7 +3001,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L44",
       "id": "batch_run_history_recordmanualbatchrunsuccess",
-      "community": 270
+      "community": 271
     },
     {
       "label": "recordManualBatchRunFailure()",
@@ -3009,7 +3009,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L99",
       "id": "batch_run_history_recordmanualbatchrunfailure",
-      "community": 270
+      "community": 271
     },
     {
       "label": "getManualBatchRunHistory()",
@@ -3017,7 +3017,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L121",
       "id": "batch_run_history_getmanualbatchrunhistory",
-      "community": 270
+      "community": 271
     },
     {
       "label": "resetBatchRunHistoryForTests()",
@@ -3025,7 +3025,7 @@
       "source_file": "packages/memento-server/src/server/batch-run-history.ts",
       "source_location": "L126",
       "id": "batch_run_history_resetbatchrunhistoryfortests",
-      "community": 270
+      "community": 271
     },
     {
       "label": "mcp-logger.ts",
@@ -3193,7 +3193,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3201,7 +3201,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 681
+      "community": 683
     },
     {
       "label": "tool-result.utils.ts",
@@ -3209,7 +3209,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_tool_result_utils_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "extractToolResultPayload()",
@@ -3217,7 +3217,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L6",
       "id": "tool_result_utils_extracttoolresultpayload",
-      "community": 682
+      "community": 684
     },
     {
       "label": "anchor-map.handler.spec.ts",
@@ -3225,7 +3225,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "createAnchorSchema()",
@@ -3233,7 +3233,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
       "source_location": "L6",
       "id": "anchor_map_handler_spec_createanchorschema",
-      "community": 683
+      "community": 685
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3241,7 +3241,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "community": 271
+      "community": 272
     },
     {
       "label": "listAnchorAgentIds()",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L49",
       "id": "anchor_map_handler_listanchoragentids",
-      "community": 271
+      "community": 272
     },
     {
       "label": "buildAnchorMapData()",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L84",
       "id": "anchor_map_handler_buildanchormapdata",
-      "community": 271
+      "community": 272
     },
     {
       "label": "buildNetworkNodesAndLinks()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L128",
       "id": "anchor_map_handler_buildnetworknodesandlinks",
-      "community": 271
+      "community": 272
     },
     {
       "label": "buildNetworkLinks()",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L238",
       "id": "anchor_map_handler_buildnetworklinks",
-      "community": 271
+      "community": 272
     },
     {
       "label": "broadcastToSubscribers()",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L286",
       "id": "anchor_map_handler_broadcasttosubscribers",
-      "community": 271
+      "community": 272
     },
     {
       "label": "broadcastAnchorMapUpdate()",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
       "source_location": "L309",
       "id": "anchor_map_handler_broadcastanchormapupdate",
-      "community": 271
+      "community": 272
     },
     {
       "label": "tool-context-meta-memory-injection.spec.ts",
@@ -3321,15 +3321,23 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 684
+      "community": 572
     },
     {
       "label": "makeMocks()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
-      "source_location": "L21",
+      "source_location": "L13",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 684
+      "community": 572
+    },
+    {
+      "label": "createMiddleware()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
+      "source_location": "L23",
+      "id": "admin_auth_middleware_spec_createmiddleware",
+      "community": 572
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3337,47 +3345,63 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
-      "community": 323
+      "community": 221
     },
     {
       "label": "writeDisabledResponse()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L8",
+      "source_location": "L26",
       "id": "programmatic_auth_middleware_writedisabledresponse",
-      "community": 323
+      "community": 221
     },
     {
       "label": "writeUnauthorized()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L28",
+      "source_location": "L46",
       "id": "programmatic_auth_middleware_writeunauthorized",
-      "community": 323
+      "community": 221
+    },
+    {
+      "label": "writeForbidden()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L66",
+      "id": "programmatic_auth_middleware_writeforbidden",
+      "community": 221
     },
     {
       "label": "readBearerToken()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L48",
+      "source_location": "L88",
       "id": "programmatic_auth_middleware_readbearertoken",
-      "community": 323
+      "community": 221
     },
     {
       "label": "readApiKeyHeader()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L58",
+      "source_location": "L98",
       "id": "programmatic_auth_middleware_readapikeyheader",
-      "community": 323
+      "community": 221
+    },
+    {
+      "label": "resolveAuthenticatedToken()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L108",
+      "id": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "community": 221
     },
     {
       "label": "createProgrammaticAuthMiddleware()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L68",
+      "source_location": "L128",
       "id": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
-      "community": 323
+      "community": 221
     },
     {
       "label": "error-handler.middleware.ts",
@@ -3433,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3441,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L32",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 685
+      "community": 686
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3449,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "createMockResponse()",
@@ -3457,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 686
+      "community": 687
     },
     {
       "label": "index.ts",
@@ -3505,7 +3529,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "createServiceInjector()",
@@ -3513,7 +3537,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 687
+      "community": 688
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3521,15 +3545,15 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "createAdminAuthMiddleware()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
-      "source_location": "L14",
+      "source_location": "L16",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 688
+      "community": 689
     },
     {
       "label": "programmatic-auth.middleware.spec.ts",
@@ -3537,15 +3561,23 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 689
+      "community": 573
     },
     {
       "label": "createMockResponse()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 689
+      "community": 573
+    },
+    {
+      "label": "createRegistry()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
+      "source_location": "L21",
+      "id": "programmatic_auth_middleware_spec_createregistry",
+      "community": 573
     },
     {
       "label": "session-store.spec.ts",
@@ -3705,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_validation_ts",
-      "community": 272
+      "community": 273
     },
     {
       "label": "optionalString()",
@@ -3713,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L5",
       "id": "agent_routes_validation_optionalstring",
-      "community": 272
+      "community": 273
     },
     {
       "label": "optionalStringArray()",
@@ -3721,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L13",
       "id": "agent_routes_validation_optionalstringarray",
-      "community": 272
+      "community": 273
     },
     {
       "label": "optionalOwnerId()",
@@ -3729,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L21",
       "id": "agent_routes_validation_optionalownerid",
-      "community": 272
+      "community": 273
     },
     {
       "label": "optionalPositiveInteger()",
@@ -3737,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L26",
       "id": "agent_routes_validation_optionalpositiveinteger",
-      "community": 272
+      "community": 273
     },
     {
       "label": "optionalMemoryTypes()",
@@ -3745,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L34",
       "id": "agent_routes_validation_optionalmemorytypes",
-      "community": 272
+      "community": 273
     },
     {
       "label": "requireCandidates()",
@@ -3753,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.validation.ts",
       "source_location": "L43",
       "id": "agent_routes_validation_requirecandidates",
-      "community": 272
+      "community": 273
     },
     {
       "label": "agent.routes.personal.ts",
@@ -3793,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_spec_ts",
-      "community": 572
+      "community": 574
     },
     {
       "label": "event()",
@@ -3801,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L13",
       "id": "agent_routes_spec_event",
-      "community": 572
+      "community": 574
     },
     {
       "label": "invoke()",
@@ -3809,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L159",
       "id": "agent_routes_spec_invoke",
-      "community": 572
+      "community": 574
     },
     {
       "label": "agent-transcript-import.spec.ts",
@@ -3993,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_ingest_ts",
-      "community": 221
+      "community": 222
     },
     {
       "label": "handlePostSessions()",
@@ -4001,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L15",
       "id": "agent_routes_ingest_handlepostsessions",
-      "community": 221
+      "community": 222
     },
     {
       "label": "prepareBatchEvent()",
@@ -4009,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L63",
       "id": "agent_routes_ingest_preparebatchevent",
-      "community": 221
+      "community": 222
     },
     {
       "label": "captureOneBatchEvent()",
@@ -4017,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L79",
       "id": "agent_routes_ingest_captureonebatchevent",
-      "community": 221
+      "community": 222
     },
     {
       "label": "maybePreCompactInjection()",
@@ -4025,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L103",
       "id": "agent_routes_ingest_maybeprecompactinjection",
-      "community": 221
+      "community": 222
     },
     {
       "label": "handlePostObservationsIngest()",
@@ -4033,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L118",
       "id": "agent_routes_ingest_handlepostobservationsingest",
-      "community": 221
+      "community": 222
     },
     {
       "label": "handlePostTranscriptsImport()",
@@ -4041,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L144",
       "id": "agent_routes_ingest_handleposttranscriptsimport",
-      "community": 221
+      "community": 222
     },
     {
       "label": "handleCaptureSessionEvent()",
@@ -4049,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ingest.ts",
       "source_location": "L177",
       "id": "agent_routes_ingest_handlecapturesessionevent",
-      "community": 221
+      "community": 222
     },
     {
       "label": "agent.routes.events.ts",
@@ -4097,7 +4129,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_status_ts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "queryObservationRows()",
@@ -4105,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L44",
       "id": "agent_routes_status_queryobservationrows",
-      "community": 222
+      "community": 223
     },
     {
       "label": "queryInjectionRows()",
@@ -4113,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L60",
       "id": "agent_routes_status_queryinjectionrows",
-      "community": 222
+      "community": 223
     },
     {
       "label": "queryObservationCounts()",
@@ -4121,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L71",
       "id": "agent_routes_status_queryobservationcounts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "queryInjectionCounts()",
@@ -4129,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L82",
       "id": "agent_routes_status_queryinjectioncounts",
-      "community": 222
+      "community": 223
     },
     {
       "label": "buildRecentEvents()",
@@ -4137,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L93",
       "id": "agent_routes_status_buildrecentevents",
-      "community": 222
+      "community": 223
     },
     {
       "label": "handleGetCapabilities()",
@@ -4145,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L124",
       "id": "agent_routes_status_handlegetcapabilities",
-      "community": 222
+      "community": 223
     },
     {
       "label": "handleGetOperationsStatus()",
@@ -4153,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.status.ts",
       "source_location": "L144",
       "id": "agent_routes_status_handlegetoperationsstatus",
-      "community": 222
+      "community": 223
     },
     {
       "label": "auth.routes.ts",
@@ -4225,7 +4257,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_spec_ts",
-      "community": 223
+      "community": 224
     },
     {
       "label": "listen()",
@@ -4233,7 +4265,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L29",
       "id": "admin_routes_spec_listen",
-      "community": 223
+      "community": 224
     },
     {
       "label": "postAdminJson()",
@@ -4241,7 +4273,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L44",
       "id": "admin_routes_spec_postadminjson",
-      "community": 223
+      "community": 224
     },
     {
       "label": "getAdmin()",
@@ -4249,7 +4281,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L80",
       "id": "admin_routes_spec_getadmin",
-      "community": 223
+      "community": 224
     },
     {
       "label": "deleteAdmin()",
@@ -4257,7 +4289,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L106",
       "id": "admin_routes_spec_deleteadmin",
-      "community": 223
+      "community": 224
     },
     {
       "label": "makeApp()",
@@ -4265,7 +4297,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L598",
       "id": "admin_routes_spec_makeapp",
-      "community": 223
+      "community": 224
     },
     {
       "label": "createBaseSchema()",
@@ -4273,7 +4305,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1036",
       "id": "admin_routes_spec_createbaseschema",
-      "community": 223
+      "community": 224
     },
     {
       "label": "readStreamUntil()",
@@ -4281,7 +4313,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.spec.ts",
       "source_location": "L1137",
       "id": "admin_routes_spec_readstreamuntil",
-      "community": 223
+      "community": 224
     },
     {
       "label": "agent.routes.provenance.ts",
@@ -4289,7 +4321,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_provenance_ts",
-      "community": 224
+      "community": 225
     },
     {
       "label": "resolveProvenanceFilter()",
@@ -4297,7 +4329,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L8",
       "id": "agent_routes_provenance_resolveprovenancefilter",
-      "community": 224
+      "community": 225
     },
     {
       "label": "loadProvenanceMemories()",
@@ -4305,7 +4337,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L17",
       "id": "agent_routes_provenance_loadprovenancememories",
-      "community": 224
+      "community": 225
     },
     {
       "label": "loadProvenanceObservations()",
@@ -4313,7 +4345,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L35",
       "id": "agent_routes_provenance_loadprovenanceobservations",
-      "community": 224
+      "community": 225
     },
     {
       "label": "loadProvenanceSessions()",
@@ -4321,7 +4353,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L46",
       "id": "agent_routes_provenance_loadprovenancesessions",
-      "community": 224
+      "community": 225
     },
     {
       "label": "handlePostProvenance()",
@@ -4329,7 +4361,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L57",
       "id": "agent_routes_provenance_handlepostprovenance",
-      "community": 224
+      "community": 225
     },
     {
       "label": "handleGetProvenance()",
@@ -4337,7 +4369,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L74",
       "id": "agent_routes_provenance_handlegetprovenance",
-      "community": 224
+      "community": 225
     },
     {
       "label": "handleGetProvenanceDetail()",
@@ -4345,7 +4377,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.provenance.ts",
       "source_location": "L93",
       "id": "agent_routes_provenance_handlegetprovenancedetail",
-      "community": 224
+      "community": 225
     },
     {
       "label": "agent-transcript-import.ts",
@@ -4761,7 +4793,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_dto_ts",
-      "community": 273
+      "community": 274
     },
     {
       "label": "sessionDto()",
@@ -4769,7 +4801,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L10",
       "id": "agent_routes_dto_sessiondto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "observationDto()",
@@ -4777,7 +4809,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L31",
       "id": "agent_routes_dto_observationdto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "exportObservationDto()",
@@ -4785,7 +4817,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L78",
       "id": "agent_routes_dto_exportobservationdto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "provenanceDto()",
@@ -4793,7 +4825,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L87",
       "id": "agent_routes_dto_provenancedto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "injectionDto()",
@@ -4801,7 +4833,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L99",
       "id": "agent_routes_dto_injectiondto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "promotionCandidateDto()",
@@ -4809,7 +4841,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.dto.ts",
       "source_location": "L130",
       "id": "agent_routes_dto_promotioncandidatedto",
-      "community": 273
+      "community": 274
     },
     {
       "label": "types.ts",
@@ -4825,7 +4857,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_handlers_ts",
-      "community": 225
+      "community": 226
     },
     {
       "label": "applyMcpCorsHeaders()",
@@ -4833,7 +4865,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L13",
       "id": "handlers_applymcpcorsheaders",
-      "community": 225
+      "community": 226
     },
     {
       "label": "sendMcpCorsPreflight()",
@@ -4841,7 +4873,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L21",
       "id": "handlers_sendmcpcorspreflight",
-      "community": 225
+      "community": 226
     },
     {
       "label": "handleMcpSseConnection()",
@@ -4849,7 +4881,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L26",
       "id": "handlers_handlemcpsseconnection",
-      "community": 225
+      "community": 226
     },
     {
       "label": "registerSseCleanup()",
@@ -4857,7 +4889,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L82",
       "id": "handlers_registerssecleanup",
-      "community": 225
+      "community": 226
     },
     {
       "label": "handleStreamableMcpPost()",
@@ -4865,7 +4897,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L112",
       "id": "handlers_handlestreamablemcppost",
-      "community": 225
+      "community": 226
     },
     {
       "label": "handleSseMessagePost()",
@@ -4873,7 +4905,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L152",
       "id": "handlers_handlessemessagepost",
-      "community": 225
+      "community": 226
     },
     {
       "label": "writeSseJson()",
@@ -4881,7 +4913,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/handlers.ts",
       "source_location": "L205",
       "id": "handlers_writessejson",
-      "community": 225
+      "community": 226
     },
     {
       "label": "json-rpc.ts",
@@ -5105,7 +5137,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 573
+      "community": 575
     },
     {
       "label": "parseParams()",
@@ -5113,7 +5145,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 573
+      "community": 575
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -5121,7 +5153,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 573
+      "community": 575
     },
     {
       "label": "admin-evolution-demo.routes.spec.ts",
@@ -5129,7 +5161,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_spec_ts",
-      "community": 574
+      "community": 576
     },
     {
       "label": "listen()",
@@ -5137,7 +5169,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L11",
       "id": "admin_evolution_demo_routes_spec_listen",
-      "community": 574
+      "community": 576
     },
     {
       "label": "getAdmin()",
@@ -5145,7 +5177,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L25",
       "id": "admin_evolution_demo_routes_spec_getadmin",
-      "community": 574
+      "community": 576
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -5233,7 +5265,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 575
+      "community": 577
     },
     {
       "label": "parseCleanupParams()",
@@ -5241,7 +5273,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 575
+      "community": 577
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -5249,7 +5281,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 575
+      "community": 577
     },
     {
       "label": "admin-relations.routes.ts",
@@ -5561,7 +5593,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 576
+      "community": 578
     },
     {
       "label": "resolveEnvPath()",
@@ -5569,7 +5601,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 576
+      "community": 578
     },
     {
       "label": "loadEnv()",
@@ -5577,7 +5609,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 576
+      "community": 578
     },
     {
       "label": "codex-connect.spec.ts",
@@ -5681,7 +5713,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 577
+      "community": 579
     },
     {
       "label": "runCli()",
@@ -5689,7 +5721,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L68",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 577
+      "community": 579
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -5697,7 +5729,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L99",
       "id": "cli_ac5_ac6_spec_createreviewqueuedatabase",
-      "community": 577
+      "community": 579
     },
     {
       "label": "agent-ask.ts",
@@ -5713,7 +5745,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_spec_ts",
-      "community": 578
+      "community": 580
     },
     {
       "label": "response()",
@@ -5721,7 +5753,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L9",
       "id": "agent_ops_spec_response",
-      "community": 578
+      "community": 580
     },
     {
       "label": "baseDependencies()",
@@ -5729,7 +5761,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L13",
       "id": "agent_ops_spec_basedependencies",
-      "community": 578
+      "community": 580
     },
     {
       "label": "review-queue-cleanup.spec.ts",
@@ -5737,7 +5769,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_review_queue_cleanup_spec_ts",
-      "community": 579
+      "community": 581
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -5745,7 +5777,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L13",
       "id": "review_queue_cleanup_spec_createreviewqueuedatabase",
-      "community": 579
+      "community": 581
     },
     {
       "label": "pendingCount()",
@@ -5753,7 +5785,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L54",
       "id": "review_queue_cleanup_spec_pendingcount",
-      "community": 579
+      "community": 581
     },
     {
       "label": "claude-code-connect.ts",
@@ -5865,7 +5897,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_ts",
-      "community": 274
+      "community": 275
     },
     {
       "label": "parsePositiveInteger()",
@@ -5873,7 +5905,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L36",
       "id": "agent_ops_parsepositiveinteger",
-      "community": 274
+      "community": 275
     },
     {
       "label": "parseOptions()",
@@ -5881,7 +5913,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L44",
       "id": "agent_ops_parseoptions",
-      "community": 274
+      "community": 275
     },
     {
       "label": "normalizeEndpoint()",
@@ -5889,7 +5921,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L71",
       "id": "agent_ops_normalizeendpoint",
-      "community": 274
+      "community": 275
     },
     {
       "label": "defaultResolveEndpoint()",
@@ -5897,7 +5929,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L79",
       "id": "agent_ops_defaultresolveendpoint",
-      "community": 274
+      "community": 275
     },
     {
       "label": "createRequest()",
@@ -5905,7 +5937,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L90",
       "id": "agent_ops_createrequest",
-      "community": 274
+      "community": 275
     },
     {
       "label": "runAgentOpsCommand()",
@@ -5913,7 +5945,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.ts",
       "source_location": "L123",
       "id": "agent_ops_runagentopscommand",
-      "community": 274
+      "community": 275
     },
     {
       "label": "codex-hook.spec.ts",
@@ -6297,7 +6329,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 580
+      "community": 582
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -6305,7 +6337,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 580
+      "community": 582
     },
     {
       "label": "runQualityMeasurement()",
@@ -6313,7 +6345,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 580
+      "community": 582
     },
     {
       "label": "test-simple-alerts.ts",
@@ -6369,7 +6401,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 581
+      "community": 583
     },
     {
       "label": "compareServices()",
@@ -6377,7 +6409,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 581
+      "community": 583
     },
     {
       "label": "testServerSynchronization()",
@@ -6385,7 +6417,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 581
+      "community": 583
     },
     {
       "label": "test-error-logging.ts",
@@ -6489,7 +6521,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 582
+      "community": 584
     },
     {
       "label": "assert()",
@@ -6497,7 +6529,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 582
+      "community": 584
     },
     {
       "label": "testMementoClient()",
@@ -6505,7 +6537,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 582
+      "community": 584
     },
     {
       "label": "test-performance-monitor.ts",
@@ -6649,7 +6681,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 583
+      "community": 585
     },
     {
       "label": "createBaseSchema()",
@@ -6657,7 +6689,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 583
+      "community": 585
     },
     {
       "label": "createTestMemory()",
@@ -6665,7 +6697,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 583
+      "community": 585
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -6673,7 +6705,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_anchor_map_search_highlight_spec_ts",
-      "community": 275
+      "community": 276
     },
     {
       "label": "getSearchItemId()",
@@ -6681,7 +6713,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L7",
       "id": "anchor_map_search_highlight_spec_getsearchitemid",
-      "community": 275
+      "community": 276
     },
     {
       "label": "countSearchMapMatches()",
@@ -6689,7 +6721,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L12",
       "id": "anchor_map_search_highlight_spec_countsearchmapmatches",
-      "community": 275
+      "community": 276
     },
     {
       "label": "buildSearchStatusMessage()",
@@ -6697,7 +6729,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L29",
       "id": "anchor_map_search_highlight_spec_buildsearchstatusmessage",
-      "community": 275
+      "community": 276
     },
     {
       "label": "highlightSearchFocusPath()",
@@ -6705,7 +6737,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L51",
       "id": "anchor_map_search_highlight_spec_highlightsearchfocuspath",
-      "community": 275
+      "community": 276
     },
     {
       "label": "findNodeForAnchor()",
@@ -6713,7 +6745,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L66",
       "id": "anchor_map_search_highlight_spec_findnodeforanchor",
-      "community": 275
+      "community": 276
     },
     {
       "label": "shouldDimNonMatchingNodes()",
@@ -6721,7 +6753,7 @@
       "source_file": "packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts",
       "source_location": "L73",
       "id": "anchor_map_search_highlight_spec_shoulddimnonmatchingnodes",
-      "community": 275
+      "community": 276
     },
     {
       "label": "vitest.config.ts",
@@ -6777,7 +6809,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 584
+      "community": 586
     },
     {
       "label": "NoopSearchProvider",
@@ -6785,7 +6817,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 584
+      "community": 586
     },
     {
       "label": ".search()",
@@ -6793,7 +6825,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 584
+      "community": 586
     },
     {
       "label": "search-factory.ts",
@@ -6905,7 +6937,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_ts",
-      "community": 226
+      "community": 227
     },
     {
       "label": "validateInjectionBundle()",
@@ -6913,7 +6945,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L72",
       "id": "injection_contract_validateinjectionbundle",
-      "community": 226
+      "community": 227
     },
     {
       "label": "injectionBundleFixture()",
@@ -6921,7 +6953,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L106",
       "id": "injection_contract_injectionbundlefixture",
-      "community": 226
+      "community": 227
     },
     {
       "label": "codexInjectionFixture()",
@@ -6929,7 +6961,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L139",
       "id": "injection_contract_codexinjectionfixture",
-      "community": 226
+      "community": 227
     },
     {
       "label": "claudeCodeInjectionFixture()",
@@ -6937,7 +6969,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L143",
       "id": "injection_contract_claudecodeinjectionfixture",
-      "community": 226
+      "community": 227
     },
     {
       "label": "agentInjectionIntegrationFixture()",
@@ -6945,7 +6977,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L147",
       "id": "injection_contract_agentinjectionintegrationfixture",
-      "community": 226
+      "community": 227
     },
     {
       "label": "isRecord()",
@@ -6953,7 +6985,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L190",
       "id": "injection_contract_isrecord",
-      "community": 226
+      "community": 227
     },
     {
       "label": "isNonNegativeInteger()",
@@ -6961,7 +6993,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.ts",
       "source_location": "L194",
       "id": "injection_contract_isnonnegativeinteger",
-      "community": 226
+      "community": 227
     },
     {
       "label": "redaction.ts",
@@ -6969,7 +7001,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_ts",
-      "community": 276
+      "community": 277
     },
     {
       "label": "increment()",
@@ -6977,7 +7009,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L51",
       "id": "redaction_increment",
-      "community": 276
+      "community": 277
     },
     {
       "label": "metadata()",
@@ -6985,7 +7017,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L55",
       "id": "redaction_metadata",
-      "community": 276
+      "community": 277
     },
     {
       "label": "scanBlocked()",
@@ -6993,7 +7025,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L61",
       "id": "redaction_scanblocked",
-      "community": 276
+      "community": 277
     },
     {
       "label": "redactString()",
@@ -7001,7 +7033,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L84",
       "id": "redaction_redactstring",
-      "community": 276
+      "community": 277
     },
     {
       "label": "redactValue()",
@@ -7009,7 +7041,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L101",
       "id": "redaction_redactvalue",
-      "community": 276
+      "community": 277
     },
     {
       "label": "redactAgentEvent()",
@@ -7017,7 +7049,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction.ts",
       "source_location": "L126",
       "id": "redaction_redactagentevent",
-      "community": 276
+      "community": 277
     },
     {
       "label": "types.ts",
@@ -7185,7 +7217,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_priority_queue_ts",
-      "community": 277
+      "community": 278
     },
     {
       "label": "eventPriority()",
@@ -7193,7 +7225,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L10",
       "id": "priority_queue_eventpriority",
-      "community": 277
+      "community": 278
     },
     {
       "label": "PriorityEventQueue",
@@ -7201,7 +7233,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L19",
       "id": "priority_queue_priorityeventqueue",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".constructor()",
@@ -7209,7 +7241,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L23",
       "id": "priority_queue_priorityeventqueue_constructor",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".size()",
@@ -7217,7 +7249,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L29",
       "id": "priority_queue_priorityeventqueue_size",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".enqueue()",
@@ -7225,7 +7257,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L33",
       "id": "priority_queue_priorityeventqueue_enqueue",
-      "community": 277
+      "community": 278
     },
     {
       "label": ".take()",
@@ -7233,7 +7265,7 @@
       "source_file": "packages/memento-agent-integration/src/priority-queue.ts",
       "source_location": "L74",
       "id": "priority_queue_priorityeventqueue_take",
-      "community": 277
+      "community": 278
     },
     {
       "label": "size-policy.ts",
@@ -7385,7 +7417,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_spec_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "git()",
@@ -7393,7 +7425,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L22",
       "id": "scope_spec_git",
-      "community": 585
+      "community": 587
     },
     {
       "label": "runner.spec.ts",
@@ -7657,7 +7689,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_spec_ts",
-      "community": 585
+      "community": 587
     },
     {
       "label": "runner.spec.ts",
@@ -7857,7 +7889,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_ts",
-      "community": 586
+      "community": 588
     },
     {
       "label": "invalid()",
@@ -7865,7 +7897,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L6",
       "id": "runner_invalid",
-      "community": 586
+      "community": 588
     },
     {
       "label": "runClaudeCodeHook()",
@@ -7873,7 +7905,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L10",
       "id": "runner_runclaudecodehook",
-      "community": 586
+      "community": 588
     },
     {
       "label": "adapter.spec.ts",
@@ -8849,7 +8881,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 587
+      "community": 589
     },
     {
       "label": "shouldLog()",
@@ -8857,7 +8889,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 587
+      "community": 589
     },
     {
       "label": "log()",
@@ -8865,7 +8897,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 587
+      "community": 589
     },
     {
       "label": "bootstrap.spec.ts",
@@ -8905,7 +8937,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 588
+      "community": 590
     },
     {
       "label": "createMementoCore()",
@@ -8913,7 +8945,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 588
+      "community": 590
     },
     {
       "label": "closeDatabase()",
@@ -8921,7 +8953,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 588
+      "community": 590
     },
     {
       "label": "bootstrap.ts",
@@ -10297,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_incremental_ts",
-      "community": 589
+      "community": 591
     },
     {
       "label": "mergeProceduralSteps()",
@@ -10305,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_incremental_mergeproceduralsteps",
-      "community": 589
+      "community": 591
     },
     {
       "label": "updateProceduralMemoryIncremental()",
@@ -10313,7 +10345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L33",
       "id": "reflexion_procedural_update_incremental_updateproceduralmemoryincremental",
-      "community": 589
+      "community": 591
     },
     {
       "label": "database-optimize-tool.ts",
@@ -10665,7 +10697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 590
+      "community": 592
     },
     {
       "label": "createBaseSchema()",
@@ -10673,7 +10705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 590
+      "community": 592
     },
     {
       "label": "measureTime()",
@@ -10681,7 +10713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 590
+      "community": 592
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -11049,7 +11081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 591
+      "community": 593
     },
     {
       "label": "addMissingColumn()",
@@ -11057,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 591
+      "community": 593
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -11065,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 591
+      "community": 593
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -11201,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_ts",
-      "community": 592
+      "community": 594
     },
     {
       "label": "initializeDatabase()",
@@ -11209,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L29",
       "id": "init_initializedatabase",
-      "community": 592
+      "community": 594
     },
     {
       "label": "closeDatabase()",
@@ -11217,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L116",
       "id": "init_closedatabase",
-      "community": 592
+      "community": 594
     },
     {
       "label": "db-integrity-preflight.spec.ts",
@@ -11297,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_legacy_schema_ts",
-      "community": 278
+      "community": 279
     },
     {
       "label": "addMissingColumn()",
@@ -11305,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L18",
       "id": "init_legacy_schema_addmissingcolumn",
-      "community": 278
+      "community": 279
     },
     {
       "label": "ensureLegacyMemoryEmbeddingColumns()",
@@ -11313,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L36",
       "id": "init_legacy_schema_ensurelegacymemoryembeddingcolumns",
-      "community": 278
+      "community": 279
     },
     {
       "label": "ensureLegacyEmbeddingModelRegistryProjectionType()",
@@ -11321,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L135",
       "id": "init_legacy_schema_ensurelegacyembeddingmodelregistryprojectiontype",
-      "community": 278
+      "community": 279
     },
     {
       "label": "reconcileMisalignedVecTables()",
@@ -11329,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L165",
       "id": "init_legacy_schema_reconcilemisalignedvectables",
-      "community": 278
+      "community": 279
     },
     {
       "label": "ensureLegacySchema()",
@@ -11337,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L217",
       "id": "init_legacy_schema_ensurelegacyschema",
-      "community": 278
+      "community": 279
     },
     {
       "label": "populateVecTables()",
@@ -11345,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-legacy-schema.ts",
       "source_location": "L235",
       "id": "init_legacy_schema_populatevectables",
-      "community": 278
+      "community": 279
     },
     {
       "label": "migrate.ts",
@@ -11353,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 593
+      "community": 595
     },
     {
       "label": "isDuplicateColumnError()",
@@ -11361,7 +11393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 593
+      "community": 595
     },
     {
       "label": "migrateDatabase()",
@@ -11369,7 +11401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 593
+      "community": 595
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -11481,7 +11513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_ts",
-      "community": 279
+      "community": 280
     },
     {
       "label": "MigrationDetector",
@@ -11489,7 +11521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L63",
       "id": "migration_detector_migrationdetector",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".constructor()",
@@ -11497,7 +11529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L66",
       "id": "migration_detector_migrationdetector_constructor",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".detectAllMigrations()",
@@ -11505,7 +11537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L73",
       "id": "migration_detector_migrationdetector_detectallmigrations",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".detectPendingMigrations()",
@@ -11513,7 +11545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L177",
       "id": "migration_detector_migrationdetector_detectpendingmigrations",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".parseVersionNumber()",
@@ -11521,7 +11553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L208",
       "id": "migration_detector_migrationdetector_parseversionnumber",
-      "community": 279
+      "community": 280
     },
     {
       "label": ".findMigrationByVersion()",
@@ -11529,7 +11561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.ts",
       "source_location": "L222",
       "id": "migration_detector_migrationdetector_findmigrationbyversion",
-      "community": 279
+      "community": 280
     },
     {
       "label": "migration-logger.ts",
@@ -12153,7 +12185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_ts",
-      "community": 227
+      "community": 228
     },
     {
       "label": "ProcessAttributeTableMigration",
@@ -12161,7 +12193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L17",
       "id": "020_process_attribute_table_processattributetablemigration",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".tableExists()",
@@ -12169,7 +12201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L22",
       "id": "020_process_attribute_table_processattributetablemigration_tableexists",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".columnExists()",
@@ -12177,7 +12209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L29",
       "id": "020_process_attribute_table_processattributetablemigration_columnexists",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".validateBefore()",
@@ -12185,7 +12217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L34",
       "id": "020_process_attribute_table_processattributetablemigration_validatebefore",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".up()",
@@ -12193,7 +12225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L49",
       "id": "020_process_attribute_table_processattributetablemigration_up",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".down()",
@@ -12201,7 +12233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L62",
       "id": "020_process_attribute_table_processattributetablemigration_down",
-      "community": 227
+      "community": 228
     },
     {
       "label": ".validateAfter()",
@@ -12209,7 +12241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.ts",
       "source_location": "L69",
       "id": "020_process_attribute_table_processattributetablemigration_validateafter",
-      "community": 227
+      "community": 228
     },
     {
       "label": "017-fact-metadata-fields.ts",
@@ -12289,7 +12321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_ts",
-      "community": 228
+      "community": 229
     },
     {
       "label": "AddProjectIdMigration",
@@ -12297,7 +12329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L8",
       "id": "032_add_project_id_addprojectidmigration",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".columnExists()",
@@ -12305,7 +12337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L13",
       "id": "032_add_project_id_addprojectidmigration_columnexists",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".indexExists()",
@@ -12313,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L18",
       "id": "032_add_project_id_addprojectidmigration_indexexists",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".validateBefore()",
@@ -12321,7 +12353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L25",
       "id": "032_add_project_id_addprojectidmigration_validatebefore",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".up()",
@@ -12329,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L27",
       "id": "032_add_project_id_addprojectidmigration_up",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".down()",
@@ -12337,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L40",
       "id": "032_add_project_id_addprojectidmigration_down",
-      "community": 228
+      "community": 229
     },
     {
       "label": ".validateAfter()",
@@ -12345,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.ts",
       "source_location": "L44",
       "id": "032_add_project_id_addprojectidmigration_validateafter",
-      "community": 228
+      "community": 229
     },
     {
       "label": "016-memory-item-attribution.spec.ts",
@@ -12553,7 +12585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_ts",
-      "community": 229
+      "community": 230
     },
     {
       "label": "MemoryReviewCandidateSchemaMigration",
@@ -12561,7 +12593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".tableExists()",
@@ -12569,7 +12601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L14",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_tableexists",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".indexExists()",
@@ -12577,7 +12609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_indexexists",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".validateBefore()",
@@ -12585,7 +12617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L28",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_validatebefore",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".up()",
@@ -12593,7 +12625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L34",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_up",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".down()",
@@ -12601,7 +12633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L69",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_down",
-      "community": 229
+      "community": 230
     },
     {
       "label": ".validateAfter()",
@@ -12609,7 +12641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.ts",
       "source_location": "L78",
       "id": "033_memory_review_candidate_schema_memoryreviewcandidateschemamigration_validateafter",
-      "community": 229
+      "community": 230
     },
     {
       "label": "029-telemetry-events-event-type-created-at-index.ts",
@@ -12617,7 +12649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_029_telemetry_events_event_type_created_at_index_ts",
-      "community": 230
+      "community": 231
     },
     {
       "label": "TelemetryEventsEventTypeCreatedAtIndexMigration",
@@ -12625,7 +12657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L9",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".tableExists()",
@@ -12633,7 +12665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L15",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_tableexists",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".indexExists()",
@@ -12641,7 +12673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L22",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_indexexists",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".validateBefore()",
@@ -12649,7 +12681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L29",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_validatebefore",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".up()",
@@ -12657,7 +12689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L31",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_up",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".down()",
@@ -12665,7 +12697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L40",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_down",
-      "community": 230
+      "community": 231
     },
     {
       "label": ".validateAfter()",
@@ -12673,7 +12705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/029-telemetry-events-event-type-created-at-index.ts",
       "source_location": "L47",
       "id": "029_telemetry_events_event_type_created_at_index_telemetryeventseventtypecreatedatindexmigration_validateafter",
-      "community": 230
+      "community": 231
     },
     {
       "label": "026-flip-consolidation-relation-directions.ts",
@@ -12857,7 +12889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_ts",
-      "community": 280
+      "community": 281
     },
     {
       "label": "objectExists()",
@@ -12865,7 +12897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L84",
       "id": "035_agent_integration_schema_objectexists",
-      "community": 280
+      "community": 281
     },
     {
       "label": "AgentIntegrationSchemaMigration",
@@ -12873,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L90",
       "id": "035_agent_integration_schema_agentintegrationschemamigration",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".validateBefore()",
@@ -12881,7 +12913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L95",
       "id": "035_agent_integration_schema_agentintegrationschemamigration_validatebefore",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".up()",
@@ -12889,7 +12921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L101",
       "id": "035_agent_integration_schema_agentintegrationschemamigration_up",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".down()",
@@ -12897,7 +12929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L105",
       "id": "035_agent_integration_schema_agentintegrationschemamigration_down",
-      "community": 280
+      "community": 281
     },
     {
       "label": ".validateAfter()",
@@ -12905,7 +12937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.ts",
       "source_location": "L129",
       "id": "035_agent_integration_schema_agentintegrationschemamigration_validateafter",
-      "community": 280
+      "community": 281
     },
     {
       "label": "012-fix-tfidf-dimension-trigger.ts",
@@ -12913,7 +12945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_012_fix_tfidf_dimension_trigger_ts",
-      "community": 231
+      "community": 232
     },
     {
       "label": "FixTfidfDimensionTriggerMigration",
@@ -12921,7 +12953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L26",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".triggerExists()",
@@ -12929,7 +12961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L37",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_triggerexists",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".tableExists()",
@@ -12937,7 +12969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L53",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_tableexists",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".validateBefore()",
@@ -12945,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L66",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_validatebefore",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".up()",
@@ -12953,7 +12985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L100",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_up",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".down()",
@@ -12961,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L224",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_down",
-      "community": 231
+      "community": 232
     },
     {
       "label": ".validateAfter()",
@@ -12969,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/012-fix-tfidf-dimension-trigger.ts",
       "source_location": "L298",
       "id": "012_fix_tfidf_dimension_trigger_fixtfidfdimensiontriggermigration_validateafter",
-      "community": 231
+      "community": 232
     },
     {
       "label": "011-meta-memory-stats-schema.spec.ts",
@@ -13073,7 +13105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_ts",
-      "community": 281
+      "community": 282
     },
     {
       "label": "BackfillKgTripleFromMemoryItemMigration",
@@ -13081,7 +13113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration",
-      "community": 281
+      "community": 282
     },
     {
       "label": ".tableExists()",
@@ -13089,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L23",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_tableexists",
-      "community": 281
+      "community": 282
     },
     {
       "label": ".validateBefore()",
@@ -13097,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L30",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validatebefore",
-      "community": 281
+      "community": 282
     },
     {
       "label": ".up()",
@@ -13105,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L47",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_up",
-      "community": 281
+      "community": 282
     },
     {
       "label": ".down()",
@@ -13113,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L94",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_down",
-      "community": 281
+      "community": 282
     },
     {
       "label": ".validateAfter()",
@@ -13121,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.ts",
       "source_location": "L101",
       "id": "019_backfill_kg_triple_from_memory_item_backfillkgtriplefrommemoryitemmigration_validateafter",
-      "community": 281
+      "community": 282
     },
     {
       "label": "023-feedback-event-score-breakdown.ts",
@@ -13129,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_023_feedback_event_score_breakdown_ts",
-      "community": 232
+      "community": 233
     },
     {
       "label": "FeedbackEventScoreBreakdownMigration",
@@ -13137,7 +13169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L9",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".tableExists()",
@@ -13145,7 +13177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L14",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_tableexists",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".columnExists()",
@@ -13153,7 +13185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L21",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_columnexists",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".validateBefore()",
@@ -13161,7 +13193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L26",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_validatebefore",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".up()",
@@ -13169,7 +13201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L28",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_up",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".down()",
@@ -13177,7 +13209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L37",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_down",
-      "community": 232
+      "community": 233
     },
     {
       "label": ".validateAfter()",
@@ -13185,7 +13217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/023-feedback-event-score-breakdown.ts",
       "source_location": "L48",
       "id": "023_feedback_event_score_breakdown_feedbackeventscorebreakdownmigration_validateafter",
-      "community": 232
+      "community": 233
     },
     {
       "label": "007-procedural-memory-enhancement.ts",
@@ -13657,7 +13689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 594
+      "community": 596
     },
     {
       "label": "createMemoryItemTable()",
@@ -13665,7 +13697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 594
+      "community": 596
     },
     {
       "label": "tableExists()",
@@ -13673,7 +13705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 594
+      "community": 596
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -13729,7 +13761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_022_feedback_event_comment_ts",
-      "community": 233
+      "community": 234
     },
     {
       "label": "FeedbackEventCommentMigration",
@@ -13737,7 +13769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L9",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".tableExists()",
@@ -13745,7 +13777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L14",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_tableexists",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".columnExists()",
@@ -13753,7 +13785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L21",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_columnexists",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".validateBefore()",
@@ -13761,7 +13793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L26",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_validatebefore",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".up()",
@@ -13769,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L28",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_up",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".down()",
@@ -13777,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L37",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_down",
-      "community": 233
+      "community": 234
     },
     {
       "label": ".validateAfter()",
@@ -13785,7 +13817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/022-feedback-event-comment.ts",
       "source_location": "L48",
       "id": "022_feedback_event_comment_feedbackeventcommentmigration_validateafter",
-      "community": 233
+      "community": 234
     },
     {
       "label": "011-meta-memory-stats-schema.ts",
@@ -13913,7 +13945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 595
+      "community": 597
     },
     {
       "label": "createMemoryItemTable()",
@@ -13921,7 +13953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 595
+      "community": 597
     },
     {
       "label": "tableExists()",
@@ -13929,7 +13961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 595
+      "community": 597
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -14257,7 +14289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_ts",
-      "community": 282
+      "community": 283
     },
     {
       "label": "objectExists()",
@@ -14265,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L33",
       "id": "036_agent_memory_promotion_schema_objectexists",
-      "community": 282
+      "community": 283
     },
     {
       "label": "AgentMemoryPromotionSchemaMigration",
@@ -14273,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L39",
       "id": "036_agent_memory_promotion_schema_agentmemorypromotionschemamigration",
-      "community": 282
+      "community": 283
     },
     {
       "label": ".validateBefore()",
@@ -14281,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L44",
       "id": "036_agent_memory_promotion_schema_agentmemorypromotionschemamigration_validatebefore",
-      "community": 282
+      "community": 283
     },
     {
       "label": ".up()",
@@ -14289,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L52",
       "id": "036_agent_memory_promotion_schema_agentmemorypromotionschemamigration_up",
-      "community": 282
+      "community": 283
     },
     {
       "label": ".down()",
@@ -14297,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L56",
       "id": "036_agent_memory_promotion_schema_agentmemorypromotionschemamigration_down",
-      "community": 282
+      "community": 283
     },
     {
       "label": ".validateAfter()",
@@ -14305,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.ts",
       "source_location": "L73",
       "id": "036_agent_memory_promotion_schema_agentmemorypromotionschemamigration_validateafter",
-      "community": 282
+      "community": 283
     },
     {
       "label": "027-telemetry-events.ts",
@@ -14361,7 +14393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_ts",
-      "community": 234
+      "community": 235
     },
     {
       "label": "ProceduralVersionFieldsMigration",
@@ -14369,7 +14401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L18",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".columnExists()",
@@ -14377,7 +14409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L23",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_columnexists",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".tableExists()",
@@ -14385,7 +14417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L28",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_tableexists",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".validateBefore()",
@@ -14393,7 +14425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L35",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_validatebefore",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".up()",
@@ -14401,7 +14433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L55",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_up",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".down()",
@@ -14409,7 +14441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L143",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_down",
-      "community": 234
+      "community": 235
     },
     {
       "label": ".validateAfter()",
@@ -14417,7 +14449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.ts",
       "source_location": "L161",
       "id": "013_procedural_version_fields_proceduralversionfieldsmigration_validateafter",
-      "community": 234
+      "community": 235
     },
     {
       "label": "015-memory-item-owner-id.spec.ts",
@@ -14705,7 +14737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_024_feedback_event_memory_created_at_index_ts",
-      "community": 235
+      "community": 236
     },
     {
       "label": "FeedbackEventMemoryCreatedAtIndexMigration",
@@ -14713,7 +14745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L9",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".tableExists()",
@@ -14721,7 +14753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L15",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_tableexists",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".indexExists()",
@@ -14729,7 +14761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L22",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_indexexists",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".validateBefore()",
@@ -14737,7 +14769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L29",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_validatebefore",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".up()",
@@ -14745,7 +14777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L31",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_up",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".down()",
@@ -14753,7 +14785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L40",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_down",
-      "community": 235
+      "community": 236
     },
     {
       "label": ".validateAfter()",
@@ -14761,7 +14793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/024-feedback-event-memory-created-at-index.ts",
       "source_location": "L47",
       "id": "024_feedback_event_memory_created_at_index_feedbackeventmemorycreatedatindexmigration_validateafter",
-      "community": 235
+      "community": 236
     },
     {
       "label": "035-agent-integration-schema.spec.ts",
@@ -14777,7 +14809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_ts",
-      "community": 236
+      "community": 237
     },
     {
       "label": "ReviewQueueHealthSnapshotMigration",
@@ -14785,7 +14817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L8",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".tableExists()",
@@ -14793,7 +14825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L14",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_tableexists",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".indexExists()",
@@ -14801,7 +14833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L21",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_indexexists",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".validateBefore()",
@@ -14809,7 +14841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L28",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_validatebefore",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".up()",
@@ -14817,7 +14849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L36",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_up",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".down()",
@@ -14825,7 +14857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L65",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_down",
-      "community": 236
+      "community": 237
     },
     {
       "label": ".validateAfter()",
@@ -14833,7 +14865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.ts",
       "source_location": "L73",
       "id": "034_review_queue_health_snapshot_reviewqueuehealthsnapshotmigration_validateafter",
-      "community": 236
+      "community": 237
     },
     {
       "label": "010-add-core-memory-version.spec.ts",
@@ -14993,7 +15025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 596
+      "community": 598
     },
     {
       "label": "createBaseSchema()",
@@ -15001,7 +15033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L8",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 596
+      "community": 598
     },
     {
       "label": "createMemoryLinkTable()",
@@ -15009,7 +15041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L109",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 596
+      "community": 598
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -15321,7 +15353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_sqlite_agent_integration_repository_spec_ts",
-      "community": 597
+      "community": 599
     },
     {
       "label": "createSession()",
@@ -15329,7 +15361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L27",
       "id": "sqlite_agent_integration_repository_spec_createsession",
-      "community": 597
+      "community": 599
     },
     {
       "label": "createObservation()",
@@ -15337,7 +15369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L59",
       "id": "sqlite_agent_integration_repository_spec_createobservation",
-      "community": 597
+      "community": 599
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -15729,7 +15761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_process_attribute_repository_sqlite_impl_ts",
-      "community": 283
+      "community": 284
     },
     {
       "label": "parseJsonArray()",
@@ -15737,7 +15769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L14",
       "id": "process_attribute_repository_sqlite_impl_parsejsonarray",
-      "community": 283
+      "community": 284
     },
     {
       "label": "stringifyJsonArray()",
@@ -15745,7 +15777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L24",
       "id": "process_attribute_repository_sqlite_impl_stringifyjsonarray",
-      "community": 283
+      "community": 284
     },
     {
       "label": "ProcessAttributeRepositorySqlite",
@@ -15753,7 +15785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L32",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite",
-      "community": 283
+      "community": 284
     },
     {
       "label": ".constructor()",
@@ -15761,7 +15793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L35",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_constructor",
-      "community": 283
+      "community": 284
     },
     {
       "label": ".getByProcessId()",
@@ -15769,7 +15801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L42",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_getbyprocessid",
-      "community": 283
+      "community": 284
     },
     {
       "label": ".upsert()",
@@ -15777,7 +15809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/process-attribute-repository-sqlite.impl.ts",
       "source_location": "L63",
       "id": "process_attribute_repository_sqlite_impl_processattributerepositorysqlite_upsert",
-      "community": 283
+      "community": 284
     },
     {
       "label": "knowledge-vault-repository-sqlite.impl.ts",
@@ -16345,7 +16377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_agent_integration_provenance_store_ts",
-      "community": 284
+      "community": 285
     },
     {
       "label": "AgentIntegrationProvenanceStore",
@@ -16353,7 +16385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L5",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore",
-      "community": 284
+      "community": 285
     },
     {
       "label": ".constructor()",
@@ -16361,7 +16393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L6",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore_constructor",
-      "community": 284
+      "community": 285
     },
     {
       "label": ".create()",
@@ -16369,7 +16401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L8",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore_create",
-      "community": 284
+      "community": 285
     },
     {
       "label": ".list()",
@@ -16377,7 +16409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L33",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore_list",
-      "community": 284
+      "community": 285
     },
     {
       "label": ".listForSession()",
@@ -16385,7 +16417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L55",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore_listforsession",
-      "community": 284
+      "community": 285
     },
     {
       "label": ".markSourceDeleted()",
@@ -16393,7 +16425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/agent-integration-provenance-store.ts",
       "source_location": "L67",
       "id": "agent_integration_provenance_store_agentintegrationprovenancestore_marksourcedeleted",
-      "community": 284
+      "community": 285
     },
     {
       "label": "core-memory-repository-sqlite.impl.spec.ts",
@@ -17217,7 +17249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 598
+      "community": 600
     },
     {
       "label": "readRunDetails()",
@@ -17225,7 +17257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L15",
       "id": "memory_review_candidates_run_diagnostics_readrundetails",
-      "community": 598
+      "community": 600
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -17233,7 +17265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L46",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 598
+      "community": 600
     },
     {
       "label": "relation-validator-executor.ts",
@@ -17385,7 +17417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_execution_coordinator_ts",
-      "community": 237
+      "community": 238
     },
     {
       "label": "BatchJobExecutionCoordinator",
@@ -17393,7 +17425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L27",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".constructor()",
@@ -17401,7 +17433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L28",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_constructor",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".addJobToQueue()",
@@ -17409,7 +17441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L30",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_addjobtoqueue",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".afterEnqueueAttempt()",
@@ -17417,7 +17449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L37",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_afterenqueueattempt",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".startJobProcessor()",
@@ -17425,7 +17457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L72",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_startjobprocessor",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".executeJobWithRetry()",
@@ -17433,7 +17465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L94",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_executejobwithretry",
-      "community": 237
+      "community": 238
     },
     {
       "label": ".executeWithTimeout()",
@@ -17441,7 +17473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-execution-coordinator.ts",
       "source_location": "L237",
       "id": "batch_job_execution_coordinator_batchjobexecutioncoordinator_executewithtimeout",
-      "community": 237
+      "community": 238
     },
     {
       "label": "file-logger.ts",
@@ -17801,7 +17833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
-      "community": 599
+      "community": 601
     },
     {
       "label": "createBaseSchema()",
@@ -17809,7 +17841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L12",
       "id": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
-      "community": 599
+      "community": 601
     },
     {
       "label": "createContext()",
@@ -17817,7 +17849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L41",
       "id": "batch_scheduler_review_meta_handlers_spec_createcontext",
-      "community": 599
+      "community": 601
     },
     {
       "label": "batch-scheduler-anchor-handlers.ts",
@@ -17889,7 +17921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 600
+      "community": 602
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -17897,7 +17929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 600
+      "community": 602
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -17905,7 +17937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 600
+      "community": 602
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -17913,7 +17945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 601
+      "community": 603
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -17921,7 +17953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 601
+      "community": 603
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -17929,7 +17961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 601
+      "community": 603
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -18161,7 +18193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_concurrency_queue_spec_ts",
-      "community": 285
+      "community": 286
     },
     {
       "label": "longRunningJob()",
@@ -18169,7 +18201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L376",
       "id": "concurrency_queue_spec_longrunningjob",
-      "community": 285
+      "community": 286
     },
     {
       "label": "testJob()",
@@ -18177,7 +18209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L472",
       "id": "concurrency_queue_spec_testjob",
-      "community": 285
+      "community": 286
     },
     {
       "label": "highPriorityJob()",
@@ -18185,7 +18217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L526",
       "id": "concurrency_queue_spec_highpriorityjob",
-      "community": 285
+      "community": 286
     },
     {
       "label": "immediateJob()",
@@ -18193,7 +18225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L529",
       "id": "concurrency_queue_spec_immediatejob",
-      "community": 285
+      "community": 286
     },
     {
       "label": "failingJob()",
@@ -18201,7 +18233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L620",
       "id": "concurrency_queue_spec_failingjob",
-      "community": 285
+      "community": 286
     },
     {
       "label": "jobWithRetryCount()",
@@ -18209,7 +18241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/concurrency-queue.spec.ts",
       "source_location": "L667",
       "id": "concurrency_queue_spec_jobwithretrycount",
-      "community": 285
+      "community": 286
     },
     {
       "label": "run-job.spec.ts",
@@ -18449,7 +18481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 602
+      "community": 604
     },
     {
       "label": "generateId()",
@@ -18457,7 +18489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 602
+      "community": 604
     },
     {
       "label": "initializeTestDatabase()",
@@ -18465,7 +18497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 602
+      "community": 604
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -18489,7 +18521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 603
+      "community": 605
     },
     {
       "label": "generateId()",
@@ -18497,7 +18529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 603
+      "community": 605
     },
     {
       "label": "initializeTestDatabase()",
@@ -18505,7 +18537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 603
+      "community": 605
     },
     {
       "label": "triple-extraction-batch-job-chunk.ts",
@@ -18513,7 +18545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_chunk_ts",
-      "community": 604
+      "community": 606
     },
     {
       "label": "splitTripleExtractionIntoChunks()",
@@ -18521,7 +18553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L25",
       "id": "triple_extraction_batch_job_chunk_splittripleextractionintochunks",
-      "community": 604
+      "community": 606
     },
     {
       "label": "processTripleExtractionChunk()",
@@ -18529,7 +18561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L42",
       "id": "triple_extraction_batch_job_chunk_processtripleextractionchunk",
-      "community": 604
+      "community": 606
     },
     {
       "label": "triple-extraction-batch-job.types.ts",
@@ -18553,7 +18585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_memory_status_ts",
-      "community": 605
+      "community": 607
     },
     {
       "label": "updateTripleExtractionMemoryStatus()",
@@ -18561,7 +18593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L8",
       "id": "triple_extraction_batch_job_memory_status_updatetripleextractionmemorystatus",
-      "community": 605
+      "community": 607
     },
     {
       "label": "calculateTripleExtractionAverageConfidence()",
@@ -18569,7 +18601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L43",
       "id": "triple_extraction_batch_job_memory_status_calculatetripleextractionaverageconfidence",
-      "community": 605
+      "community": 607
     },
     {
       "label": "triple-extraction-batch-job-retry.ts",
@@ -18641,7 +18673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_diagnostics_ts",
-      "community": 606
+      "community": 608
     },
     {
       "label": "writeBatchSchedulerDiagnosticsEvent()",
@@ -18649,7 +18681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L6",
       "id": "batch_scheduler_diagnostics_writebatchschedulerdiagnosticsevent",
-      "community": 606
+      "community": 608
     },
     {
       "label": "emitMemoryReviewCandidatesRunRecord()",
@@ -18657,7 +18689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L28",
       "id": "batch_scheduler_diagnostics_emitmemoryreviewcandidatesrunrecord",
-      "community": 606
+      "community": 608
     },
     {
       "label": "batch-scheduler-singleton.ts",
@@ -18729,7 +18761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_lifecycle_ts",
-      "community": 607
+      "community": 609
     },
     {
       "label": "startBatchScheduler()",
@@ -18737,7 +18769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L30",
       "id": "batch_scheduler_lifecycle_startbatchscheduler",
-      "community": 607
+      "community": 609
     },
     {
       "label": "stopBatchScheduler()",
@@ -18745,7 +18777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L76",
       "id": "batch_scheduler_lifecycle_stopbatchscheduler",
-      "community": 607
+      "community": 609
     },
     {
       "label": "batch-scheduler-stats.ts",
@@ -18769,7 +18801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_interval_ts",
-      "community": 608
+      "community": 610
     },
     {
       "label": "scheduleBatchJob()",
@@ -18777,7 +18809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L16",
       "id": "batch_scheduler_interval_schedulebatchjob",
-      "community": 608
+      "community": 610
     },
     {
       "label": "waitForRunningBatchJobs()",
@@ -18785,7 +18817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L36",
       "id": "batch_scheduler_interval_waitforrunningbatchjobs",
-      "community": 608
+      "community": 610
     },
     {
       "label": "batch-scheduler-job-runners.ts",
@@ -18793,7 +18825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_job_runners_ts",
-      "community": 609
+      "community": 611
     },
     {
       "label": "createBatchSchedulerJobRunners()",
@@ -18801,7 +18833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L39",
       "id": "batch_scheduler_job_runners_createbatchschedulerjobrunners",
-      "community": 609
+      "community": 611
     },
     {
       "label": "runManualBatchSchedulerJob()",
@@ -18809,7 +18841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L61",
       "id": "batch_scheduler_job_runners_runmanualbatchschedulerjob",
-      "community": 609
+      "community": 611
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -18841,7 +18873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_external_api_retry_logging_ts",
-      "community": 610
+      "community": 612
     },
     {
       "label": "isTransientCapacityError()",
@@ -18849,7 +18881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L21",
       "id": "external_api_retry_logging_istransientcapacityerror",
-      "community": 610
+      "community": 612
     },
     {
       "label": "logExternalApiRetry()",
@@ -18857,7 +18889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L26",
       "id": "external_api_retry_logging_logexternalapiretry",
-      "community": 610
+      "community": 612
     },
     {
       "label": "stopwords.spec.ts",
@@ -18945,7 +18977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 611
+      "community": 613
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -18953,7 +18985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L39",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 611
+      "community": 613
     },
     {
       "label": ".extract()",
@@ -18961,7 +18993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L40",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 611
+      "community": 613
     },
     {
       "label": "sql-security-validator.ts",
@@ -18969,7 +19001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 612
+      "community": 614
     },
     {
       "label": "validateTableName()",
@@ -18977,7 +19009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 612
+      "community": 614
     },
     {
       "label": "getVectorTableName()",
@@ -18985,7 +19017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 612
+      "community": 614
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -19057,7 +19089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_normalize_ts",
-      "community": 286
+      "community": 287
     },
     {
       "label": "normalizeReflectionNoteObject()",
@@ -19065,7 +19097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L42",
       "id": "reflection_notes_normalize_normalizereflectionnoteobject",
-      "community": 286
+      "community": 287
     },
     {
       "label": "isKeyTokenField()",
@@ -19073,7 +19105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L82",
       "id": "reflection_notes_normalize_iskeytokenfield",
-      "community": 286
+      "community": 287
     },
     {
       "label": "isExcludedField()",
@@ -19081,7 +19113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L86",
       "id": "reflection_notes_normalize_isexcludedfield",
-      "community": 286
+      "community": 287
     },
     {
       "label": "normalizeReflectionNotes()",
@@ -19089,7 +19121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L108",
       "id": "reflection_notes_normalize_normalizereflectionnotes",
-      "community": 286
+      "community": 287
     },
     {
       "label": "extractKeyTokens()",
@@ -19097,7 +19129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L151",
       "id": "reflection_notes_normalize_extractkeytokens",
-      "community": 286
+      "community": 287
     },
     {
       "label": "getSearchQueryExamples()",
@@ -19105,7 +19137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-normalize.ts",
       "source_location": "L168",
       "id": "reflection_notes_normalize_getsearchqueryexamples",
-      "community": 286
+      "community": 287
     },
     {
       "label": "relation-type-converter.ts",
@@ -19185,7 +19217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_ts",
-      "community": 287
+      "community": 288
     },
     {
       "label": "normalizeJson()",
@@ -19193,7 +19225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L104",
       "id": "procedural_memory_change_detector_normalizejson",
-      "community": 287
+      "community": 288
     },
     {
       "label": "computeJsonHash()",
@@ -19201,7 +19233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L168",
       "id": "procedural_memory_change_detector_computejsonhash",
-      "community": 287
+      "community": 288
     },
     {
       "label": "computeReflectionNotesCount()",
@@ -19209,7 +19241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L221",
       "id": "procedural_memory_change_detector_computereflectionnotescount",
-      "community": 287
+      "community": 288
     },
     {
       "label": "createProceduralMemorySnapshot()",
@@ -19217,7 +19249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L254",
       "id": "procedural_memory_change_detector_createproceduralmemorysnapshot",
-      "community": 287
+      "community": 288
     },
     {
       "label": "isEqual()",
@@ -19225,7 +19257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L325",
       "id": "procedural_memory_change_detector_isequal",
-      "community": 287
+      "community": 288
     },
     {
       "label": "hasProceduralMemoryChanged()",
@@ -19233,7 +19265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.ts",
       "source_location": "L357",
       "id": "procedural_memory_change_detector_hasproceduralmemorychanged",
-      "community": 287
+      "community": 288
     },
     {
       "label": "logging-rate-limiter.ts",
@@ -19313,7 +19345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_ts",
-      "community": 288
+      "community": 289
     },
     {
       "label": "isValidMemoryType()",
@@ -19321,7 +19353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L18",
       "id": "type_param_validator_isvalidmemorytype",
-      "community": 288
+      "community": 289
     },
     {
       "label": "validateTypeParam()",
@@ -19329,7 +19361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L37",
       "id": "type_param_validator_validatetypeparam",
-      "community": 288
+      "community": 289
     },
     {
       "label": "parseTypeParamMode()",
@@ -19337,7 +19369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L103",
       "id": "type_param_validator_parsetypeparammode",
-      "community": 288
+      "community": 289
     },
     {
       "label": "validateTriggerConditions()",
@@ -19345,7 +19377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L129",
       "id": "type_param_validator_validatetriggerconditions",
-      "community": 288
+      "community": 289
     },
     {
       "label": "validateWorkflowOrSkillName()",
@@ -19353,7 +19385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L171",
       "id": "type_param_validator_validateworkfloworskillname",
-      "community": 288
+      "community": 289
     },
     {
       "label": "validateProceduralMemoryFields()",
@@ -19361,7 +19393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.ts",
       "source_location": "L197",
       "id": "type_param_validator_validateproceduralmemoryfields",
-      "community": 288
+      "community": 289
     },
     {
       "label": "procedural-memory-similarity.ts",
@@ -19425,7 +19457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_visualizer_ts",
-      "community": 238
+      "community": 239
     },
     {
       "label": "escapeDotString()",
@@ -19433,7 +19465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L12",
       "id": "relation_visualizer_escapedotstring",
-      "community": 238
+      "community": 239
     },
     {
       "label": "RelationVisualizer",
@@ -19441,7 +19473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L68",
       "id": "relation_visualizer_relationvisualizer",
-      "community": 238
+      "community": 239
     },
     {
       "label": ".visualizeAsText()",
@@ -19449,7 +19481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L76",
       "id": "relation_visualizer_relationvisualizer_visualizeastext",
-      "community": 238
+      "community": 239
     },
     {
       "label": ".visualizeSubgraph()",
@@ -19457,7 +19489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L140",
       "id": "relation_visualizer_relationvisualizer_visualizesubgraph",
-      "community": 238
+      "community": 239
     },
     {
       "label": ".visualizeSimple()",
@@ -19465,7 +19497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L324",
       "id": "relation_visualizer_relationvisualizer_visualizesimple",
-      "community": 238
+      "community": 239
     },
     {
       "label": ".visualizeAsJSON()",
@@ -19473,7 +19505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L346",
       "id": "relation_visualizer_relationvisualizer_visualizeasjson",
-      "community": 238
+      "community": 239
     },
     {
       "label": ".visualizeAsDot()",
@@ -19481,7 +19513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-visualizer.ts",
       "source_location": "L368",
       "id": "relation_visualizer_relationvisualizer_visualizeasdot",
-      "community": 238
+      "community": 239
     },
     {
       "label": "fts5-migration-status.ts",
@@ -19825,7 +19857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 613
+      "community": 615
     },
     {
       "label": "issue()",
@@ -19833,7 +19865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L42",
       "id": "configuration_validator_issue",
-      "community": 613
+      "community": 615
     },
     {
       "label": "validateConfiguration()",
@@ -19841,7 +19873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L46",
       "id": "configuration_validator_validateconfiguration",
-      "community": 613
+      "community": 615
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -19905,7 +19937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 614
+      "community": 616
     },
     {
       "label": "transactionFn()",
@@ -19913,7 +19945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 614
+      "community": 616
     },
     {
       "label": "outerTransaction()",
@@ -19921,7 +19953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 614
+      "community": 616
     },
     {
       "label": "write-coalescing.ts",
@@ -20049,7 +20081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_path_validator_ts",
-      "community": 289
+      "community": 290
     },
     {
       "label": "getAllowedDirs()",
@@ -20057,7 +20089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L22",
       "id": "path_validator_getalloweddirs",
-      "community": 289
+      "community": 290
     },
     {
       "label": "isAbsolutePath()",
@@ -20065,7 +20097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L45",
       "id": "path_validator_isabsolutepath",
-      "community": 289
+      "community": 290
     },
     {
       "label": "containsPathTraversal()",
@@ -20073,7 +20105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L55",
       "id": "path_validator_containspathtraversal",
-      "community": 289
+      "community": 290
     },
     {
       "label": "isWithinAllowedDirs()",
@@ -20081,7 +20113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L78",
       "id": "path_validator_iswithinalloweddirs",
-      "community": 289
+      "community": 290
     },
     {
       "label": "validateFilePath()",
@@ -20089,7 +20121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L117",
       "id": "path_validator_validatefilepath",
-      "community": 289
+      "community": 290
     },
     {
       "label": "sanitizeFileName()",
@@ -20097,7 +20129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/path-validator.ts",
       "source_location": "L159",
       "id": "path_validator_sanitizefilename",
-      "community": 289
+      "community": 290
     },
     {
       "label": "ensure-memory-review-candidate-schema.ts",
@@ -20153,7 +20185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_ts",
-      "community": 239
+      "community": 240
     },
     {
       "label": "getObjectSize()",
@@ -20161,7 +20193,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L55",
       "id": "reflection_notes_merge_getobjectsize",
-      "community": 239
+      "community": 240
     },
     {
       "label": "validateSingleObjectSize()",
@@ -20169,7 +20201,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L70",
       "id": "reflection_notes_merge_validatesingleobjectsize",
-      "community": 239
+      "community": 240
     },
     {
       "label": "limitArraySize()",
@@ -20177,7 +20209,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L85",
       "id": "reflection_notes_merge_limitarraysize",
-      "community": 239
+      "community": 240
     },
     {
       "label": "validateAndCleanupTotalSize()",
@@ -20185,7 +20217,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L109",
       "id": "reflection_notes_merge_validateandcleanuptotalsize",
-      "community": 239
+      "community": 240
     },
     {
       "label": "normalizeNewReflectionNotes()",
@@ -20193,7 +20225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L167",
       "id": "reflection_notes_merge_normalizenewreflectionnotes",
-      "community": 239
+      "community": 240
     },
     {
       "label": "mergeReflectionNotes()",
@@ -20201,7 +20233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L207",
       "id": "reflection_notes_merge_mergereflectionnotes",
-      "community": 239
+      "community": 240
     },
     {
       "label": "serializeReflectionNotes()",
@@ -20209,7 +20241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.ts",
       "source_location": "L286",
       "id": "reflection_notes_merge_serializereflectionnotes",
-      "community": 239
+      "community": 240
     },
     {
       "label": "prompt-template-loader.ts",
@@ -20217,7 +20249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_prompt_template_loader_ts",
-      "community": 290
+      "community": 291
     },
     {
       "label": "PromptTemplateLoader",
@@ -20225,7 +20257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L29",
       "id": "prompt_template_loader_prompttemplateloader",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".loadTemplate()",
@@ -20233,7 +20265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L40",
       "id": "prompt_template_loader_prompttemplateloader_loadtemplate",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".renderTemplate()",
@@ -20241,7 +20273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L76",
       "id": "prompt_template_loader_prompttemplateloader_rendertemplate",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".loadAndRender()",
@@ -20249,7 +20281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L95",
       "id": "prompt_template_loader_prompttemplateloader_loadandrender",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".clearCache()",
@@ -20257,7 +20289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L103",
       "id": "prompt_template_loader_prompttemplateloader_clearcache",
-      "community": 290
+      "community": 291
     },
     {
       "label": ".getTemplatePath()",
@@ -20265,7 +20297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/prompt-template-loader.ts",
       "source_location": "L113",
       "id": "prompt_template_loader_prompttemplateloader_gettemplatepath",
-      "community": 290
+      "community": 291
     },
     {
       "label": "logger.ts",
@@ -20369,7 +20401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 615
+      "community": 617
     },
     {
       "label": "createValidReflectionNote()",
@@ -20377,7 +20409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 615
+      "community": 617
     },
     {
       "label": "createLargeNote()",
@@ -20385,7 +20417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 615
+      "community": 617
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -20569,7 +20601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_pii_masker_ts",
-      "community": 240
+      "community": 241
     },
     {
       "label": "isPIIMaskingEnabled()",
@@ -20577,7 +20609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L53",
       "id": "pii_masker_ispiimaskingenabled",
-      "community": 240
+      "community": 241
     },
     {
       "label": "PIIMasker",
@@ -20585,7 +20617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L67",
       "id": "pii_masker_piimasker",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".mask()",
@@ -20593,7 +20625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L78",
       "id": "pii_masker_piimasker_mask",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".hasPII()",
@@ -20601,7 +20633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L258",
       "id": "pii_masker_piimasker_haspii",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".detectPIITypes()",
@@ -20609,7 +20641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L273",
       "id": "pii_masker_piimasker_detectpiitypes",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".maskObject()",
@@ -20617,7 +20649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L293",
       "id": "pii_masker_piimasker_maskobject",
-      "community": 240
+      "community": 241
     },
     {
       "label": ".maskError()",
@@ -20625,7 +20657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/pii-masker.ts",
       "source_location": "L347",
       "id": "pii_masker_piimasker_maskerror",
-      "community": 240
+      "community": 241
     },
     {
       "label": "stopwords.ts",
@@ -20905,7 +20937,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 616
+      "community": 618
     },
     {
       "label": "isMemoryItemType()",
@@ -20913,7 +20945,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 616
+      "community": 618
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -20921,7 +20953,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 616
+      "community": 618
     },
     {
       "label": "error-types.ts",
@@ -21209,7 +21241,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_llm_model_resolver_ts",
-      "community": 617
+      "community": 619
     },
     {
       "label": "resolveProviderDefaultModel()",
@@ -21217,7 +21249,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L28",
       "id": "llm_model_resolver_resolveproviderdefaultmodel",
-      "community": 617
+      "community": 619
     },
     {
       "label": "resolveLlmModel()",
@@ -21225,7 +21257,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L51",
       "id": "llm_model_resolver_resolvellmmodel",
-      "community": 617
+      "community": 619
     },
     {
       "label": "index.ts",
@@ -21239,7 +21271,7 @@
       "label": "validateConfig()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/config/index.ts",
-      "source_location": "L163",
+      "source_location": "L165",
       "id": "index_validateconfig",
       "community": 794
     },
@@ -21249,7 +21281,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_config_loader_utils_ts",
-      "community": 241
+      "community": 242
     },
     {
       "label": "findProjectRoot()",
@@ -21257,7 +21289,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L50",
       "id": "config_loader_utils_findprojectroot",
-      "community": 241
+      "community": 242
     },
     {
       "label": "loadTOMLConfig()",
@@ -21265,7 +21297,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L113",
       "id": "config_loader_utils_loadtomlconfig",
-      "community": 241
+      "community": 242
     },
     {
       "label": "validateConfig()",
@@ -21273,7 +21305,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L140",
       "id": "config_loader_utils_validateconfig",
-      "community": 241
+      "community": 242
     },
     {
       "label": "mergeWithDefaults()",
@@ -21281,7 +21313,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L201",
       "id": "config_loader_utils_mergewithdefaults",
-      "community": 241
+      "community": 242
     },
     {
       "label": "getCachedConfig()",
@@ -21289,7 +21321,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L235",
       "id": "config_loader_utils_getcachedconfig",
-      "community": 241
+      "community": 242
     },
     {
       "label": "clearConfigCache()",
@@ -21297,7 +21329,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L247",
       "id": "config_loader_utils_clearconfigcache",
-      "community": 241
+      "community": 242
     },
     {
       "label": "clearConfigCacheByPrefix()",
@@ -21305,7 +21337,7 @@
       "source_file": "packages/memento-core/src/shared/config/config-loader-utils.ts",
       "source_location": "L258",
       "id": "config_loader_utils_clearconfigcachebyprefix",
-      "community": 241
+      "community": 242
     },
     {
       "label": "ranking-weights-loader.spec.ts",
@@ -21721,7 +21753,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 618
+      "community": 620
     },
     {
       "label": "getMockMementoConfig()",
@@ -21729,7 +21761,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L21",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 618
+      "community": 620
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -21737,7 +21769,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L50",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 618
+      "community": 620
     },
     {
       "label": "initialize.spec.ts",
@@ -22201,7 +22233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_ts",
-      "community": 242
+      "community": 243
     },
     {
       "label": "LocalSearchService",
@@ -22209,7 +22241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L24",
       "id": "local_search_service_localsearchservice",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".constructor()",
@@ -22217,7 +22249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L31",
       "id": "local_search_service_localsearchservice_constructor",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".setDatabase()",
@@ -22225,7 +22257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L46",
       "id": "local_search_service_localsearchservice_setdatabase",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".getAnchorWithEmbedding()",
@@ -22233,7 +22265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L56",
       "id": "local_search_service_localsearchservice_getanchorwithembedding",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".performNHopSearch()",
@@ -22241,7 +22273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L90",
       "id": "local_search_service_localsearchservice_performnhopsearch",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".applyQueryFilter()",
@@ -22249,7 +22281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L113",
       "id": "local_search_service_localsearchservice_applyqueryfilter",
-      "community": 242
+      "community": 243
     },
     {
       "label": ".handleFallback()",
@@ -22257,7 +22289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.ts",
       "source_location": "L128",
       "id": "local_search_service_localsearchservice_handlefallback",
-      "community": 242
+      "community": 243
     },
     {
       "label": "query-filter-service.spec.ts",
@@ -22553,7 +22585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_ts",
-      "community": 291
+      "community": 292
     },
     {
       "label": "QueryFilterService",
@@ -22561,7 +22593,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L41",
       "id": "query_filter_service_queryfilterservice",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".constructor()",
@@ -22569,7 +22601,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L45",
       "id": "query_filter_service_queryfilterservice_constructor",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".filterByQuery()",
@@ -22577,7 +22609,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L53",
       "id": "query_filter_service_queryfilterservice_filterbyquery",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".cosineSimilarity()",
@@ -22585,7 +22617,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L151",
       "id": "query_filter_service_queryfilterservice_cosinesimilarity",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".calculateTextSimilarity()",
@@ -22593,7 +22625,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L175",
       "id": "query_filter_service_queryfilterservice_calculatetextsimilarity",
-      "community": 291
+      "community": 292
     },
     {
       "label": ".calculateBaseRankingScore()",
@@ -22601,7 +22633,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.ts",
       "source_location": "L186",
       "id": "query_filter_service_queryfilterservice_calculatebaserankingscore",
-      "community": 291
+      "community": 292
     },
     {
       "label": "anchor-manager.ts",
@@ -24537,7 +24569,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_error_ts",
-      "community": 619
+      "community": 621
     },
     {
       "label": "SearchError",
@@ -24545,7 +24577,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L11",
       "id": "search_error_searcherror",
-      "community": 619
+      "community": 621
     },
     {
       "label": ".constructor()",
@@ -24553,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L12",
       "id": "search_error_searcherror_constructor",
-      "community": 619
+      "community": 621
     },
     {
       "label": "search-logger.ts",
@@ -24561,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_logger_ts",
-      "community": 292
+      "community": 293
     },
     {
       "label": "SearchLogger",
@@ -24569,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L4",
       "id": "search_logger_searchlogger",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".logSearchStart()",
@@ -24577,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L5",
       "id": "search_logger_searchlogger_logsearchstart",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".logSearchStep()",
@@ -24585,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L9",
       "id": "search_logger_searchlogger_logsearchstep",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".logSearchComplete()",
@@ -24593,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L17",
       "id": "search_logger_searchlogger_logsearchcomplete",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".logSearchError()",
@@ -24601,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L25",
       "id": "search_logger_searchlogger_logsearcherror",
-      "community": 292
+      "community": 293
     },
     {
       "label": ".logExperiment()",
@@ -24609,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-logger.ts",
       "source_location": "L29",
       "id": "search_logger_searchlogger_logexperiment",
-      "community": 292
+      "community": 293
     },
     {
       "label": "procedural-memory-matcher.ts",
@@ -24617,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_procedural_memory_matcher_ts",
-      "community": 243
+      "community": 244
     },
     {
       "label": "ProceduralMemoryMatcher",
@@ -24625,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L20",
       "id": "procedural_memory_matcher_proceduralmemorymatcher",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".extractQueryInfo()",
@@ -24633,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L29",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_extractqueryinfo",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".fetchProceduralMemoryRows()",
@@ -24641,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L57",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_fetchproceduralmemoryrows",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".matchWorkflowName()",
@@ -24649,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L93",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchworkflowname",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".matchSkillName()",
@@ -24657,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L124",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchskillname",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".matchTriggerConditions()",
@@ -24665,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L156",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_matchtriggerconditions",
-      "community": 243
+      "community": 244
     },
     {
       "label": ".fetchProceduralMemoryMatches()",
@@ -24673,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/procedural-memory-matcher.ts",
       "source_location": "L242",
       "id": "procedural_memory_matcher_proceduralmemorymatcher_fetchproceduralmemorymatches",
-      "community": 243
+      "community": 244
     },
     {
       "label": "process-attribute-fit.ts",
@@ -24729,7 +24761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 620
+      "community": 622
     },
     {
       "label": "initializeTestDatabase()",
@@ -24737,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 620
+      "community": 622
     },
     {
       "label": "createValidReflectionNote()",
@@ -24745,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 620
+      "community": 622
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -25153,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_performance_repository_ts",
-      "community": 244
+      "community": 245
     },
     {
       "label": "VectorPerformanceRepositoryImpl",
@@ -25161,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L13",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl",
-      "community": 244
+      "community": 245
     },
     {
       "label": ".constructor()",
@@ -25169,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L17",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_constructor",
-      "community": 244
+      "community": 245
     },
     {
       "label": ".checkVecAvailability()",
@@ -25177,7 +25209,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L25",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_checkvecavailability",
-      "community": 244
+      "community": 245
     },
     {
       "label": ".runPerformanceTest()",
@@ -25185,7 +25217,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L84",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_runperformancetest",
-      "community": 244
+      "community": 245
     },
     {
       "label": ".executeSearch()",
@@ -25193,7 +25225,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L138",
       "id": "vector_performance_repository_vectorperformancerepositoryimpl_executesearch",
-      "community": 244
+      "community": 245
     },
     {
       "label": "isSqliteTableRow()",
@@ -25201,7 +25233,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L167",
       "id": "vector_performance_repository_issqlitetablerow",
-      "community": 244
+      "community": 245
     },
     {
       "label": "isVectorPerformanceRow()",
@@ -25209,7 +25241,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-performance.repository.ts",
       "source_location": "L171",
       "id": "vector_performance_repository_isvectorperformancerow",
-      "community": 244
+      "community": 245
     },
     {
       "label": "vector-performance.repository.spec.ts",
@@ -25313,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_runtime_context_ts",
-      "community": 245
+      "community": 246
     },
     {
       "label": "getTableName()",
@@ -25321,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L16",
       "id": "vector_search_runtime_context_gettablename",
-      "community": 245
+      "community": 246
     },
     {
       "label": "getExpectedDimensions()",
@@ -25329,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L20",
       "id": "vector_search_runtime_context_getexpecteddimensions",
-      "community": 245
+      "community": 246
     },
     {
       "label": "shouldUseDominantStoredDimensionsForTable()",
@@ -25337,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L28",
       "id": "vector_search_runtime_context_shouldusedominantstoreddimensionsfortable",
-      "community": 245
+      "community": 246
     },
     {
       "label": "getVecTableSchemaDimensions()",
@@ -25345,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L35",
       "id": "vector_search_runtime_context_getvectableschemadimensions",
-      "community": 245
+      "community": 246
     },
     {
       "label": "getDominantStoredDimensions()",
@@ -25353,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L51",
       "id": "vector_search_runtime_context_getdominantstoreddimensions",
-      "community": 245
+      "community": 246
     },
     {
       "label": "resolveRuntimeVectorContext()",
@@ -25361,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L67",
       "id": "vector_search_runtime_context_resolveruntimevectorcontext",
-      "community": 245
+      "community": 246
     },
     {
       "label": "alignQueryVectorToStoredDimensions()",
@@ -25369,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-runtime-context.ts",
       "source_location": "L120",
       "id": "vector_search_runtime_context_alignqueryvectortostoreddimensions",
-      "community": 245
+      "community": 246
     },
     {
       "label": "vector-search-availability.ts",
@@ -25577,7 +25609,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_ts",
-      "community": 293
+      "community": 294
     },
     {
       "label": "VectorPerformanceTester",
@@ -25585,7 +25617,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L12",
       "id": "vector_performance_tester_vectorperformancetester",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".constructor()",
@@ -25593,7 +25625,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L13",
       "id": "vector_performance_tester_vectorperformancetester_constructor",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".runPerformanceTest()",
@@ -25601,7 +25633,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L18",
       "id": "vector_performance_tester_vectorperformancetester_runperformancetest",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".validateTestParameters()",
@@ -25609,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L44",
       "id": "vector_performance_tester_vectorperformancetester_validatetestparameters",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".analyzeResults()",
@@ -25617,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L57",
       "id": "vector_performance_tester_vectorperformancetester_analyzeresults",
-      "community": 293
+      "community": 294
     },
     {
       "label": ".generateReport()",
@@ -25625,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.ts",
       "source_location": "L87",
       "id": "vector_performance_tester_vectorperformancetester_generatereport",
-      "community": 293
+      "community": 294
     },
     {
       "label": "vector-search.service.spec.ts",
@@ -25649,7 +25681,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_ts",
-      "community": 294
+      "community": 295
     },
     {
       "label": "VectorIndexManager",
@@ -25657,7 +25689,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L12",
       "id": "vector_index_manager_vectorindexmanager",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".constructor()",
@@ -25665,7 +25697,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L13",
       "id": "vector_index_manager_vectorindexmanager_constructor",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".getIndexStatus()",
@@ -25673,7 +25705,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L21",
       "id": "vector_index_manager_vectorindexmanager_getindexstatus",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".rebuildIndex()",
@@ -25681,7 +25713,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L54",
       "id": "vector_index_manager_vectorindexmanager_rebuildindex",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".isAvailable()",
@@ -25689,7 +25721,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L72",
       "id": "vector_index_manager_vectorindexmanager_isavailable",
-      "community": 294
+      "community": 295
     },
     {
       "label": ".getStatusSummary()",
@@ -25697,7 +25729,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.ts",
       "source_location": "L87",
       "id": "vector_index_manager_vectorindexmanager_getstatussummary",
-      "community": 294
+      "community": 295
     },
     {
       "label": "vector-search-facade.ts",
@@ -27729,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_search_quality_query_ts",
-      "community": 621
+      "community": 623
     },
     {
       "label": "avgCandidateCountForPeriod()",
@@ -27737,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L11",
       "id": "telemetry_search_quality_query_avgcandidatecountforperiod",
-      "community": 621
+      "community": 623
     },
     {
       "label": "querySearchQuality()",
@@ -27745,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L37",
       "id": "telemetry_search_quality_query_querysearchquality",
-      "community": 621
+      "community": 623
     },
     {
       "label": "telemetry-repository.ts",
@@ -27897,7 +27929,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_memory_quality_query_ts",
-      "community": 622
+      "community": 624
     },
     {
       "label": "queryMemoryQuality()",
@@ -27905,7 +27937,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L8",
       "id": "telemetry_memory_quality_query_querymemoryquality",
-      "community": 622
+      "community": 624
     },
     {
       "label": "queryConsolidationQuality()",
@@ -27913,7 +27945,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L82",
       "id": "telemetry_memory_quality_query_queryconsolidationquality",
-      "community": 622
+      "community": 624
     },
     {
       "label": "get-telemetry-summary-tool.spec.ts",
@@ -28265,7 +28297,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 623
+      "community": 625
     },
     {
       "label": "readProviderToken()",
@@ -28273,7 +28305,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 623
+      "community": 625
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -28281,7 +28313,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 623
+      "community": 625
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -28977,7 +29009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 624
+      "community": 626
     },
     {
       "label": "validateRecallQuery()",
@@ -28985,7 +29017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 624
+      "community": 626
     },
     {
       "label": "validateRecallFilters()",
@@ -28993,7 +29025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 624
+      "community": 626
     },
     {
       "label": "recall-tool-schema.ts",
@@ -29145,7 +29177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_feedback_tool_ts",
-      "community": 295
+      "community": 296
     },
     {
       "label": "normalizeFeedbackCreatedAtToIso()",
@@ -29153,7 +29185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L14",
       "id": "feedback_tool_normalizefeedbackcreatedattoiso",
-      "community": 295
+      "community": 296
     },
     {
       "label": "findApprovedPromotionCandidate()",
@@ -29161,7 +29193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L33",
       "id": "feedback_tool_findapprovedpromotioncandidate",
-      "community": 295
+      "community": 296
     },
     {
       "label": "FeedbackTool",
@@ -29169,7 +29201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L81",
       "id": "feedback_tool_feedbacktool",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".constructor()",
@@ -29177,7 +29209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L82",
       "id": "feedback_tool_feedbacktool_constructor",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".feedbackContractError()",
@@ -29185,7 +29217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L124",
       "id": "feedback_tool_feedbacktool_feedbackcontracterror",
-      "community": 295
+      "community": 296
     },
     {
       "label": ".handle()",
@@ -29193,7 +29225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/feedback-tool.ts",
       "source_location": "L137",
       "id": "feedback_tool_feedbacktool_handle",
-      "community": 295
+      "community": 296
     },
     {
       "label": "cleanup-memory-tool.ts",
@@ -29233,7 +29265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 625
+      "community": 627
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -29241,7 +29273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 625
+      "community": 627
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -29249,7 +29281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 625
+      "community": 627
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -29481,7 +29513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_post_search_ts",
-      "community": 246
+      "community": 247
     },
     {
       "label": "filterLatestOnly()",
@@ -29489,7 +29521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L22",
       "id": "recall_tool_post_search_filterlatestonly",
-      "community": 246
+      "community": 247
     },
     {
       "label": "filterSpecificVersion()",
@@ -29497,7 +29529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L34",
       "id": "recall_tool_post_search_filterspecificversion",
-      "community": 246
+      "community": 247
     },
     {
       "label": "applyVersionFilter()",
@@ -29505,7 +29537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L51",
       "id": "recall_tool_post_search_applyversionfilter",
-      "community": 246
+      "community": 247
     },
     {
       "label": "enrichProceduralVersionInfo()",
@@ -29513,7 +29545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L68",
       "id": "recall_tool_post_search_enrichproceduralversioninfo",
-      "community": 246
+      "community": 247
     },
     {
       "label": "collectMetaMemoryStats()",
@@ -29521,7 +29553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L110",
       "id": "recall_tool_post_search_collectmetamemorystats",
-      "community": 246
+      "community": 247
     },
     {
       "label": "updateConsolidationScoreMetadata()",
@@ -29529,7 +29561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L146",
       "id": "recall_tool_post_search_updateconsolidationscoremetadata",
-      "community": 246
+      "community": 247
     },
     {
       "label": "runMemoryItemPostSearchPipeline()",
@@ -29537,7 +29569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-post-search.ts",
       "source_location": "L255",
       "id": "recall_tool_post_search_runmemoryitempostsearchpipeline",
-      "community": 246
+      "community": 247
     },
     {
       "label": "recall-tool-neighbors-fetch.ts",
@@ -29617,7 +29649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_direct_ts",
-      "community": 626
+      "community": 628
     },
     {
       "label": "recallCoreMemoryDirect()",
@@ -29625,7 +29657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L13",
       "id": "recall_tool_direct_recallcorememorydirect",
-      "community": 626
+      "community": 628
     },
     {
       "label": "recallVaultMemoryDirect()",
@@ -29633,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L67",
       "id": "recall_tool_direct_recallvaultmemorydirect",
-      "community": 626
+      "community": 628
     },
     {
       "label": "unpin-tool.ts",
@@ -29889,7 +29921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 627
+      "community": 629
     },
     {
       "label": "getMetaStatsForResults()",
@@ -29897,7 +29929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L33",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 627
+      "community": 629
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -29905,7 +29937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L77",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 627
+      "community": 629
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -30209,7 +30241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 628
+      "community": 630
     },
     {
       "label": "initializeTestDatabase()",
@@ -30217,7 +30249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 628
+      "community": 630
     },
     {
       "label": "createValidReflectionNote()",
@@ -30225,7 +30257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L831",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 628
+      "community": 630
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -30345,7 +30377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 629
+      "community": 631
     },
     {
       "label": "initializeTestDatabase()",
@@ -30353,7 +30385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 629
+      "community": 631
     },
     {
       "label": "createValidReflectionNote()",
@@ -30361,7 +30393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1436",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 629
+      "community": 631
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -30377,7 +30409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
-      "community": 630
+      "community": 632
     },
     {
       "label": "initializeProductionLikeSchema()",
@@ -30385,7 +30417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L15",
       "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
-      "community": 630
+      "community": 632
     },
     {
       "label": "createHost()",
@@ -30393,7 +30425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L33",
       "id": "remember_tool_relation_load_spec_createhost",
-      "community": 630
+      "community": 632
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -30793,7 +30825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 631
+      "community": 633
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -30801,7 +30833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 631
+      "community": 633
     },
     {
       "label": ".runScan()",
@@ -30809,7 +30841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 631
+      "community": 633
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -30817,7 +30849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 632
+      "community": 634
     },
     {
       "label": "generateMemoryId()",
@@ -30825,7 +30857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 632
+      "community": 634
     },
     {
       "label": "rollbackToVersion()",
@@ -30833,7 +30865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 632
+      "community": 634
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -30841,7 +30873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_neighbor_service_ts",
-      "community": 247
+      "community": 248
     },
     {
       "label": "MemoryNotFoundError",
@@ -30849,7 +30881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L58",
       "id": "memory_neighbor_service_memorynotfounderror",
-      "community": 247
+      "community": 248
     },
     {
       "label": ".constructor()",
@@ -30857,7 +30889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L59",
       "id": "memory_neighbor_service_memorynotfounderror_constructor",
-      "community": 247
+      "community": 248
     },
     {
       "label": "MemoryNeighborService",
@@ -30865,7 +30897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L69",
       "id": "memory_neighbor_service_memoryneighborservice",
-      "community": 247
+      "community": 248
     },
     {
       "label": ".constructor()",
@@ -30873,7 +30905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L80",
       "id": "memory_neighbor_service_memoryneighborservice_constructor",
-      "community": 247
+      "community": 248
     },
     {
       "label": ".setDatabase()",
@@ -30881,7 +30913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L102",
       "id": "memory_neighbor_service_memoryneighborservice_setdatabase",
-      "community": 247
+      "community": 248
     },
     {
       "label": ".getNeighbors()",
@@ -30889,7 +30921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L122",
       "id": "memory_neighbor_service_memoryneighborservice_getneighbors",
-      "community": 247
+      "community": 248
     },
     {
       "label": ".updateNeighborsForNewMemory()",
@@ -30897,7 +30929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-neighbor-service.ts",
       "source_location": "L338",
       "id": "memory_neighbor_service_memoryneighborservice_updateneighborsfornewmemory",
-      "community": 247
+      "community": 248
     },
     {
       "label": "memory-review-candidate-selection-service.ts",
@@ -30905,7 +30937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 633
+      "community": 635
     },
     {
       "label": "selectionWindowLimit()",
@@ -30913,7 +30945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 633
+      "community": 635
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -30921,7 +30953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 633
+      "community": 635
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -31913,7 +31945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 634
+      "community": 636
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -31921,7 +31953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 634
+      "community": 636
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -31929,7 +31961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 634
+      "community": 636
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -32489,7 +32521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_pipeline_ts",
-      "community": 248
+      "community": 249
     },
     {
       "label": "SemanticMemoryUpdatePipeline",
@@ -32497,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L22",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".constructor()",
@@ -32505,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L23",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_constructor",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".validateInput()",
@@ -32513,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L33",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_validateinput",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".prepareUpdateData()",
@@ -32521,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L45",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_prepareupdatedata",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".applyUpdates()",
@@ -32529,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L60",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_applyupdates",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".processSingleTriple()",
@@ -32537,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L101",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_processsingletriple",
-      "community": 248
+      "community": 249
     },
     {
       "label": ".notifyListeners()",
@@ -32545,7 +32577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-pipeline.ts",
       "source_location": "L185",
       "id": "semantic_memory_update_pipeline_semanticmemoryupdatepipeline_notifylisteners",
-      "community": 248
+      "community": 249
     },
     {
       "label": "semantic-memory-relations.ts",
@@ -32553,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_relations_ts",
-      "community": 249
+      "community": 250
     },
     {
       "label": "SemanticMemoryRelations",
@@ -32561,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L12",
       "id": "semantic_memory_relations_semanticmemoryrelations",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".constructor()",
@@ -32569,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L13",
       "id": "semantic_memory_relations_semanticmemoryrelations_constructor",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".ensureRelationTypes()",
@@ -32577,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L18",
       "id": "semantic_memory_relations_semanticmemoryrelations_ensurerelationtypes",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".validateRelationDirection()",
@@ -32585,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L64",
       "id": "semantic_memory_relations_semanticmemoryrelations_validaterelationdirection",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".createEpisodicEdge()",
@@ -32593,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L98",
       "id": "semantic_memory_relations_semanticmemoryrelations_createepisodicedge",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".tryCreateEpisodicRelation()",
@@ -32601,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L145",
       "id": "semantic_memory_relations_semanticmemoryrelations_trycreateepisodicrelation",
-      "community": 249
+      "community": 250
     },
     {
       "label": ".isUniqueConstraintError()",
@@ -32609,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-relations.ts",
       "source_location": "L186",
       "id": "semantic_memory_relations_semanticmemoryrelations_isuniqueconstrainterror",
-      "community": 249
+      "community": 250
     },
     {
       "label": "semantic-memory-statistics.ts",
@@ -32617,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_statistics_ts",
-      "community": 296
+      "community": 297
     },
     {
       "label": "SemanticMemoryStatisticsService",
@@ -32625,7 +32657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L43",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".constructor()",
@@ -32633,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L48",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_constructor",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".initializeStatistics()",
@@ -32641,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L55",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_initializestatistics",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".recordUpdate()",
@@ -32649,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L86",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_recordupdate",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".getStatistics()",
@@ -32657,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L154",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_getstatistics",
-      "community": 296
+      "community": 297
     },
     {
       "label": ".reset()",
@@ -32665,7 +32697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-statistics.ts",
       "source_location": "L161",
       "id": "semantic_memory_statistics_semanticmemorystatisticsservice_reset",
-      "community": 296
+      "community": 297
     },
     {
       "label": "semantic-memory-similarity.ts",
@@ -32721,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_scoring_ts",
-      "community": 297
+      "community": 298
     },
     {
       "label": "SemanticMemoryScoring",
@@ -32729,7 +32761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L9",
       "id": "semantic_memory_scoring_semanticmemoryscoring",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".tripleToNaturalLanguage()",
@@ -32737,7 +32769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L13",
       "id": "semantic_memory_scoring_semanticmemoryscoring_tripletonaturallanguage",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".normalizeTripleForKg()",
@@ -32745,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L17",
       "id": "semantic_memory_scoring_semanticmemoryscoring_normalizetripleforkg",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".calculateConfidence()",
@@ -32753,7 +32785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L28",
       "id": "semantic_memory_scoring_semanticmemoryscoring_calculateconfidence",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".calculateImportance()",
@@ -32761,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L52",
       "id": "semantic_memory_scoring_semanticmemoryscoring_calculateimportance",
-      "community": 297
+      "community": 298
     },
     {
       "label": ".canonicalizeAndLink()",
@@ -32769,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-scoring.ts",
       "source_location": "L63",
       "id": "semantic_memory_scoring_semanticmemoryscoring_canonicalizeandlink",
-      "community": 297
+      "community": 298
     },
     {
       "label": "semantic-memory-update-types.ts",
@@ -33041,7 +33073,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_ts",
-      "community": 298
+      "community": 299
     },
     {
       "label": "ClusteringService",
@@ -33049,7 +33081,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L16",
       "id": "clustering_service_clusteringservice",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".getSimilarityThreshold()",
@@ -33057,7 +33089,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L17",
       "id": "clustering_service_clusteringservice_getsimilaritythreshold",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".getMinClusterSize()",
@@ -33065,7 +33097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L23",
       "id": "clustering_service_clusteringservice_getminclustersize",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".cosineSimilarity()",
@@ -33073,7 +33105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L29",
       "id": "clustering_service_clusteringservice_cosinesimilarity",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".clusterGroup()",
@@ -33081,7 +33113,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L50",
       "id": "clustering_service_clusteringservice_clustergroup",
-      "community": 298
+      "community": 299
     },
     {
       "label": ".buildClusters()",
@@ -33089,7 +33121,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.ts",
       "source_location": "L117",
       "id": "clustering_service_clusteringservice_buildclusters",
-      "community": 298
+      "community": 299
     },
     {
       "label": "summarization-service.spec.ts",
@@ -33401,7 +33433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_ts",
-      "community": 299
+      "community": 300
     },
     {
       "label": "resolveExtractTriplesOwner()",
@@ -33409,7 +33441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L37",
       "id": "extract_triples_tool_resolveextracttriplesowner",
-      "community": 299
+      "community": 300
     },
     {
       "label": "normalizeChunkOverlapForPipeline()",
@@ -33417,7 +33449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L42",
       "id": "extract_triples_tool_normalizechunkoverlapforpipeline",
-      "community": 299
+      "community": 300
     },
     {
       "label": "ExtractTriplesTool",
@@ -33425,7 +33457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L52",
       "id": "extract_triples_tool_extracttriplestool",
-      "community": 299
+      "community": 300
     },
     {
       "label": ".constructor()",
@@ -33433,7 +33465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L53",
       "id": "extract_triples_tool_extracttriplestool_constructor",
-      "community": 299
+      "community": 300
     },
     {
       "label": ".handle()",
@@ -33441,7 +33473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L84",
       "id": "extract_triples_tool_extracttriplestool_handle",
-      "community": 299
+      "community": 300
     },
     {
       "label": "toChatMessageInputs()",
@@ -33449,7 +33481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.ts",
       "source_location": "L176",
       "id": "extract_triples_tool_tochatmessageinputs",
-      "community": 299
+      "community": 300
     },
     {
       "label": "get-relations-tool.spec.ts",
@@ -33457,7 +33489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 635
+      "community": 637
     },
     {
       "label": "createBaseSchema()",
@@ -33465,7 +33497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 635
+      "community": 637
     },
     {
       "label": "createTestMemory()",
@@ -33473,7 +33505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L52",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 635
+      "community": 637
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -33481,7 +33513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 636
+      "community": 638
     },
     {
       "label": "createBaseSchema()",
@@ -33489,7 +33521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 636
+      "community": 638
     },
     {
       "label": "createTestMemory()",
@@ -33497,7 +33529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 636
+      "community": 638
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -33505,7 +33537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 637
+      "community": 639
     },
     {
       "label": "createBaseSchema()",
@@ -33513,7 +33545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 637
+      "community": 639
     },
     {
       "label": "createTestMemory()",
@@ -33521,7 +33553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 637
+      "community": 639
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -33537,7 +33569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 638
+      "community": 640
     },
     {
       "label": "createBaseSchema()",
@@ -33545,7 +33577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 638
+      "community": 640
     },
     {
       "label": "createTestMemory()",
@@ -33553,7 +33585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L52",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 638
+      "community": 640
     },
     {
       "label": "relation-retry-manager.ts",
@@ -33593,7 +33625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_errors_ts",
-      "community": 300
+      "community": 301
     },
     {
       "label": "RelationGraphError",
@@ -33601,7 +33633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L3",
       "id": "relation_errors_relationgrapherror",
-      "community": 300
+      "community": 301
     },
     {
       "label": ".constructor()",
@@ -33609,7 +33641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L4",
       "id": "relation_errors_relationgrapherror_constructor",
-      "community": 300
+      "community": 301
     },
     {
       "label": "DuplicateRelationError",
@@ -33617,7 +33649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L10",
       "id": "relation_errors_duplicaterelationerror",
-      "community": 300
+      "community": 301
     },
     {
       "label": ".constructor()",
@@ -33625,7 +33657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L11",
       "id": "relation_errors_duplicaterelationerror_constructor",
-      "community": 300
+      "community": 301
     },
     {
       "label": "CyclicRelationError",
@@ -33633,7 +33665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L25",
       "id": "relation_errors_cyclicrelationerror",
-      "community": 300
+      "community": 301
     },
     {
       "label": ".constructor()",
@@ -33641,7 +33673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-errors.ts",
       "source_location": "L26",
       "id": "relation_errors_cyclicrelationerror_constructor",
-      "community": 300
+      "community": 301
     },
     {
       "label": "rule-based-relation-extractor.ts",
@@ -34105,7 +34137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_extractor_ts",
-      "community": 250
+      "community": 251
     },
     {
       "label": "RelationExtractor",
@@ -34113,7 +34145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L30",
       "id": "relation_extractor_relationextractor",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".constructor()",
@@ -34121,7 +34153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L35",
       "id": "relation_extractor_relationextractor_constructor",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".extractRelations()",
@@ -34129,7 +34161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L55",
       "id": "relation_extractor_relationextractor_extractrelations",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".getApplicableRelationTypes()",
@@ -34137,7 +34169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L189",
       "id": "relation_extractor_relationextractor_getapplicablerelationtypes",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".mergeCandidates()",
@@ -34145,7 +34177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L212",
       "id": "relation_extractor_relationextractor_mergecandidates",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".generateCacheKey()",
@@ -34153,7 +34185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L247",
       "id": "relation_extractor_relationextractor_generatecachekey",
-      "community": 250
+      "community": 251
     },
     {
       "label": ".extractRelationsBatch()",
@@ -34161,7 +34193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-extractor.ts",
       "source_location": "L270",
       "id": "relation_extractor_relationextractor_extractrelationsbatch",
-      "community": 250
+      "community": 251
     },
     {
       "label": "relation-graph-traversal.ts",
@@ -34505,7 +34537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_cache_ts",
-      "community": 251
+      "community": 252
     },
     {
       "label": "RelationGraphCache",
@@ -34513,7 +34545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L9",
       "id": "relation_graph_cache_relationgraphcache",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".constructor()",
@@ -34521,7 +34553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L12",
       "id": "relation_graph_cache_relationgraphcache_constructor",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".generateCacheKey()",
@@ -34529,7 +34561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L20",
       "id": "relation_graph_cache_relationgraphcache_generatecachekey",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".addCacheKeyToIndex()",
@@ -34537,7 +34569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L33",
       "id": "relation_graph_cache_relationgraphcache_addcachekeytoindex",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".get()",
@@ -34545,7 +34577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L43",
       "id": "relation_graph_cache_relationgraphcache_get",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".set()",
@@ -34553,7 +34585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L61",
       "id": "relation_graph_cache_relationgraphcache_set",
-      "community": 251
+      "community": 252
     },
     {
       "label": ".invalidate()",
@@ -34561,7 +34593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cache.ts",
       "source_location": "L70",
       "id": "relation_graph_cache_relationgraphcache_invalidate",
-      "community": 251
+      "community": 252
     },
     {
       "label": "relation-extraction-quality.integration.spec.ts",
@@ -34609,7 +34641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 639
+      "community": 641
     },
     {
       "label": "createBaseSchema()",
@@ -34617,7 +34649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 639
+      "community": 641
     },
     {
       "label": "createTestMemory()",
@@ -34625,7 +34657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 639
+      "community": 641
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -34697,7 +34729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_based_relation_extractor_spec_ts",
-      "community": 301
+      "community": 302
     },
     {
       "label": "getMockEmbeddingFunctions()",
@@ -34705,7 +34737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L97",
       "id": "llm_based_relation_extractor_spec_getmockembeddingfunctions",
-      "community": 301
+      "community": 302
     },
     {
       "label": "createMockConfig()",
@@ -34713,7 +34745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L106",
       "id": "llm_based_relation_extractor_spec_createmockconfig",
-      "community": 301
+      "community": 302
     },
     {
       "label": "createTestMemory()",
@@ -34721,7 +34753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L162",
       "id": "llm_based_relation_extractor_spec_createtestmemory",
-      "community": 301
+      "community": 302
     },
     {
       "label": "createMockEmbeddingService()",
@@ -34729,7 +34761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L183",
       "id": "llm_based_relation_extractor_spec_createmockembeddingservice",
-      "community": 301
+      "community": 302
     },
     {
       "label": "generateEmbedding()",
@@ -34737,7 +34769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L230",
       "id": "llm_based_relation_extractor_spec_generateembedding",
-      "community": 301
+      "community": 302
     },
     {
       "label": "searchSimilar()",
@@ -34745,7 +34777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-based-relation-extractor.spec.ts",
       "source_location": "L231",
       "id": "llm_based_relation_extractor_spec_searchsimilar",
-      "community": 301
+      "community": 302
     },
     {
       "label": "provider-auto.spec.ts",
@@ -34769,7 +34801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 640
+      "community": 642
     },
     {
       "label": "getMockMementoConfig()",
@@ -34777,7 +34809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 640
+      "community": 642
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -34785,7 +34817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 640
+      "community": 642
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -34945,7 +34977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_statistics_ts",
-      "community": 252
+      "community": 253
     },
     {
       "label": "TripleExtractionStatisticsService",
@@ -34953,7 +34985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L54",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".constructor()",
@@ -34961,7 +34993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L58",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_constructor",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".initializeStatistics()",
@@ -34969,7 +35001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L65",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_initializestatistics",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".recordExtraction()",
@@ -34977,7 +35009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L99",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_recordextraction",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".getStatistics()",
@@ -34985,7 +35017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L181",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_getstatistics",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".reset()",
@@ -34993,7 +35025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L191",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_reset",
-      "community": 252
+      "community": 253
     },
     {
       "label": ".getFailureReasonStatistics()",
@@ -35001,7 +35033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-statistics.ts",
       "source_location": "L201",
       "id": "triple_extraction_statistics_tripleextractionstatisticsservice_getfailurereasonstatistics",
-      "community": 252
+      "community": 253
     },
     {
       "label": "entity-linker.ts",
@@ -35081,7 +35113,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_providers_ts",
-      "community": 302
+      "community": 303
     },
     {
       "label": "isRecord()",
@@ -35089,7 +35121,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L26",
       "id": "triple_extraction_llm_providers_isrecord",
-      "community": 302
+      "community": 303
     },
     {
       "label": "getStringField()",
@@ -35097,7 +35129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L30",
       "id": "triple_extraction_llm_providers_getstringfield",
-      "community": 302
+      "community": 303
     },
     {
       "label": "extractRawWithOpenAI()",
@@ -35105,7 +35137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L35",
       "id": "triple_extraction_llm_providers_extractrawwithopenai",
-      "community": 302
+      "community": 303
     },
     {
       "label": "extractRawWithGemini()",
@@ -35113,7 +35145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L92",
       "id": "triple_extraction_llm_providers_extractrawwithgemini",
-      "community": 302
+      "community": 303
     },
     {
       "label": "extractRawWithOllama()",
@@ -35121,7 +35153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L146",
       "id": "triple_extraction_llm_providers_extractrawwithollama",
-      "community": 302
+      "community": 303
     },
     {
       "label": "checkOllamaModelInstalled()",
@@ -35129,7 +35161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-providers.ts",
       "source_location": "L272",
       "id": "triple_extraction_llm_providers_checkollamamodelinstalled",
-      "community": 302
+      "community": 303
     },
     {
       "label": "triple-pipeline-orchestrator.spec.ts",
@@ -35153,7 +35185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 641
+      "community": 643
     },
     {
       "label": "tripleDedupeKey()",
@@ -35161,7 +35193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 641
+      "community": 643
     },
     {
       "label": "mergeTripleLists()",
@@ -35169,7 +35201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 641
+      "community": 643
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -35185,7 +35217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_ts",
-      "community": 303
+      "community": 304
     },
     {
       "label": "createTripleLlmUnavailableResponse()",
@@ -35193,7 +35225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L27",
       "id": "triple_extraction_llm_pipeline_createtriplellmunavailableresponse",
-      "community": 303
+      "community": 304
     },
     {
       "label": "buildTripleLlmProviderAttemptOrder()",
@@ -35201,7 +35233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L40",
       "id": "triple_extraction_llm_pipeline_buildtriplellmproviderattemptorder",
-      "community": 303
+      "community": 304
     },
     {
       "label": "invokeTripleProviderWithFallback()",
@@ -35209,7 +35241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L50",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderwithfallback",
-      "community": 303
+      "community": 304
     },
     {
       "label": "invokeTripleProviderRawOutput()",
@@ -35217,7 +35249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L104",
       "id": "triple_extraction_llm_pipeline_invoketripleproviderrawoutput",
-      "community": 303
+      "community": 304
     },
     {
       "label": "resolveTripleParseOrFailure()",
@@ -35225,7 +35257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L137",
       "id": "triple_extraction_llm_pipeline_resolvetripleparseorfailure",
-      "community": 303
+      "community": 304
     },
     {
       "label": "logTripleExtractionClientInitResult()",
@@ -35233,7 +35265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.ts",
       "source_location": "L171",
       "id": "triple_extraction_llm_pipeline_logtripleextractionclientinitresult",
-      "community": 303
+      "community": 304
     },
     {
       "label": "triple-extraction-service.ts",
@@ -35913,7 +35945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 642
+      "community": 644
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -35921,7 +35953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 642
+      "community": 644
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -35929,7 +35961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 642
+      "community": 644
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -36009,7 +36041,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 643
+      "community": 645
     },
     {
       "label": "candidate()",
@@ -36017,7 +36049,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 643
+      "community": 645
     },
     {
       "label": "source()",
@@ -36025,7 +36057,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 643
+      "community": 645
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -36041,7 +36073,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 644
+      "community": 646
     },
     {
       "label": "AgentIntegrationError",
@@ -36049,7 +36081,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 644
+      "community": 646
     },
     {
       "label": ".constructor()",
@@ -36057,7 +36089,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 644
+      "community": 646
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -36073,7 +36105,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 645
+      "community": 647
     },
     {
       "label": "createSession()",
@@ -36081,7 +36113,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 645
+      "community": 647
     },
     {
       "label": "addObservation()",
@@ -36089,7 +36121,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 645
+      "community": 647
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -36657,7 +36689,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 646
+      "community": 648
     },
     {
       "label": "addObservation()",
@@ -36665,7 +36697,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 646
+      "community": 648
     },
     {
       "label": "finishAndSummarize()",
@@ -36673,7 +36705,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 646
+      "community": 648
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -37497,7 +37529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_mock_embedding_service_ts",
-      "community": 253
+      "community": 254
     },
     {
       "label": "deterministicHash()",
@@ -37505,7 +37537,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L20",
       "id": "mock_embedding_service_deterministichash",
-      "community": 253
+      "community": 254
     },
     {
       "label": "generateMockEmbedding()",
@@ -37513,7 +37545,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L32",
       "id": "mock_embedding_service_generatemockembedding",
-      "community": 253
+      "community": 254
     },
     {
       "label": "MockEmbeddingService",
@@ -37521,7 +37553,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L42",
       "id": "mock_embedding_service_mockembeddingservice",
-      "community": 253
+      "community": 254
     },
     {
       "label": ".generateEmbedding()",
@@ -37529,7 +37561,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L43",
       "id": "mock_embedding_service_mockembeddingservice_generateembedding",
-      "community": 253
+      "community": 254
     },
     {
       "label": ".searchSimilar()",
@@ -37537,7 +37569,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L52",
       "id": "mock_embedding_service_mockembeddingservice_searchsimilar",
-      "community": 253
+      "community": 254
     },
     {
       "label": ".isAvailable()",
@@ -37545,7 +37577,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L67",
       "id": "mock_embedding_service_mockembeddingservice_isavailable",
-      "community": 253
+      "community": 254
     },
     {
       "label": ".getModelInfo()",
@@ -37553,7 +37585,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/mock-embedding-service.ts",
       "source_location": "L71",
       "id": "mock_embedding_service_mockembeddingservice_getmodelinfo",
-      "community": 253
+      "community": 254
     },
     {
       "label": "lightweight-embedding-service.ts",
@@ -38177,7 +38209,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 647
+      "community": 649
     },
     {
       "label": "createSchema()",
@@ -38185,7 +38217,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 647
+      "community": 649
     },
     {
       "label": "seedMemoryItem()",
@@ -38193,7 +38225,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 647
+      "community": 649
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -39201,7 +39233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_search_metrics_store_ts",
-      "community": 304
+      "community": 305
     },
     {
       "label": "createEmptyStats()",
@@ -39209,7 +39241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L23",
       "id": "search_metrics_store_createemptystats",
-      "community": 304
+      "community": 305
     },
     {
       "label": "SearchMetricsStore",
@@ -39217,7 +39249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L35",
       "id": "search_metrics_store_searchmetricsstore",
-      "community": 304
+      "community": 305
     },
     {
       "label": ".recordSearch()",
@@ -39225,7 +39257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L38",
       "id": "search_metrics_store_searchmetricsstore_recordsearch",
-      "community": 304
+      "community": 305
     },
     {
       "label": ".getSearchMetrics()",
@@ -39233,7 +39265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L55",
       "id": "search_metrics_store_searchmetricsstore_getsearchmetrics",
-      "community": 304
+      "community": 305
     },
     {
       "label": ".resetStats()",
@@ -39241,7 +39273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L71",
       "id": "search_metrics_store_searchmetricsstore_resetstats",
-      "community": 304
+      "community": 305
     },
     {
       "label": ".importFromExportData()",
@@ -39249,7 +39281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/search-metrics-store.ts",
       "source_location": "L75",
       "id": "search_metrics_store_searchmetricsstore_importfromexportdata",
-      "community": 304
+      "community": 305
     },
     {
       "label": "alert-notification-service.ts",
@@ -39257,7 +39289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_alert_notification_service_ts",
-      "community": 254
+      "community": 255
     },
     {
       "label": "AlertNotificationService",
@@ -39265,7 +39297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L6",
       "id": "alert_notification_service_alertnotificationservice",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".emitAlert()",
@@ -39273,7 +39305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L10",
       "id": "alert_notification_service_alertnotificationservice_emitalert",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".getAlerts()",
@@ -39281,7 +39313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L23",
       "id": "alert_notification_service_alertnotificationservice_getalerts",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".getActiveAlerts()",
@@ -39289,7 +39321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L29",
       "id": "alert_notification_service_alertnotificationservice_getactivealerts",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".acknowledgeAlert()",
@@ -39297,7 +39329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L33",
       "id": "alert_notification_service_alertnotificationservice_acknowledgealert",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".subscribe()",
@@ -39305,7 +39337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L45",
       "id": "alert_notification_service_alertnotificationservice_subscribe",
-      "community": 254
+      "community": 255
     },
     {
       "label": ".clear()",
@@ -39313,7 +39345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/alert-notification-service.ts",
       "source_location": "L52",
       "id": "alert_notification_service_alertnotificationservice_clear",
-      "community": 254
+      "community": 255
     },
     {
       "label": "cpu-usage-tracker.ts",
@@ -39761,7 +39793,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_ts",
-      "community": 255
+      "community": 256
     },
     {
       "label": "QualityRecorder",
@@ -39769,7 +39801,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L55",
       "id": "quality_recorder_qualityrecorder",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".constructor()",
@@ -39777,7 +39809,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L56",
       "id": "quality_recorder_qualityrecorder_constructor",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".generateId()",
@@ -39785,7 +39817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L65",
       "id": "quality_recorder_qualityrecorder_generateid",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".recordMeasurement()",
@@ -39793,7 +39825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L81",
       "id": "quality_recorder_qualityrecorder_recordmeasurement",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".recordAllMeasurements()",
@@ -39801,7 +39833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L229",
       "id": "quality_recorder_qualityrecorder_recordallmeasurements",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".getMeasurementHistory()",
@@ -39809,7 +39841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L269",
       "id": "quality_recorder_qualityrecorder_getmeasurementhistory",
-      "community": 255
+      "community": 256
     },
     {
       "label": ".getLatestMetrics()",
@@ -39817,7 +39849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.ts",
       "source_location": "L340",
       "id": "quality_recorder_qualityrecorder_getlatestmetrics",
-      "community": 255
+      "community": 256
     },
     {
       "label": "quality-evaluator.spec.ts",
@@ -40041,7 +40073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_ts",
-      "community": 256
+      "community": 257
     },
     {
       "label": "QualityReporter",
@@ -40049,7 +40081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L167",
       "id": "quality_reporter_qualityreporter",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".constructor()",
@@ -40057,7 +40089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L171",
       "id": "quality_reporter_qualityreporter_constructor",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".collectReportData()",
@@ -40065,7 +40097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L185",
       "id": "quality_reporter_qualityreporter_collectreportdata",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".generateMarkdownReport()",
@@ -40073,7 +40105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L346",
       "id": "quality_reporter_qualityreporter_generatemarkdownreport",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".generateJsonReport()",
@@ -40081,7 +40113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L356",
       "id": "quality_reporter_qualityreporter_generatejsonreport",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".generateHtmlReport()",
@@ -40089,7 +40121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L366",
       "id": "quality_reporter_qualityreporter_generatehtmlreport",
-      "community": 256
+      "community": 257
     },
     {
       "label": ".generateReport()",
@@ -40097,7 +40129,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.ts",
       "source_location": "L379",
       "id": "quality_reporter_qualityreporter_generatereport",
-      "community": 256
+      "community": 257
     },
     {
       "label": "quality-reporter.spec.ts",
@@ -40833,7 +40865,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_index_ts",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getToolRegistry()",
@@ -40841,7 +40873,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L58",
       "id": "index_gettoolregistry",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getTool()",
@@ -40849,7 +40881,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L62",
       "id": "index_gettool",
-      "community": 305
+      "community": 306
     },
     {
       "label": "getAllTools()",
@@ -40857,7 +40889,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L66",
       "id": "index_getalltools",
-      "community": 305
+      "community": 306
     },
     {
       "label": "telemetryParamsContext()",
@@ -40865,7 +40897,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L71",
       "id": "index_telemetryparamscontext",
-      "community": 305
+      "community": 306
     },
     {
       "label": "resolveTelemetryOwnerId()",
@@ -40873,7 +40905,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L89",
       "id": "index_resolvetelemetryownerid",
-      "community": 305
+      "community": 306
     },
     {
       "label": "executeTool()",
@@ -40881,7 +40913,7 @@
       "source_file": "packages/memento-core/src/tools/index.ts",
       "source_location": "L110",
       "id": "index_executetool",
-      "community": 305
+      "community": 306
     },
     {
       "label": "performance-benchmark.ts",
@@ -41049,7 +41081,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 648
+      "community": 650
     },
     {
       "label": "compareToolResults()",
@@ -41057,7 +41089,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 648
+      "community": 650
     },
     {
       "label": "testToolConsistency()",
@@ -41065,7 +41097,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 648
+      "community": 650
     },
     {
       "label": "test-quality-assurance.ts",
@@ -41073,7 +41105,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 649
+      "community": 651
     },
     {
       "label": "createQualityTables()",
@@ -41081,7 +41113,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 649
+      "community": 651
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -41089,7 +41121,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 649
+      "community": 651
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -41233,7 +41265,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 650
+      "community": 652
     },
     {
       "label": "setupResourceHandlers()",
@@ -41241,7 +41273,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 650
+      "community": 652
     },
     {
       "label": "createTestMemories()",
@@ -41249,7 +41281,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 650
+      "community": 652
     },
     {
       "label": "test-regression.ts",
@@ -41273,7 +41305,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_anchor_system_ts",
-      "community": 306
+      "community": 307
     },
     {
       "label": "createAnchorTable()",
@@ -41281,7 +41313,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L16",
       "id": "test_anchor_system_createanchortable",
-      "community": 306
+      "community": 307
     },
     {
       "label": "testAnchorSystemWorkflow()",
@@ -41289,7 +41321,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L35",
       "id": "test_anchor_system_testanchorsystemworkflow",
-      "community": 306
+      "community": 307
     },
     {
       "label": "testMultiClientScenario()",
@@ -41297,7 +41329,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L179",
       "id": "test_anchor_system_testmulticlientscenario",
-      "community": 306
+      "community": 307
     },
     {
       "label": "testFallbackMechanism()",
@@ -41305,7 +41337,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L316",
       "id": "test_anchor_system_testfallbackmechanism",
-      "community": 306
+      "community": 307
     },
     {
       "label": "expect()",
@@ -41313,7 +41345,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L431",
       "id": "test_anchor_system_expect",
-      "community": 306
+      "community": 307
     },
     {
       "label": "runAllTests()",
@@ -41321,7 +41353,7 @@
       "source_file": "packages/memento-core/src/test/test-anchor-system.ts",
       "source_location": "L471",
       "id": "test_anchor_system_runalltests",
-      "community": 306
+      "community": 307
     },
     {
       "label": "test-vector-search-quality-with-consolidation.spec.ts",
@@ -41337,7 +41369,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_multi_provider_search_performance_benchmark_ts",
-      "community": 257
+      "community": 258
     },
     {
       "label": "MultiProviderSearchBenchmark",
@@ -41345,7 +41377,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L46",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".constructor()",
@@ -41353,7 +41385,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L51",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_constructor",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".prepareTestData()",
@@ -41361,7 +41393,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L60",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_preparetestdata",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".benchmarkSingleProvider()",
@@ -41369,7 +41401,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L116",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_benchmarksingleprovider",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".benchmarkMultiProvider()",
@@ -41377,7 +41409,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L161",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_benchmarkmultiprovider",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".runBenchmark()",
@@ -41385,7 +41417,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L214",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_runbenchmark",
-      "community": 257
+      "community": 258
     },
     {
       "label": ".generateReport()",
@@ -41393,7 +41425,7 @@
       "source_file": "packages/memento-core/src/test/multi-provider-search-performance-benchmark.ts",
       "source_location": "L277",
       "id": "multi_provider_search_performance_benchmark_multiprovidersearchbenchmark_generatereport",
-      "community": 257
+      "community": 258
     },
     {
       "label": "test-single-provider-regression.ts",
@@ -41417,7 +41449,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_visualize_recency_ts",
-      "community": 307
+      "community": 308
     },
     {
       "label": "calculateRecency()",
@@ -41425,7 +41457,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L21",
       "id": "visualize_recency_calculaterecency",
-      "community": 307
+      "community": 308
     },
     {
       "label": "generateRecencyData()",
@@ -41433,7 +41465,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L28",
       "id": "visualize_recency_generaterecencydata",
-      "community": 307
+      "community": 308
     },
     {
       "label": "printConsoleGraph()",
@@ -41441,7 +41473,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L55",
       "id": "visualize_recency_printconsolegraph",
-      "community": 307
+      "community": 308
     },
     {
       "label": "printKeyPoints()",
@@ -41449,7 +41481,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L133",
       "id": "visualize_recency_printkeypoints",
-      "community": 307
+      "community": 308
     },
     {
       "label": "printCSV()",
@@ -41457,7 +41489,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L164",
       "id": "visualize_recency_printcsv",
-      "community": 307
+      "community": 308
     },
     {
       "label": "main()",
@@ -41465,7 +41497,7 @@
       "source_file": "packages/memento-core/src/test/visualize-recency.ts",
       "source_location": "L180",
       "id": "visualize_recency_main",
-      "community": 307
+      "community": 308
     },
     {
       "label": "embedding-integration-test.ts",
@@ -41481,7 +41513,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_consolidation_search_quality_ts",
-      "community": 308
+      "community": 309
     },
     {
       "label": "generateGroundTruth()",
@@ -41489,7 +41521,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L44",
       "id": "test_consolidation_search_quality_generategroundtruth",
-      "community": 308
+      "community": 309
     },
     {
       "label": "convertToSearchResults()",
@@ -41497,7 +41529,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L67",
       "id": "test_consolidation_search_quality_converttosearchresults",
-      "community": 308
+      "community": 309
     },
     {
       "label": "measureSearchQuality()",
@@ -41505,7 +41537,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L79",
       "id": "test_consolidation_search_quality_measuresearchquality",
-      "community": 308
+      "community": 309
     },
     {
       "label": "compareWithAndWithoutConsolidation()",
@@ -41513,7 +41545,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L130",
       "id": "test_consolidation_search_quality_comparewithandwithoutconsolidation",
-      "community": 308
+      "community": 309
     },
     {
       "label": "verifyRankingOrder()",
@@ -41521,7 +41553,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L174",
       "id": "test_consolidation_search_quality_verifyrankingorder",
-      "community": 308
+      "community": 309
     },
     {
       "label": "testConsolidationSearchQuality()",
@@ -41529,7 +41561,7 @@
       "source_file": "packages/memento-core/src/test/test-consolidation-search-quality.ts",
       "source_location": "L197",
       "id": "test_consolidation_search_quality_testconsolidationsearchquality",
-      "community": 308
+      "community": 309
     },
     {
       "label": "test-vector-search-engine.ts",
@@ -41873,7 +41905,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 651
+      "community": 653
     },
     {
       "label": "readSource()",
@@ -41881,7 +41913,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 651
+      "community": 653
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -41889,7 +41921,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 651
+      "community": 653
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -42041,7 +42073,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_ts",
-      "community": 309
+      "community": 310
     },
     {
       "label": "loadLabelCandidates()",
@@ -42049,7 +42081,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L19",
       "id": "search_quality_review_checklist_loadlabelcandidates",
-      "community": 309
+      "community": 310
     },
     {
       "label": "summarizeContent()",
@@ -42057,7 +42089,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L33",
       "id": "search_quality_review_checklist_summarizecontent",
-      "community": 309
+      "community": 310
     },
     {
       "label": "findGroundTruth()",
@@ -42065,7 +42097,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L42",
       "id": "search_quality_review_checklist_findgroundtruth",
-      "community": 309
+      "community": 310
     },
     {
       "label": "renderCandidate()",
@@ -42073,7 +42105,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L48",
       "id": "search_quality_review_checklist_rendercandidate",
-      "community": 309
+      "community": 310
     },
     {
       "label": "renderRelevantEntry()",
@@ -42081,7 +42113,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L65",
       "id": "search_quality_review_checklist_renderrelevantentry",
-      "community": 309
+      "community": 310
     },
     {
       "label": "buildReviewChecklistMarkdown()",
@@ -42089,7 +42121,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.ts",
       "source_location": "L82",
       "id": "search_quality_review_checklist_buildreviewchecklistmarkdown",
-      "community": 309
+      "community": 310
     },
     {
       "label": "benchmark-search-database.ts",
@@ -42193,7 +42225,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 652
+      "community": 654
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -42201,7 +42233,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 652
+      "community": 654
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -42209,7 +42241,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 652
+      "community": 654
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -42889,7 +42921,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L1",
       "id": "tests_root_quality_gates_spec_ts",
-      "community": 258
+      "community": 259
     },
     {
       "label": "readJson()",
@@ -42897,7 +42929,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L23",
       "id": "root_quality_gates_spec_readjson",
-      "community": 258
+      "community": 259
     },
     {
       "label": "normalizeCommand()",
@@ -42905,7 +42937,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L29",
       "id": "root_quality_gates_spec_normalizecommand",
-      "community": 258
+      "community": 259
     },
     {
       "label": "readScript()",
@@ -42913,7 +42945,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L33",
       "id": "root_quality_gates_spec_readscript",
-      "community": 258
+      "community": 259
     },
     {
       "label": "expectExactScript()",
@@ -42921,7 +42953,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L41",
       "id": "root_quality_gates_spec_expectexactscript",
-      "community": 258
+      "community": 259
     },
     {
       "label": "collectSourceFiles()",
@@ -42929,7 +42961,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L45",
       "id": "root_quality_gates_spec_collectsourcefiles",
-      "community": 258
+      "community": 259
     },
     {
       "label": "splitSequentialCommands()",
@@ -42937,7 +42969,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L66",
       "id": "root_quality_gates_spec_splitsequentialcommands",
-      "community": 258
+      "community": 259
     },
     {
       "label": "ruleSeverity()",
@@ -42945,7 +42977,7 @@
       "source_file": "tests/root-quality-gates.spec.ts",
       "source_location": "L70",
       "id": "root_quality_gates_spec_ruleseverity",
-      "community": 258
+      "community": 259
     },
     {
       "label": "static-design-contracts.spec.ts",
@@ -42953,7 +42985,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 653
+      "community": 655
     },
     {
       "label": "readStaticFile()",
@@ -42961,7 +42993,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 653
+      "community": 655
     },
     {
       "label": "getFunctionMetrics()",
@@ -42969,7 +43001,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L9",
       "id": "static_design_contracts_spec_getfunctionmetrics",
-      "community": 653
+      "community": 655
     },
     {
       "label": "anchor-map.e2e.ts",
@@ -42993,7 +43025,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_fixtures_ts",
-      "community": 310
+      "community": 311
     },
     {
       "label": "session()",
@@ -43001,7 +43033,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L32",
       "id": "agent_sessions_fixtures_session",
-      "community": 310
+      "community": 311
     },
     {
       "label": "observation()",
@@ -43009,7 +43041,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L49",
       "id": "agent_sessions_fixtures_observation",
-      "community": 310
+      "community": 311
     },
     {
       "label": "createAudit()",
@@ -43017,7 +43049,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L63",
       "id": "agent_sessions_fixtures_createaudit",
-      "community": 310
+      "community": 311
     },
     {
       "label": "fulfillJson()",
@@ -43025,7 +43057,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L90",
       "id": "agent_sessions_fixtures_fulfilljson",
-      "community": 310
+      "community": 311
     },
     {
       "label": "installDashboardRoutes()",
@@ -43033,7 +43065,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L102",
       "id": "agent_sessions_fixtures_installdashboardroutes",
-      "community": 310
+      "community": 311
     },
     {
       "label": "openAgentSessions()",
@@ -43041,7 +43073,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.fixtures.ts",
       "source_location": "L242",
       "id": "agent_sessions_fixtures_openagentsessions",
-      "community": 310
+      "community": 311
     },
     {
       "label": "smoke.spec.ts",
@@ -43065,7 +43097,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L1",
       "id": "scripts_check_legacy_script_usage_ts",
-      "community": 259
+      "community": 260
     },
     {
       "label": "checkGitHistory()",
@@ -43073,7 +43105,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L47",
       "id": "check_legacy_script_usage_checkgithistory",
-      "community": 259
+      "community": 260
     },
     {
       "label": "checkDocumentation()",
@@ -43081,7 +43113,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L67",
       "id": "check_legacy_script_usage_checkdocumentation",
-      "community": 259
+      "community": 260
     },
     {
       "label": "checkCode()",
@@ -43089,7 +43121,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L120",
       "id": "check_legacy_script_usage_checkcode",
-      "community": 259
+      "community": 260
     },
     {
       "label": "checkPackageJson()",
@@ -43097,7 +43129,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L159",
       "id": "check_legacy_script_usage_checkpackagejson",
-      "community": 259
+      "community": 260
     },
     {
       "label": "checkLegacyScriptUsage()",
@@ -43105,7 +43137,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L187",
       "id": "check_legacy_script_usage_checklegacyscriptusage",
-      "community": 259
+      "community": 260
     },
     {
       "label": "printJSON()",
@@ -43113,7 +43145,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L230",
       "id": "check_legacy_script_usage_printjson",
-      "community": 259
+      "community": 260
     },
     {
       "label": "printText()",
@@ -43121,7 +43153,7 @@
       "source_file": "scripts/check-legacy-script-usage.ts",
       "source_location": "L237",
       "id": "check_legacy_script_usage_printtext",
-      "community": 259
+      "community": 260
     },
     {
       "label": "quality-report.ts",
@@ -43257,7 +43289,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 654
+      "community": 656
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -43265,7 +43297,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 654
+      "community": 656
     },
     {
       "label": "readTarString()",
@@ -43273,7 +43305,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 654
+      "community": 656
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -43281,7 +43313,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_candidates_ts",
-      "community": 311
+      "community": 312
     },
     {
       "label": "parseArgs()",
@@ -43289,7 +43321,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L23",
       "id": "generate_search_quality_candidates_parseargs",
-      "community": 311
+      "community": 312
     },
     {
       "label": "printHelp()",
@@ -43297,7 +43329,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L63",
       "id": "generate_search_quality_candidates_printhelp",
-      "community": 311
+      "community": 312
     },
     {
       "label": "buildMemoryIdToBenchmarkIdMap()",
@@ -43305,7 +43337,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L83",
       "id": "generate_search_quality_candidates_buildmemoryidtobenchmarkidmap",
-      "community": 311
+      "community": 312
     },
     {
       "label": "hashString()",
@@ -43313,7 +43345,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L91",
       "id": "generate_search_quality_candidates_hashstring",
-      "community": 311
+      "community": 312
     },
     {
       "label": "sampleDeterministicNegatives()",
@@ -43321,7 +43353,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L100",
       "id": "generate_search_quality_candidates_sampledeterministicnegatives",
-      "community": 311
+      "community": 312
     },
     {
       "label": "main()",
@@ -43329,7 +43361,7 @@
       "source_file": "scripts/generate-search-quality-candidates.ts",
       "source_location": "L123",
       "id": "generate_search_quality_candidates_main",
-      "community": 311
+      "community": 312
     },
     {
       "label": "fix-migration.js",
@@ -43361,7 +43393,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_ts",
-      "community": 260
+      "community": 261
     },
     {
       "label": "mean()",
@@ -43369,7 +43401,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L45",
       "id": "compare_weight_profiles_mean",
-      "community": 260
+      "community": 261
     },
     {
       "label": "calcP95()",
@@ -43377,7 +43409,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L65",
       "id": "compare_weight_profiles_calcp95",
-      "community": 260
+      "community": 261
     },
     {
       "label": "pairedPermutationPValue()",
@@ -43385,7 +43417,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L73",
       "id": "compare_weight_profiles_pairedpermutationpvalue",
-      "community": 260
+      "community": 261
     },
     {
       "label": "evaluateProfile()",
@@ -43393,7 +43425,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L102",
       "id": "compare_weight_profiles_evaluateprofile",
-      "community": 260
+      "community": 261
     },
     {
       "label": "assertRankingProfileFilesExist()",
@@ -43401,7 +43433,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L199",
       "id": "compare_weight_profiles_assertrankingprofilefilesexist",
-      "community": 260
+      "community": 261
     },
     {
       "label": "parseArgs()",
@@ -43409,7 +43441,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L208",
       "id": "compare_weight_profiles_parseargs",
-      "community": 260
+      "community": 261
     },
     {
       "label": "main()",
@@ -43417,7 +43449,7 @@
       "source_file": "scripts/compare-weight-profiles.ts",
       "source_location": "L223",
       "id": "compare_weight_profiles_main",
-      "community": 260
+      "community": 261
     },
     {
       "label": "agent-memory-benchmark-adapter.ts",
@@ -44161,7 +44193,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 655
+      "community": 657
     },
     {
       "label": "temporaryRoot()",
@@ -44169,7 +44201,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 655
+      "community": 657
     },
     {
       "label": "dependencies()",
@@ -44177,7 +44209,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 655
+      "community": 657
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -44361,7 +44393,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 656
+      "community": 658
     },
     {
       "label": "fetchJson()",
@@ -44369,7 +44401,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L7",
       "id": "test_docker_fetchjson",
-      "community": 656
+      "community": 658
     },
     {
       "label": "testDockerServer()",
@@ -44377,7 +44409,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L23",
       "id": "test_docker_testdockerserver",
-      "community": 656
+      "community": 658
     },
     {
       "label": "pack-with-restore.js",
@@ -44425,7 +44457,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L1",
       "id": "scripts_generate_ground_truth_ts",
-      "community": 312
+      "community": 313
     },
     {
       "label": "parseArgs()",
@@ -44433,7 +44465,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L53",
       "id": "generate_ground_truth_parseargs",
-      "community": 312
+      "community": 313
     },
     {
       "label": "printHelp()",
@@ -44441,7 +44473,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L92",
       "id": "generate_ground_truth_printhelp",
-      "community": 312
+      "community": 313
     },
     {
       "label": "getMemoryIds()",
@@ -44449,7 +44481,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L129",
       "id": "generate_ground_truth_getmemoryids",
-      "community": 312
+      "community": 313
     },
     {
       "label": "extractKeywordsFromMemories()",
@@ -44457,7 +44489,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L143",
       "id": "generate_ground_truth_extractkeywordsfrommemories",
-      "community": 312
+      "community": 313
     },
     {
       "label": "generateGroundTruthFromSearch()",
@@ -44465,7 +44497,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L186",
       "id": "generate_ground_truth_generategroundtruthfromsearch",
-      "community": 312
+      "community": 313
     },
     {
       "label": "main()",
@@ -44473,7 +44505,7 @@
       "source_file": "scripts/generate-ground-truth.ts",
       "source_location": "L226",
       "id": "generate_ground_truth_main",
-      "community": 312
+      "community": 313
     },
     {
       "label": "save-work-memory.ts",
@@ -44985,7 +45017,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 657
+      "community": 659
     },
     {
       "label": "loadVecExtension()",
@@ -44993,7 +45025,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 657
+      "community": 659
     },
     {
       "label": "fixTfidfDimensions()",
@@ -45001,7 +45033,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 657
+      "community": 659
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -45033,7 +45065,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 658
+      "community": 660
     },
     {
       "label": "reappearanceRate()",
@@ -45041,7 +45073,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 658
+      "community": 660
     },
     {
       "label": "main()",
@@ -45049,7 +45081,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 658
+      "community": 660
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -45081,7 +45113,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L1",
       "id": "scripts_generate_relation_report_ts",
-      "community": 261
+      "community": 262
     },
     {
       "label": "parseArgs()",
@@ -45089,7 +45121,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L38",
       "id": "generate_relation_report_parseargs",
-      "community": 261
+      "community": 262
     },
     {
       "label": "loadTestDataset()",
@@ -45097,7 +45129,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L72",
       "id": "generate_relation_report_loadtestdataset",
-      "community": 261
+      "community": 262
     },
     {
       "label": "createBaseSchema()",
@@ -45105,7 +45137,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L105",
       "id": "generate_relation_report_createbaseschema",
-      "community": 261
+      "community": 262
     },
     {
       "label": "createTestMemory()",
@@ -45113,7 +45145,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L135",
       "id": "generate_relation_report_createtestmemory",
-      "community": 261
+      "community": 262
     },
     {
       "label": "extractRelations()",
@@ -45121,7 +45153,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L150",
       "id": "generate_relation_report_extractrelations",
-      "community": 261
+      "community": 262
     },
     {
       "label": "generateMarkdownReport()",
@@ -45129,7 +45161,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L227",
       "id": "generate_relation_report_generatemarkdownreport",
-      "community": 261
+      "community": 262
     },
     {
       "label": "main()",
@@ -45137,7 +45169,7 @@
       "source_file": "scripts/generate-relation-report.ts",
       "source_location": "L358",
       "id": "generate_relation_report_main",
-      "community": 261
+      "community": 262
     },
     {
       "label": "check-sql-injection.ts",
@@ -45369,7 +45401,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L1",
       "id": "scripts_tune_weights_ts",
-      "community": 313
+      "community": 314
     },
     {
       "label": "mulberry32()",
@@ -45377,7 +45409,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L24",
       "id": "tune_weights_mulberry32",
-      "community": 313
+      "community": 314
     },
     {
       "label": "parseTuneArgs()",
@@ -45385,7 +45417,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L43",
       "id": "tune_weights_parsetuneargs",
-      "community": 313
+      "community": 314
     },
     {
       "label": "generateCandidate()",
@@ -45393,7 +45425,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L71",
       "id": "tune_weights_generatecandidate",
-      "community": 313
+      "community": 314
     },
     {
       "label": "compositeScore()",
@@ -45401,7 +45433,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L88",
       "id": "tune_weights_compositescore",
-      "community": 313
+      "community": 314
     },
     {
       "label": "selectBest()",
@@ -45409,7 +45441,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L117",
       "id": "tune_weights_selectbest",
-      "community": 313
+      "community": 314
     },
     {
       "label": "main()",
@@ -45417,7 +45449,7 @@
       "source_file": "scripts/tune-weights.ts",
       "source_location": "L128",
       "id": "tune_weights_main",
-      "community": 313
+      "community": 314
     },
     {
       "label": "check-db-integrity.js",
@@ -45665,7 +45697,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L1",
       "id": "scripts_mcp_http_client_js",
-      "community": 314
+      "community": 315
     },
     {
       "label": "callHttpTool()",
@@ -45673,7 +45705,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L14",
       "id": "mcp_http_client_callhttptool",
-      "community": 314
+      "community": 315
     },
     {
       "label": "getHttpTools()",
@@ -45681,7 +45713,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L37",
       "id": "mcp_http_client_gethttptools",
-      "community": 314
+      "community": 315
     },
     {
       "label": "sendResponse()",
@@ -45689,7 +45721,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L60",
       "id": "mcp_http_client_sendresponse",
-      "community": 314
+      "community": 315
     },
     {
       "label": "handleRequest()",
@@ -45697,7 +45729,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L76",
       "id": "mcp_http_client_handlerequest",
-      "community": 314
+      "community": 315
     },
     {
       "label": "checkServerHealth()",
@@ -45705,7 +45737,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L142",
       "id": "mcp_http_client_checkserverhealth",
-      "community": 314
+      "community": 315
     },
     {
       "label": "main()",
@@ -45713,7 +45745,7 @@
       "source_file": "scripts/mcp-http-client.js",
       "source_location": "L157",
       "id": "mcp_http_client_main",
-      "community": 314
+      "community": 315
     },
     {
       "label": "weekly-relation-validation.ts",
@@ -45721,7 +45753,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L1",
       "id": "scripts_weekly_relation_validation_ts",
-      "community": 262
+      "community": 263
     },
     {
       "label": "parseArgs()",
@@ -45729,7 +45761,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L35",
       "id": "weekly_relation_validation_parseargs",
-      "community": 262
+      "community": 263
     },
     {
       "label": "loadTestDataset()",
@@ -45737,7 +45769,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L64",
       "id": "weekly_relation_validation_loadtestdataset",
-      "community": 262
+      "community": 263
     },
     {
       "label": "createBaseSchema()",
@@ -45745,7 +45777,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L89",
       "id": "weekly_relation_validation_createbaseschema",
-      "community": 262
+      "community": 263
     },
     {
       "label": "createTestMemory()",
@@ -45753,7 +45785,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L119",
       "id": "weekly_relation_validation_createtestmemory",
-      "community": 262
+      "community": 263
     },
     {
       "label": "extractRelations()",
@@ -45761,7 +45793,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L134",
       "id": "weekly_relation_validation_extractrelations",
-      "community": 262
+      "community": 263
     },
     {
       "label": "generateMarkdownReport()",
@@ -45769,7 +45801,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L211",
       "id": "weekly_relation_validation_generatemarkdownreport",
-      "community": 262
+      "community": 263
     },
     {
       "label": "main()",
@@ -45777,7 +45809,7 @@
       "source_file": "scripts/weekly-relation-validation.ts",
       "source_location": "L299",
       "id": "weekly_relation_validation_main",
-      "community": 262
+      "community": 263
     },
     {
       "label": "migrate-embedding-data.js",
@@ -46273,7 +46305,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 659
+      "community": 661
     },
     {
       "label": "createBackup()",
@@ -46281,7 +46313,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 659
+      "community": 661
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -46289,7 +46321,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 659
+      "community": 661
     },
     {
       "label": "restore-legacy.ps1",
@@ -46305,7 +46337,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_retry_usage_ts",
-      "community": 263
+      "community": 264
     },
     {
       "label": "getAllTsFiles()",
@@ -46313,7 +46345,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L53",
       "id": "check_retry_usage_getalltsfiles",
-      "community": 263
+      "community": 264
     },
     {
       "label": "checkRetryUsage()",
@@ -46321,7 +46353,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L84",
       "id": "check_retry_usage_checkretryusage",
-      "community": 263
+      "community": 264
     },
     {
       "label": "checkAllFiles()",
@@ -46329,7 +46361,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L130",
       "id": "check_retry_usage_checkallfiles",
-      "community": 263
+      "community": 264
     },
     {
       "label": "printResultsJSON()",
@@ -46337,7 +46369,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L147",
       "id": "check_retry_usage_printresultsjson",
-      "community": 263
+      "community": 264
     },
     {
       "label": "printResultsCSV()",
@@ -46345,7 +46377,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L156",
       "id": "check_retry_usage_printresultscsv",
-      "community": 263
+      "community": 264
     },
     {
       "label": "printResultsText()",
@@ -46353,7 +46385,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L164",
       "id": "check_retry_usage_printresultstext",
-      "community": 263
+      "community": 264
     },
     {
       "label": "main()",
@@ -46361,7 +46393,7 @@
       "source_file": "scripts/archive/check-retry-usage.ts",
       "source_location": "L185",
       "id": "check_retry_usage_main",
-      "community": 263
+      "community": 264
     },
     {
       "label": "analyze-simple-throws.ts",
@@ -46657,7 +46689,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 660
+      "community": 662
     },
     {
       "label": "normalizeMessage()",
@@ -46665,7 +46697,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 660
+      "community": 662
     },
     {
       "label": "createFingerprint()",
@@ -46673,7 +46705,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 660
+      "community": 662
     },
     {
       "label": "sanitizer.ts",
@@ -46681,7 +46713,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 661
+      "community": 663
     },
     {
       "label": "limitUtf8Bytes()",
@@ -46689,7 +46721,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 661
+      "community": 663
     },
     {
       "label": "sanitizeExcerpt()",
@@ -46697,7 +46729,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 661
+      "community": 663
     },
     {
       "label": "parsers.ts",
@@ -46881,7 +46913,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_github_client_ts",
-      "community": 264
+      "community": 265
     },
     {
       "label": "GitHubIssueClient",
@@ -46889,7 +46921,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L13",
       "id": "github_client_githubissueclient",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".constructor()",
@@ -46897,7 +46929,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L17",
       "id": "github_client_githubissueclient_constructor",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".findOpenIssueByFingerprint()",
@@ -46905,7 +46937,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L21",
       "id": "github_client_githubissueclient_findopenissuebyfingerprint",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".getIssue()",
@@ -46913,7 +46945,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L33",
       "id": "github_client_githubissueclient_getissue",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".createIssue()",
@@ -46921,7 +46953,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L37",
       "id": "github_client_githubissueclient_createissue",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".updateIssue()",
@@ -46929,7 +46961,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L44",
       "id": "github_client_githubissueclient_updateissue",
-      "community": 264
+      "community": 265
     },
     {
       "label": ".request()",
@@ -46937,7 +46969,7 @@
       "source_file": "scripts/log-issue-monitor/github-client.ts",
       "source_location": "L51",
       "id": "github_client_githubissueclient_request",
-      "community": 264
+      "community": 265
     },
     {
       "label": "detectors.ts",
@@ -46945,7 +46977,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_detectors_ts",
-      "community": 315
+      "community": 316
     },
     {
       "label": "nowIso()",
@@ -46953,7 +46985,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L6",
       "id": "detectors_nowiso",
-      "community": 315
+      "community": 316
     },
     {
       "label": "truncateTitle()",
@@ -46961,7 +46993,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L10",
       "id": "detectors_truncatetitle",
-      "community": 315
+      "community": 316
     },
     {
       "label": "redactDockerInspectEnv()",
@@ -46969,7 +47001,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L14",
       "id": "detectors_redactdockerinspectenv",
-      "community": 315
+      "community": 316
     },
     {
       "label": "detectAppLogEvent()",
@@ -46977,7 +47009,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L39",
       "id": "detectors_detectapplogevent",
-      "community": 315
+      "community": 316
     },
     {
       "label": "detectRuntimeAnomaly()",
@@ -46985,7 +47017,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L87",
       "id": "detectors_detectruntimeanomaly",
-      "community": 315
+      "community": 316
     },
     {
       "label": "detectDockerAnomaly()",
@@ -46993,7 +47025,7 @@
       "source_file": "scripts/log-issue-monitor/detectors.ts",
       "source_location": "L110",
       "id": "detectors_detectdockeranomaly",
-      "community": 315
+      "community": 316
     },
     {
       "label": "config.ts",
@@ -47001,7 +47033,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_config_ts",
-      "community": 316
+      "community": 317
     },
     {
       "label": "defaultLogsRoot()",
@@ -47009,7 +47041,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L5",
       "id": "config_defaultlogsroot",
-      "community": 316
+      "community": 317
     },
     {
       "label": "optionalString()",
@@ -47017,7 +47049,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L7",
       "id": "config_optionalstring",
-      "community": 316
+      "community": 317
     },
     {
       "label": "numberFromEnv()",
@@ -47025,7 +47057,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L12",
       "id": "config_numberfromenv",
-      "community": 316
+      "community": 317
     },
     {
       "label": "booleanFromEnv()",
@@ -47033,7 +47065,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L19",
       "id": "config_booleanfromenv",
-      "community": 316
+      "community": 317
     },
     {
       "label": "labelsFromEnv()",
@@ -47041,7 +47073,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L27",
       "id": "config_labelsfromenv",
-      "community": 316
+      "community": 317
     },
     {
       "label": "loadMonitorConfig()",
@@ -47049,7 +47081,7 @@
       "source_file": "scripts/log-issue-monitor/config.ts",
       "source_location": "L32",
       "id": "config_loadmonitorconfig",
-      "community": 316
+      "community": 317
     },
     {
       "label": "promotion.spec.ts",
@@ -47209,7 +47241,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L1",
       "id": "static_js_memento_admin_fetch_js",
-      "community": 317
+      "community": 318
     },
     {
       "label": "getDashboardAuth()",
@@ -47217,7 +47249,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L8",
       "id": "memento_admin_fetch_getdashboardauth",
-      "community": 317
+      "community": 318
     },
     {
       "label": "waitForSession()",
@@ -47225,7 +47257,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L12",
       "id": "memento_admin_fetch_waitforsession",
-      "community": 317
+      "community": 318
     },
     {
       "label": "buildRequestOptions()",
@@ -47233,7 +47265,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L20",
       "id": "memento_admin_fetch_buildrequestoptions",
-      "community": 317
+      "community": 318
     },
     {
       "label": "isProgrammaticToolsRequest()",
@@ -47241,7 +47273,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L28",
       "id": "memento_admin_fetch_isprogrammatictoolsrequest",
-      "community": 317
+      "community": 318
     },
     {
       "label": "performFetch()",
@@ -47249,7 +47281,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L33",
       "id": "memento_admin_fetch_performfetch",
-      "community": 317
+      "community": 318
     },
     {
       "label": "mementoAdminFetch()",
@@ -47257,7 +47289,7 @@
       "source_file": "static/js/memento-admin-fetch.js",
       "source_location": "L57",
       "id": "memento_admin_fetch_mementoadminfetch",
-      "community": 317
+      "community": 318
     },
     {
       "label": "embedding-map-state.js",
@@ -47329,7 +47361,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_js",
-      "community": 662
+      "community": 664
     },
     {
       "label": "buildEmbeddingMapQuery()",
@@ -47337,7 +47369,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L12",
       "id": "embedding_map_fetch_buildembeddingmapquery",
-      "community": 662
+      "community": 664
     },
     {
       "label": "handleEmbeddingMapResponse()",
@@ -47345,7 +47377,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_handleembeddingmapresponse",
-      "community": 662
+      "community": 664
     },
     {
       "label": "review-candidates-panel-poll.js",
@@ -47465,7 +47497,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_fetch_js",
-      "community": 663
+      "community": 665
     },
     {
       "label": "loadBatchRunHistory()",
@@ -47473,7 +47505,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L15",
       "id": "review_candidates_panel_health_fetch_loadbatchrunhistory",
-      "community": 663
+      "community": 665
     },
     {
       "label": "loadHealthMetrics()",
@@ -47481,7 +47513,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L61",
       "id": "review_candidates_panel_health_fetch_loadhealthmetrics",
-      "community": 663
+      "community": 665
     },
     {
       "label": "graph.js",
@@ -48009,7 +48041,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_ws_js",
-      "community": 265
+      "community": 266
     },
     {
       "label": "startAutoRefresh()",
@@ -48017,7 +48049,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L12",
       "id": "anchor_map_ws_startautorefresh",
-      "community": 265
+      "community": 266
     },
     {
       "label": "stopAutoRefresh()",
@@ -48025,7 +48057,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L20",
       "id": "anchor_map_ws_stopautorefresh",
-      "community": 265
+      "community": 266
     },
     {
       "label": "resubscribeWebSocket()",
@@ -48033,7 +48065,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L28",
       "id": "anchor_map_ws_resubscribewebsocket",
-      "community": 265
+      "community": 266
     },
     {
       "label": "disconnectWebSocket()",
@@ -48041,7 +48073,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L37",
       "id": "anchor_map_ws_disconnectwebsocket",
-      "community": 265
+      "community": 266
     },
     {
       "label": "handleWsMessage()",
@@ -48049,7 +48081,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L44",
       "id": "anchor_map_ws_handlewsmessage",
-      "community": 265
+      "community": 266
     },
     {
       "label": "fallbackToPolling()",
@@ -48057,7 +48089,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L62",
       "id": "anchor_map_ws_fallbacktopolling",
-      "community": 265
+      "community": 266
     },
     {
       "label": "tryConnectWebSocket()",
@@ -48065,7 +48097,7 @@
       "source_file": "static/js/anchor-map-ws.js",
       "source_location": "L69",
       "id": "anchor_map_ws_tryconnectwebsocket",
-      "community": 265
+      "community": 266
     },
     {
       "label": "review-candidates-panel-poll-config.js",
@@ -48257,7 +48289,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_scatter_js",
-      "community": 318
+      "community": 319
     },
     {
       "label": "computeDomains()",
@@ -48265,7 +48297,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L12",
       "id": "embedding_map_chart_scatter_computedomains",
-      "community": 318
+      "community": 319
     },
     {
       "label": "renderAxes()",
@@ -48273,7 +48305,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L23",
       "id": "embedding_map_chart_scatter_renderaxes",
-      "community": 318
+      "community": 319
     },
     {
       "label": "dotRadius()",
@@ -48281,7 +48313,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L35",
       "id": "embedding_map_chart_scatter_dotradius",
-      "community": 318
+      "community": 319
     },
     {
       "label": "dotPosition()",
@@ -48289,7 +48321,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L39",
       "id": "embedding_map_chart_scatter_dotposition",
-      "community": 318
+      "community": 319
     },
     {
       "label": "attachDotHandlers()",
@@ -48297,7 +48329,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L43",
       "id": "embedding_map_chart_scatter_attachdothandlers",
-      "community": 318
+      "community": 319
     },
     {
       "label": "updateDotAttributes()",
@@ -48305,7 +48337,7 @@
       "source_file": "static/js/embedding-map-chart-scatter.js",
       "source_location": "L64",
       "id": "embedding_map_chart_scatter_updatedotattributes",
-      "community": 318
+      "community": 319
     },
     {
       "label": "agent-sessions-panel-import.js",
@@ -48593,7 +48625,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_bulk_js",
-      "community": 319
+      "community": 320
     },
     {
       "label": "syncBulkControls()",
@@ -48601,7 +48633,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L19",
       "id": "review_candidates_panel_bulk_syncbulkcontrols",
-      "community": 319
+      "community": 320
     },
     {
       "label": "resetBulkSelection()",
@@ -48609,7 +48641,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L48",
       "id": "review_candidates_panel_bulk_resetbulkselection",
-      "community": 319
+      "community": 320
     },
     {
       "label": "setAllVisibleSelected()",
@@ -48617,7 +48649,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L54",
       "id": "review_candidates_panel_bulk_setallvisibleselected",
-      "community": 319
+      "community": 320
     },
     {
       "label": "wireBulkTableSelection()",
@@ -48625,7 +48657,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L68",
       "id": "review_candidates_panel_bulk_wirebulktableselection",
-      "community": 319
+      "community": 320
     },
     {
       "label": "postBulkAction()",
@@ -48633,7 +48665,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L90",
       "id": "review_candidates_panel_bulk_postbulkaction",
-      "community": 319
+      "community": 320
     },
     {
       "label": "wireBulkReviewActions()",
@@ -48641,7 +48673,7 @@
       "source_file": "static/js/review-candidates-panel-bulk.js",
       "source_location": "L142",
       "id": "review_candidates_panel_bulk_wirebulkreviewactions",
-      "community": 319
+      "community": 320
     },
     {
       "label": "review-candidates-panel-poll-snapshot.js",
@@ -48665,7 +48697,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_prompt_js",
-      "community": 664
+      "community": 666
     },
     {
       "label": "isReviewNotifyPromptDismissed()",
@@ -48673,7 +48705,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_prompt_isreviewnotifypromptdismissed",
-      "community": 664
+      "community": 666
     },
     {
       "label": "dismissReviewNotifyPrompt()",
@@ -48681,7 +48713,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L18",
       "id": "review_candidates_panel_poll_prompt_dismissreviewnotifyprompt",
-      "community": 664
+      "community": 666
     },
     {
       "label": "dashboard-auth-dom.js",
@@ -48689,7 +48721,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_dom_js",
-      "community": 665
+      "community": 667
     },
     {
       "label": "selectFirst()",
@@ -48697,7 +48729,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L12",
       "id": "dashboard_auth_dom_selectfirst",
-      "community": 665
+      "community": 667
     },
     {
       "label": "getElementByIdFallback()",
@@ -48705,7 +48737,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L20",
       "id": "dashboard_auth_dom_getelementbyidfallback",
-      "community": 665
+      "community": 667
     },
     {
       "label": "graph-search.js",
@@ -48713,7 +48745,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L1",
       "id": "static_js_graph_search_js",
-      "community": 266
+      "community": 267
     },
     {
       "label": "normalizeSearchText()",
@@ -48721,7 +48753,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L14",
       "id": "graph_search_normalizesearchtext",
-      "community": 266
+      "community": 267
     },
     {
       "label": "getSearchHaystack()",
@@ -48729,7 +48761,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L18",
       "id": "graph_search_getsearchhaystack",
-      "community": 266
+      "community": 267
     },
     {
       "label": "getNodeId()",
@@ -48737,7 +48769,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L30",
       "id": "graph_search_getnodeid",
-      "community": 266
+      "community": 267
     },
     {
       "label": "collectMatchingIds()",
@@ -48745,7 +48777,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L34",
       "id": "graph_search_collectmatchingids",
-      "community": 266
+      "community": 267
     },
     {
       "label": "setMatchBadge()",
@@ -48753,7 +48785,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L44",
       "id": "graph_search_setmatchbadge",
-      "community": 266
+      "community": 267
     },
     {
       "label": "applyNodeHighlight()",
@@ -48761,7 +48793,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L58",
       "id": "graph_search_applynodehighlight",
-      "community": 266
+      "community": 267
     },
     {
       "label": "applyLinkHighlight()",
@@ -48769,7 +48801,7 @@
       "source_file": "static/js/graph-search.js",
       "source_location": "L72",
       "id": "graph_search_applylinkhighlight",
-      "community": 266
+      "community": 267
     },
     {
       "label": "embedding-map.js",
@@ -48777,7 +48809,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 666
+      "community": 668
     },
     {
       "label": "refreshChartIfActive()",
@@ -48785,7 +48817,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L13",
       "id": "embedding_map_refreshchartifactive",
-      "community": 666
+      "community": 668
     },
     {
       "label": "initEmbeddingMap()",
@@ -48793,7 +48825,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_initembeddingmap",
-      "community": 666
+      "community": 668
     },
     {
       "label": "anchor-map-search.js",
@@ -48801,7 +48833,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_search_js",
-      "community": 320
+      "community": 321
     },
     {
       "label": "renderSearchResultsList()",
@@ -48809,7 +48841,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L13",
       "id": "anchor_map_search_rendersearchresultslist",
-      "community": 320
+      "community": 321
     },
     {
       "label": "updateNodeHighlight()",
@@ -48817,7 +48849,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L44",
       "id": "anchor_map_search_updatenodehighlight",
-      "community": 320
+      "community": 321
     },
     {
       "label": "highlightSearchResults()",
@@ -48825,7 +48857,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L86",
       "id": "anchor_map_search_highlightsearchresults",
-      "community": 320
+      "community": 321
     },
     {
       "label": "performSearch()",
@@ -48833,7 +48865,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L116",
       "id": "anchor_map_search_performsearch",
-      "community": 320
+      "community": 321
     },
     {
       "label": "clearSearch()",
@@ -48841,7 +48873,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L154",
       "id": "anchor_map_search_clearsearch",
-      "community": 320
+      "community": 321
     },
     {
       "label": "displaySearchResultDetails()",
@@ -48849,7 +48881,7 @@
       "source_file": "static/js/anchor-map-search.js",
       "source_location": "L168",
       "id": "anchor_map_search_displaysearchresultdetails",
-      "community": 320
+      "community": 321
     },
     {
       "label": "anchor-map-data.js",
@@ -49345,7 +49377,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_render_js",
-      "community": 321
+      "community": 322
     },
     {
       "label": "ratioText()",
@@ -49353,7 +49385,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L12",
       "id": "review_candidates_panel_health_render_ratiotext",
-      "community": 321
+      "community": 322
     },
     {
       "label": "formatHealthMetricCard()",
@@ -49361,7 +49393,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L19",
       "id": "review_candidates_panel_health_render_formathealthmetriccard",
-      "community": 321
+      "community": 322
     },
     {
       "label": "renderLiveHealthHtml()",
@@ -49369,7 +49401,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L29",
       "id": "review_candidates_panel_health_render_renderlivehealthhtml",
-      "community": 321
+      "community": 322
     },
     {
       "label": "renderHealthSnapshotsTable()",
@@ -49377,7 +49409,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L45",
       "id": "review_candidates_panel_health_render_renderhealthsnapshotstable",
-      "community": 321
+      "community": 322
     },
     {
       "label": "formatDurationMs()",
@@ -49385,7 +49417,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L77",
       "id": "review_candidates_panel_health_render_formatdurationms",
-      "community": 321
+      "community": 322
     },
     {
       "label": "renderBatchRunHistoryTable()",
@@ -49393,7 +49425,7 @@
       "source_file": "static/js/review-candidates-panel-health-render.js",
       "source_location": "L89",
       "id": "review_candidates_panel_health_render_renderbatchrunhistorytable",
-      "community": 321
+      "community": 322
     },
     {
       "label": "review-candidates-panel-render.js",
@@ -49569,7 +49601,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L1",
       "id": "static_js_graph_fetch_js",
-      "community": 667
+      "community": 669
     },
     {
       "label": "resetGraphState()",
@@ -49577,7 +49609,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L48",
       "id": "graph_fetch_resetgraphstate",
-      "community": 667
+      "community": 669
     },
     {
       "label": "handleGraphPayload()",
@@ -49585,7 +49617,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L62",
       "id": "graph_fetch_handlegraphpayload",
-      "community": 667
+      "community": 669
     },
     {
       "label": "embedding-map-panel.js",
@@ -54101,7 +54133,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L76",
+      "source_location": "L77",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_settestdependencies",
@@ -54113,7 +54145,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L99",
+      "source_location": "L100",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_resolvestaticroot",
@@ -54125,7 +54157,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L191",
+      "source_location": "L192",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_isprotectedmcpprogrammaticpath",
@@ -54137,7 +54169,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L195",
+      "source_location": "L196",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_gethttpauthtrustmodelnotice",
@@ -54149,7 +54181,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L199",
+      "source_location": "L200",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_gethttpauthmissingadminkeywarning",
@@ -54161,7 +54193,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L228",
+      "source_location": "L229",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_initializecoreservices",
@@ -54173,7 +54205,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L238",
+      "source_location": "L239",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_setupmiddleware",
@@ -54185,7 +54217,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L247",
+      "source_location": "L248",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_createcontextinjectionservice",
@@ -54197,7 +54229,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L262",
+      "source_location": "L263",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_createallrouters",
@@ -54209,7 +54241,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L290",
+      "source_location": "L291",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_registerroutes",
@@ -54221,7 +54253,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L319",
+      "source_location": "L325",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_logembeddingproviderinfo",
@@ -54233,7 +54265,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L336",
+      "source_location": "L342",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_initializeserver",
@@ -54245,7 +54277,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L360",
+      "source_location": "L366",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_cleanup",
@@ -54257,7 +54289,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L375",
+      "source_location": "L381",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_http_server_ts",
       "_tgt": "http_server_startserver",
@@ -54269,7 +54301,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L412",
+      "source_location": "L421",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_gethttpauthtrustmodelnotice",
@@ -54281,7 +54313,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L405",
+      "source_location": "L411",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_gethttpauthmissingadminkeywarning",
@@ -54293,7 +54325,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L341",
+      "source_location": "L347",
       "weight": 1.0,
       "_src": "http_server_initializeserver",
       "_tgt": "http_server_initializecoreservices",
@@ -54305,7 +54337,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L342",
+      "source_location": "L348",
       "weight": 1.0,
       "_src": "http_server_initializeserver",
       "_tgt": "http_server_setupmiddleware",
@@ -54317,7 +54349,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L282",
+      "source_location": "L283",
       "weight": 1.0,
       "_src": "http_server_createallrouters",
       "_tgt": "http_server_createcontextinjectionservice",
@@ -54329,7 +54361,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L287",
+      "source_location": "L288",
       "weight": 1.0,
       "_src": "http_server_createallrouters",
       "_tgt": "http_server_registerroutes",
@@ -54341,7 +54373,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L343",
+      "source_location": "L349",
       "weight": 1.0,
       "_src": "http_server_initializeserver",
       "_tgt": "http_server_createallrouters",
@@ -54353,7 +54385,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L348",
+      "source_location": "L354",
       "weight": 1.0,
       "_src": "http_server_initializeserver",
       "_tgt": "http_server_logembeddingproviderinfo",
@@ -54365,7 +54397,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L415",
+      "source_location": "L424",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_initializeserver",
@@ -54377,7 +54409,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/http-server.ts",
-      "source_location": "L418",
+      "source_location": "L427",
       "weight": 1.0,
       "_src": "http_server_startserver",
       "_tgt": "http_server_cleanup",
@@ -55049,7 +55081,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
-      "source_location": "L21",
+      "source_location": "L13",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
       "_tgt": "admin_auth_middleware_spec_makemocks",
@@ -55060,8 +55092,20 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
+      "source_location": "L23",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
+      "_tgt": "admin_auth_middleware_spec_createmiddleware",
+      "source": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
+      "target": "admin_auth_middleware_spec_createmiddleware",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L8",
+      "source_location": "L26",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "_tgt": "programmatic_auth_middleware_writedisabledresponse",
@@ -55073,7 +55117,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L28",
+      "source_location": "L46",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "_tgt": "programmatic_auth_middleware_writeunauthorized",
@@ -55085,7 +55129,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L48",
+      "source_location": "L66",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
+      "_tgt": "programmatic_auth_middleware_writeforbidden",
+      "source": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
+      "target": "programmatic_auth_middleware_writeforbidden",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L88",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "_tgt": "programmatic_auth_middleware_readbearertoken",
@@ -55097,7 +55153,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L58",
+      "source_location": "L98",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "_tgt": "programmatic_auth_middleware_readapikeyheader",
@@ -55109,12 +55165,48 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
-      "source_location": "L68",
+      "source_location": "L108",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
+      "_tgt": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "source": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
+      "target": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L128",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "_tgt": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
       "source": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_ts",
       "target": "programmatic_auth_middleware_createprogrammaticauthmiddleware",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L112",
+      "weight": 1.0,
+      "_src": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "_tgt": "programmatic_auth_middleware_readbearertoken",
+      "source": "programmatic_auth_middleware_readbearertoken",
+      "target": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts",
+      "source_location": "L120",
+      "weight": 1.0,
+      "_src": "programmatic_auth_middleware_resolveauthenticatedtoken",
+      "_tgt": "programmatic_auth_middleware_readapikeyheader",
+      "source": "programmatic_auth_middleware_readapikeyheader",
+      "target": "programmatic_auth_middleware_resolveauthenticatedtoken",
       "confidence_score": 1.0
     },
     {
@@ -55313,7 +55405,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
-      "source_location": "L14",
+      "source_location": "L16",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
       "_tgt": "admin_auth_middleware_createadminauthmiddleware",
@@ -55325,12 +55417,24 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
       "_tgt": "programmatic_auth_middleware_spec_createmockresponse",
       "source": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
       "target": "programmatic_auth_middleware_spec_createmockresponse",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
+      "source_location": "L21",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
+      "_tgt": "programmatic_auth_middleware_spec_createregistry",
+      "source": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
+      "target": "programmatic_auth_middleware_spec_createregistry",
       "confidence_score": 1.0
     },
     {
@@ -60077,7 +60181,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L630",
+      "source_location": "L633",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_setuptestdatabase",
@@ -60101,7 +60205,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L684",
+      "source_location": "L687",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_testbasicendpoints",
@@ -60113,7 +60217,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L685",
+      "source_location": "L688",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_testmcptools",
@@ -60125,7 +60229,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L686",
+      "source_location": "L689",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_testadminapis",
@@ -60137,7 +60241,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L687",
+      "source_location": "L690",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_testwebsocket",
@@ -60149,7 +60253,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
-      "source_location": "L688",
+      "source_location": "L691",
       "weight": 1.0,
       "_src": "test_http_server_v2_runtests",
       "_tgt": "test_http_server_v2_testsse",
@@ -86225,7 +86329,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/config/index.ts",
-      "source_location": "L163",
+      "source_location": "L165",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_config_index_ts",
       "_tgt": "index_validateconfig",
@@ -86465,7 +86569,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
-      "source_location": "L92",
+      "source_location": "L93",
       "weight": 1.0,
       "_src": "http_bind_policy_getmementohttpsecuritystartupviolationmessage",
       "_tgt": "http_bind_policy_ishttpbindhostremotelyreachable",

--- a/packages/memento-core/src/index.ts
+++ b/packages/memento-core/src/index.ts
@@ -116,6 +116,7 @@ export { logger } from './shared/utils/logger.js';
 export { loggingRateLimiter } from './shared/utils/logging-rate-limiter.js';
 export { withErrorHandling } from './shared/utils/error-handling.js';
 export type { MemoryItem } from './shared/types/index.js';
+export type { ApiScope, ApiTokenEntry } from './shared/types/api-token.js';
 export type { IErrorLoggingService } from './shared/interfaces/error-logging.interface.js';
 export { ErrorSeverity, ErrorCategory } from './shared/types/error-types.js';
 export type { AppErrorContract } from './shared/types/error-types.js';

--- a/packages/memento-core/src/shared/config/api-tokens.spec.ts
+++ b/packages/memento-core/src/shared/config/api-tokens.spec.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resetLegacyApiTokenDeprecationLogForTests, resolveApiTokens } from './api-tokens.js';
+
+describe('resolveApiTokens', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    resetLegacyApiTokenDeprecationLogForTests();
+  });
+
+  it('parses MEMENTO_API_TOKENS JSON array', () => {
+    vi.stubEnv(
+      'MEMENTO_API_TOKENS',
+      JSON.stringify([
+        { id: 'tools-1', secret: 'tools-secret', scopes: ['tools:invoke'] },
+        { id: 'admin-1', secret: 'admin-secret', scopes: ['admin:destructive'] },
+      ]),
+    );
+
+    const tokens = resolveApiTokens(undefined);
+    expect(tokens).toEqual([
+      { id: 'tools-1', secret: 'tools-secret', scopes: ['tools:invoke'] },
+      { id: 'admin-1', secret: 'admin-secret', scopes: ['admin:destructive'] },
+    ]);
+  });
+
+  it('synthesizes legacy-admin token when only ADMIN_API_KEY is set', () => {
+    const tokens = resolveApiTokens('legacy-key');
+    expect(tokens).toEqual([
+      {
+        id: 'legacy-admin',
+        secret: 'legacy-key',
+        scopes: ['tools:invoke', 'admin:destructive'],
+      },
+    ]);
+  });
+
+  it('returns empty array when no env tokens and no admin key', () => {
+    expect(resolveApiTokens(undefined)).toEqual([]);
+    expect(resolveApiTokens('   ')).toEqual([]);
+  });
+});

--- a/packages/memento-core/src/shared/config/api-tokens.ts
+++ b/packages/memento-core/src/shared/config/api-tokens.ts
@@ -1,0 +1,114 @@
+import { logger } from '../utils/logger.js';
+import type { ApiScope, ApiTokenEntry } from '../types/api-token.js';
+import { API_SCOPES } from '../types/api-token.js';
+import { getRawEnvValue } from './environment.js';
+
+const LEGACY_ADMIN_TOKEN_ID = 'legacy-admin';
+const LEGACY_DEPRECATION_MESSAGE =
+  'ADMIN_API_KEY is deprecated for programmatic HTTP access. ' +
+  'Migrate to MEMENTO_API_TOKENS with scoped tokens (tools:invoke, admin:destructive). ' +
+  'Legacy key currently grants both scopes via synthetic token id "legacy-admin".';
+
+let legacyDeprecationLogged = false;
+
+function isApiScope(value: unknown): value is ApiScope {
+  return typeof value === 'string' && (API_SCOPES as readonly string[]).includes(value);
+}
+
+function parseTokenEntry(raw: unknown, index: number): ApiTokenEntry | null {
+  if (typeof raw !== 'object' || raw === null) {
+    logger.warn('MEMENTO_API_TOKENS entry ignored: expected object', { index });
+    return null;
+  }
+
+  const record = raw as Record<string, unknown>;
+  const id = typeof record.id === 'string' ? record.id.trim() : '';
+  const secret = typeof record.secret === 'string' ? record.secret.trim() : '';
+  const scopesRaw = record.scopes;
+
+  if (!id || !secret) {
+    logger.warn('MEMENTO_API_TOKENS entry ignored: id and secret are required', { index, id: id || undefined });
+    return null;
+  }
+
+  if (!Array.isArray(scopesRaw) || scopesRaw.length === 0) {
+    logger.warn('MEMENTO_API_TOKENS entry ignored: scopes must be a non-empty array', { index, id });
+    return null;
+  }
+
+  const scopes: ApiScope[] = [];
+  for (const scope of scopesRaw) {
+    if (isApiScope(scope)) {
+      scopes.push(scope);
+    } else {
+      logger.warn('MEMENTO_API_TOKENS entry ignored: unknown scope', { index, id, scope });
+      return null;
+    }
+  }
+
+  return { id, secret, scopes };
+}
+
+function parseEnvTokens(raw: string): ApiTokenEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    logger.error('MEMENTO_API_TOKENS is not valid JSON; ignoring configured tokens', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) {
+    logger.error('MEMENTO_API_TOKENS must be a JSON array');
+    return [];
+  }
+
+  const tokens: ApiTokenEntry[] = [];
+  parsed.forEach((entry, index) => {
+    const token = parseTokenEntry(entry, index);
+    if (token) {
+      tokens.push(token);
+    }
+  });
+  return tokens;
+}
+
+function synthesizeLegacyAdminToken(adminApiKey: string): ApiTokenEntry {
+  if (!legacyDeprecationLogged) {
+    logger.warn(LEGACY_DEPRECATION_MESSAGE);
+    legacyDeprecationLogged = true;
+  }
+  return {
+    id: LEGACY_ADMIN_TOKEN_ID,
+    secret: adminApiKey.trim(),
+    scopes: ['tools:invoke', 'admin:destructive'],
+  };
+}
+
+/**
+ * Resolve programmatic API tokens from env.
+ * - MEMENTO_API_TOKENS JSON array when set and non-empty
+ * - else ADMIN_API_KEY synthesized as legacy-admin with both scopes (deprecation warn once)
+ */
+export function resolveApiTokens(adminApiKey: string | undefined): ApiTokenEntry[] {
+  const rawTokensEnv = getRawEnvValue('MEMENTO_API_TOKENS');
+  if (rawTokensEnv !== undefined && rawTokensEnv.trim() !== '') {
+    const envTokens = parseEnvTokens(rawTokensEnv.trim());
+    if (envTokens.length > 0) {
+      return envTokens;
+    }
+  }
+
+  if (adminApiKey && adminApiKey.trim() !== '') {
+    return [synthesizeLegacyAdminToken(adminApiKey)];
+  }
+
+  return [];
+}
+
+/** Test-only reset for deprecation log guard. */
+export function resetLegacyApiTokenDeprecationLogForTests(): void {
+  legacyDeprecationLogged = false;
+}

--- a/packages/memento-core/src/shared/config/index.ts
+++ b/packages/memento-core/src/shared/config/index.ts
@@ -7,6 +7,7 @@ import type { MementoConfig, EmbeddingProvider, LLMProvider } from '../types/ind
 import { validateConfiguration } from '../utils/configuration-validator.js';
 import { isValidConfigurationEnvironment } from '../utils/environment-check.js';
 import { parseTypeParamMode } from '../utils/type-param-validator.js';
+import { resolveApiTokens } from './api-tokens.js';
 import {
   providerDimensionDefaults,
   resolveNumber,
@@ -124,6 +125,7 @@ export const mementoConfig: MementoConfig = {
 
   // Admin/API/Quality 인증 (ADMIN_API_KEY 설정 시 해당 라우트에 Bearer 또는 X-API-Key 필요)
   adminApiKey: resolveOptionalString('ADMIN_API_KEY'),
+  apiTokens: resolveApiTokens(resolveOptionalString('ADMIN_API_KEY')),
 
   // HTTP 바인드·보안 (원격 바인딩 시 ADMIN_API_KEY 또는 루프백/명시적 insecure 필요)
   httpListenHost: resolveString('MEMENTO_HTTP_BIND_HOST', {

--- a/packages/memento-core/src/shared/http/http-bind-policy.spec.ts
+++ b/packages/memento-core/src/shared/http/http-bind-policy.spec.ts
@@ -98,13 +98,24 @@ describe('http-bind-policy', () => {
       ).toBeNull();
     });
 
+    it('returns null when scoped API tokens are configured on public bind', () => {
+      expect(
+        getMementoHttpSecurityStartupViolationMessage({
+          httpListenHost: '0.0.0.0',
+          adminApiKey: undefined,
+          apiTokens: [{ id: 'tools-1', secret: 'x', scopes: ['tools:invoke'] }],
+          allowInsecureHttpAdmin: false,
+        }),
+      ).toBeNull();
+    });
+
     it('returns message when public bind without key or insecure', () => {
       const msg = getMementoHttpSecurityStartupViolationMessage({
         httpListenHost: '0.0.0.0',
         adminApiKey: undefined,
         allowInsecureHttpAdmin: false
       });
-      expect(msg).toContain('ADMIN_API_KEY');
+      expect(msg).toContain('MEMENTO_API_TOKENS');
     });
   });
 });

--- a/packages/memento-core/src/shared/http/http-bind-policy.ts
+++ b/packages/memento-core/src/shared/http/http-bind-policy.ts
@@ -87,21 +87,23 @@ export function isHttpBindHostRemotelyReachable(host: string): boolean {
 export function getMementoHttpSecurityStartupViolationMessage(config: {
   httpListenHost: string;
   adminApiKey: string | undefined;
+  apiTokens?: readonly unknown[];
   allowInsecureHttpAdmin: boolean;
 }): string | null {
   if (!isHttpBindHostRemotelyReachable(config.httpListenHost)) {
     return null;
   }
-  const hasKey = !!(config.adminApiKey && config.adminApiKey.trim() !== '');
-  if (hasKey) {
+  const hasLegacyKey = !!(config.adminApiKey && config.adminApiKey.trim() !== '');
+  const hasTokens = (config.apiTokens?.length ?? 0) > 0;
+  if (hasLegacyKey || hasTokens) {
     return null;
   }
   if (config.allowInsecureHttpAdmin) {
     return null;
   }
   return (
-    'HTTP 서버가 루프백이 아닌 주소에 바인딩되어 있는데 ADMIN_API_KEY가 없습니다. ' +
-    '관리·API·품질 경로 무인증 노출을 막으려면 ADMIN_API_KEY를 설정하거나, ' +
+    'HTTP 서버가 루프백이 아닌 주소에 바인딩되어 있는데 programmatic API 토큰이 없습니다. ' +
+    '관리·API·품질 경로 무인증 노출을 막으려면 MEMENTO_API_TOKENS 또는 ADMIN_API_KEY를 설정하거나, ' +
     '로컬 전용으로 루프백 주소(예: 127.0.0.1, ::1)를 MEMENTO_HTTP_BIND_HOST에 두세요. ' +
     '개발 전용 위험 허용은 MEMENTO_ALLOW_INSECURE_HTTP_ADMIN=true (문서 필독).'
   );

--- a/packages/memento-core/src/shared/types/api-token.ts
+++ b/packages/memento-core/src/shared/types/api-token.ts
@@ -1,0 +1,12 @@
+/**
+ * HTTP programmatic API token scopes (Issue #662).
+ */
+export type ApiScope = 'tools:invoke' | 'admin:destructive';
+
+export const API_SCOPES: readonly ApiScope[] = ['tools:invoke', 'admin:destructive'] as const;
+
+export type ApiTokenEntry = {
+  id: string;
+  secret: string;
+  scopes: ApiScope[];
+};

--- a/packages/memento-core/src/shared/types/index.ts
+++ b/packages/memento-core/src/shared/types/index.ts
@@ -235,6 +235,9 @@ export interface StoredEmbeddingProviderStats {
   avg_dimensions: number;
 }
 
+export type { ApiScope, ApiTokenEntry } from './api-token.js';
+import type { ApiTokenEntry } from './api-token.js';
+
 export interface MementoConfig {
   dbPath: string;
   serverName: string;
@@ -305,6 +308,8 @@ export interface MementoConfig {
   corsAllowedOrigins: string[];
   // Admin/API/Quality 라우트 인증: 설정 시 Authorization: Bearer <key> 또는 X-API-Key: <key> 필요
   adminApiKey: string | undefined;
+  /** MEMENTO_API_TOKENS 또는 legacy ADMIN_API_KEY에서 파생된 programmatic API 토큰 */
+  apiTokens: ApiTokenEntry[];
   /** HTTP 서버 바인드 주소 (MEMENTO_HTTP_BIND_HOST, 미설정 시 기본 127.0.0.1) */
   httpListenHost: string;
   /**

--- a/packages/memento-server/src/server/auth/api-token-registry.spec.ts
+++ b/packages/memento-server/src/server/auth/api-token-registry.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { createApiTokenRegistry, hasScope } from './api-token-registry.js';
+
+describe('api-token-registry', () => {
+  it('resolves configured secrets and checks scopes', () => {
+    const registry = createApiTokenRegistry([
+      { id: 'tools-1', secret: 'tools-secret', scopes: ['tools:invoke'] },
+      { id: 'admin-1', secret: 'admin-secret', scopes: ['admin:destructive', 'tools:invoke'] },
+    ]);
+
+    expect(registry.hasConfiguredTokens()).toBe(true);
+
+    const tools = registry.resolveToken('tools-secret');
+    expect(tools).toEqual({ id: 'tools-1', scopes: ['tools:invoke'] });
+    expect(hasScope(tools!.scopes, 'tools:invoke')).toBe(true);
+    expect(hasScope(tools!.scopes, 'admin:destructive')).toBe(false);
+
+    const admin = registry.resolveToken('admin-secret');
+    expect(hasScope(admin!.scopes, ['tools:invoke', 'admin:destructive'])).toBe(true);
+    expect(registry.resolveToken('missing')).toBeNull();
+  });
+});

--- a/packages/memento-server/src/server/auth/api-token-registry.ts
+++ b/packages/memento-server/src/server/auth/api-token-registry.ts
@@ -1,0 +1,44 @@
+import type { ApiScope, ApiTokenEntry } from '@memento/core';
+
+export type ResolvedApiToken = {
+  id: string;
+  scopes: ApiScope[];
+};
+
+export type ApiTokenRegistry = {
+  hasConfiguredTokens: () => boolean;
+  resolveToken: (secret: string | null | undefined) => ResolvedApiToken | null;
+};
+
+export function createApiTokenRegistry(tokens: readonly ApiTokenEntry[]): ApiTokenRegistry {
+  const bySecret = new Map<string, ResolvedApiToken>();
+
+  for (const token of tokens) {
+    const secret = token.secret.trim();
+    if (!secret) {
+      continue;
+    }
+    bySecret.set(secret, { id: token.id, scopes: [...token.scopes] });
+  }
+
+  return {
+    hasConfiguredTokens(): boolean {
+      return bySecret.size > 0;
+    },
+    resolveToken(secret: string | null | undefined): ResolvedApiToken | null {
+      if (!secret) {
+        return null;
+      }
+      const trimmed = secret.trim();
+      return trimmed === '' ? null : (bySecret.get(trimmed) ?? null);
+    },
+  };
+}
+
+export function hasScope(
+  scopes: readonly ApiScope[],
+  required: ApiScope | ApiScope[],
+): boolean {
+  const requiredScopes = Array.isArray(required) ? required : [required];
+  return requiredScopes.every((scope) => scopes.includes(scope));
+}

--- a/packages/memento-server/src/server/http-server.ts
+++ b/packages/memento-server/src/server/http-server.ts
@@ -43,13 +43,14 @@ import { createAuthRouter } from './routes/auth.routes.js';
 import { createMcpRouter,type SSETransport } from './routes/mcp.routes.js';
 import { createQualityRouter } from './routes/quality.routes.js';
 import { createToolsRouter } from './routes/tools.routes.js';
+import { createApiTokenRegistry } from './auth/api-token-registry.js';
 import {
-createAdminAuthMiddleware,
-createProgrammaticAuthMiddleware,
-createServiceInjector,
-createSessionAuthMiddleware,
-createToolContextMiddleware,
-errorHandler
+  createAdminAuthMiddleware,
+  createProgrammaticAuthMiddleware,
+  createServiceInjector,
+  createSessionAuthMiddleware,
+  createToolContextMiddleware,
+  errorHandler
 } from './middleware/index.js';
 import {
   createRuntimeDiagnosticsWriter,
@@ -184,9 +185,9 @@ const DASHBOARD_SESSION_IDLE_TTL_MS = 15 * 60 * 1000;
 const DASHBOARD_SESSION_ABSOLUTE_TTL_MS = 8 * 60 * 60 * 1000;
 
 const HTTP_AUTH_TRUST_MODEL_NOTICE =
-  'HTTP trust model: /auth/session starts the browser-session cookie flow; /admin and /api require a browser session; /api/v1/quality, /api/v1/agent, /tools, /mcp, and /messages require Authorization Bearer or X-API-Key.';
+  'HTTP trust model: /auth/session starts the browser-session cookie flow; /admin and /api require a browser session; /api/v1/quality requires admin:destructive scope; /api/v1/agent, /tools, /mcp, and /messages require tools:invoke scope (Authorization Bearer or X-API-Key).';
 const HTTP_AUTH_MISSING_ADMIN_KEY_WARNING =
-  'ADMIN_API_KEY is not configured: /api/v1/quality, /api/v1/agent, /tools, /mcp, and /messages fail closed with 401 until ADMIN_API_KEY is set.';
+  'No programmatic API tokens configured: /api/v1/quality, /api/v1/agent, /tools, /mcp, and /messages fail closed with 401 until MEMENTO_API_TOKENS or ADMIN_API_KEY is set.';
 
 function isProtectedMcpProgrammaticPath(pathname: string): boolean {
   return /^\/(?:mcp|messages)\/?$/.test(pathname);
@@ -292,10 +293,15 @@ function registerRoutes(qualityRouter: express.Router, agentRouter: express.Rout
     store: adminSessionStore!,
     cookieName: DASHBOARD_SESSION_COOKIE_NAME
   });
-  const adminAuth = createAdminAuthMiddleware();
-  const programmaticAuth = createProgrammaticAuthMiddleware({ expectedKey: mementoConfig.adminApiKey });
+  const tokenRegistry = createApiTokenRegistry(mementoConfig.apiTokens);
+  const adminAuth = createAdminAuthMiddleware(tokenRegistry);
+  const programmaticAuth = createProgrammaticAuthMiddleware({
+    registry: tokenRegistry,
+    requiredScope: 'tools:invoke',
+  });
   const agentProgrammaticAuth = createProgrammaticAuthMiddleware({
-    expectedKey: mementoConfig.adminApiKey,
+    registry: tokenRegistry,
+    requiredScope: 'tools:invoke',
     errorFormat: 'agent',
   });
   const mcpProgrammaticAuth: express.RequestHandler = (req, res, next) => {
@@ -384,6 +390,7 @@ export async function startServer() {
   const securityViolation = getMementoHttpSecurityStartupViolationMessage({
     httpListenHost: bindHostRaw,
     adminApiKey: mementoConfig.adminApiKey,
+    apiTokens: mementoConfig.apiTokens,
     allowInsecureHttpAdmin: mementoConfig.allowInsecureHttpAdmin
   });
   if (securityViolation) {
@@ -399,11 +406,13 @@ export async function startServer() {
     );
   }
 
-  // FR-003: ADMIN_API_KEY 미설정 시 경고 (loopback 포함 항상 emit)
-  const adminKey = mementoConfig.adminApiKey;
-  if (!adminKey || adminKey.trim() === '') {
+  // FR-003: programmatic API 토큰 미설정 시 경고 (loopback 포함 항상 emit)
+  if (mementoConfig.apiTokens.length === 0) {
     logger.warn(getHttpAuthMissingAdminKeyWarning());
-  } else if ([...adminKey].some((char) => char.charCodeAt(0) > 0x7f)) {
+  } else if (
+    mementoConfig.adminApiKey &&
+    [...mementoConfig.adminApiKey].some((char) => char.charCodeAt(0) > 0x7f)
+  ) {
     logger.warn(
       'ADMIN_API_KEY contains non-ASCII characters: browser-based dashboard sign-in or programmatic clients may fail to send Authorization reliably (use ASCII-only keys, e.g. hex or base64url).'
     );

--- a/packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts
+++ b/packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts
@@ -1,31 +1,36 @@
 /**
  * admin-auth.middleware.ts 테스트
  *
- * US2: fail-closed 동작 — ADMIN_API_KEY 미설정 시 모든 요청에 401 반환
+ * US2: fail-closed 동작 — API 토큰 미설정 시 모든 요청에 401 반환
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { Request, Response, NextFunction } from 'express';
 
-// mementoConfig mock
-vi.mock('@memento/core', () => ({
-  mementoConfig: {
-    adminApiKey: undefined as string | undefined
-  }
-}));
-
-import { mementoConfig } from '@memento/core';
+import { createApiTokenRegistry } from '../auth/api-token-registry.js';
 import { createAdminAuthMiddleware } from './admin-auth.middleware.js';
 
-// Helper: mock Express request/response/next
 function makeMocks() {
   const req = {} as Request;
   const res = {
     status: vi.fn().mockReturnThis(),
-    json: vi.fn().mockReturnThis()
+    json: vi.fn().mockReturnThis(),
   } as unknown as Response;
   const next = vi.fn() as unknown as NextFunction;
   return { req, res, next };
+}
+
+function createMiddleware(secret: string | undefined) {
+  const registry = secret
+    ? createApiTokenRegistry([
+        {
+          id: 'legacy-admin',
+          secret,
+          scopes: ['tools:invoke', 'admin:destructive'],
+        },
+      ])
+    : createApiTokenRegistry([]);
+  return createAdminAuthMiddleware(registry);
 }
 
 describe('createAdminAuthMiddleware — fail-closed behavior', () => {
@@ -33,10 +38,8 @@ describe('createAdminAuthMiddleware — fail-closed behavior', () => {
     vi.clearAllMocks();
   });
 
-  // T008: ADMIN_API_KEY absent → 401
-  it('returns 401 when ADMIN_API_KEY is absent (undefined)', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = undefined;
-    const middleware = createAdminAuthMiddleware();
+  it('returns 401 when no API tokens are configured', () => {
+    const middleware = createMiddleware(undefined);
     const { req, res, next } = makeMocks();
 
     middleware(req, res, next);
@@ -45,55 +48,27 @@ describe('createAdminAuthMiddleware — fail-closed behavior', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         error: 'Unauthorized',
-        message: expect.stringContaining('ADMIN_API_KEY')
-      })
+        message: expect.stringContaining('MEMENTO_API_TOKENS'),
+      }),
     );
     expect(next).not.toHaveBeenCalled();
   });
 
-  // T009: ADMIN_API_KEY empty string → 401
-  it('returns 401 when ADMIN_API_KEY is empty string', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = '';
-    const middleware = createAdminAuthMiddleware();
+  it('returns 401 when API token secret is empty', () => {
+    const middleware = createMiddleware('   ');
     const { req, res, next } = makeMocks();
 
     middleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: 'Unauthorized',
-        message: expect.stringContaining('ADMIN_API_KEY')
-      })
-    );
     expect(next).not.toHaveBeenCalled();
   });
 
-  // T010: ADMIN_API_KEY whitespace only → 401
-  it('returns 401 when ADMIN_API_KEY is whitespace only', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = '   ';
-    const middleware = createAdminAuthMiddleware();
-    const { req, res, next } = makeMocks();
-
-    middleware(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: 'Unauthorized',
-        message: expect.stringContaining('ADMIN_API_KEY')
-      })
-    );
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  // T011: ADMIN_API_KEY set and correct key provided → allow (next called)
-  it('allows request when correct ADMIN_API_KEY is provided via Authorization header', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = 'secret-key-123';
-    const middleware = createAdminAuthMiddleware();
+  it('allows request when correct admin token is provided via Authorization header', () => {
+    const middleware = createMiddleware('secret-key-123');
     const { req, res, next } = makeMocks();
     (req as Request & { headers: Record<string, string> }).headers = {
-      authorization: 'Bearer secret-key-123'
+      authorization: 'Bearer secret-key-123',
     };
 
     middleware(req, res, next);
@@ -102,12 +77,11 @@ describe('createAdminAuthMiddleware — fail-closed behavior', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('allows request when correct ADMIN_API_KEY is provided via X-API-Key header', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = 'secret-key-123';
-    const middleware = createAdminAuthMiddleware();
+  it('allows request when correct admin token is provided via X-API-Key header', () => {
+    const middleware = createMiddleware('secret-key-123');
     const { req, res, next } = makeMocks();
     (req as Request & { headers: Record<string, string> }).headers = {
-      'x-api-key': 'secret-key-123'
+      'x-api-key': 'secret-key-123',
     };
 
     middleware(req, res, next);
@@ -116,28 +90,37 @@ describe('createAdminAuthMiddleware — fail-closed behavior', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when ADMIN_API_KEY is set but wrong key is provided', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = 'secret-key-123';
-    const middleware = createAdminAuthMiddleware();
+  it('returns 403 when token lacks admin:destructive scope', () => {
+    const registry = createApiTokenRegistry([
+      { id: 'tools-only', secret: 'tools-key', scopes: ['tools:invoke'] },
+    ]);
+    const middleware = createAdminAuthMiddleware(registry);
     const { req, res, next } = makeMocks();
     (req as Request & { headers: Record<string, string> }).headers = {
-      authorization: 'Bearer wrong-key'
+      authorization: 'Bearer tools-key',
+    };
+
+    middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token is set but wrong key is provided', () => {
+    const middleware = createMiddleware('secret-key-123');
+    const { req, res, next } = makeMocks();
+    (req as Request & { headers: Record<string, string> }).headers = {
+      authorization: 'Bearer wrong-key',
     };
 
     middleware(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('/api/v1/quality')
-      })
-    );
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when ADMIN_API_KEY is set but no key is provided', () => {
-    (mementoConfig as { adminApiKey: string | undefined }).adminApiKey = 'secret-key-123';
-    const middleware = createAdminAuthMiddleware();
+  it('returns 401 when token is set but no key is provided', () => {
+    const middleware = createMiddleware('secret-key-123');
     const { req, res, next } = makeMocks();
     (req as Request & { headers: Record<string, string> }).headers = {};
 

--- a/packages/memento-server/src/server/middleware/admin-auth.middleware.ts
+++ b/packages/memento-server/src/server/middleware/admin-auth.middleware.ts
@@ -1,44 +1,22 @@
 /**
- * Programmatic quality API용 ADMIN_API_KEY 인증 미들웨어.
+ * Programmatic quality API용 scoped token 인증 미들웨어.
  * 현재 HTTP trust model에서 이 미들웨어는 /api/v1/quality/* 에만 붙으며
  * 브라우저 세션이 아니라 Authorization / X-API-Key 헤더만 허용한다.
  *
  * fail-closed 동작:
- *   - ADMIN_API_KEY 미설정(absent/empty/whitespace) → 모든 요청에 401 반환
- *   - ADMIN_API_KEY 설정 시: Authorization: Bearer <key> 또는 X-API-Key: <key> 검증
+ *   - API 토큰 미설정 → 모든 요청에 401 반환
+ *   - 유효 토큰이 admin:destructive 스코프 없음 → 403
  */
 
-import type { Request, Response, NextFunction } from 'express';
 import { mementoConfig } from '@memento/core';
 
-export function createAdminAuthMiddleware(): (req: Request, res: Response, next: NextFunction) => void {
-  const expectedKey = mementoConfig.adminApiKey;
+import { createApiTokenRegistry, type ApiTokenRegistry } from '../auth/api-token-registry.js';
+import { createProgrammaticAuthMiddleware } from './programmatic-auth.middleware.js';
 
-  return (req: Request, res: Response, next: NextFunction): void => {
-    // fail-closed: ADMIN_API_KEY 미설정(absent/empty/whitespace) → 401
-    if (!expectedKey || expectedKey.trim() === '') {
-      res.status(401).json({
-        error: 'Unauthorized',
-        message: 'Quality API is disabled: ADMIN_API_KEY is not configured. Set ADMIN_API_KEY to enable /api/v1/quality access.',
-        timestamp: new Date().toISOString()
-      });
-      return;
-    }
-
-    const authHeader = req.headers.authorization;
-    const apiKeyHeader = req.headers['x-api-key'] as string | undefined;
-    const bearer = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : undefined;
-    const provided = bearer ?? apiKeyHeader?.trim();
-
-    if (provided === expectedKey) {
-      next();
-      return;
-    }
-
-    res.status(401).json({
-      error: 'Unauthorized',
-      message: 'The programmatic quality API (/api/v1/quality) requires a valid API key via Authorization: Bearer <key> or X-API-Key: <key>.',
-      timestamp: new Date().toISOString()
-    });
-  };
+export function createAdminAuthMiddleware(registry?: ApiTokenRegistry) {
+  const tokenRegistry = registry ?? createApiTokenRegistry(mementoConfig.apiTokens);
+  return createProgrammaticAuthMiddleware({
+    registry: tokenRegistry,
+    requiredScope: 'admin:destructive',
+  });
 }

--- a/packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts
+++ b/packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { createApiTokenRegistry } from '../auth/api-token-registry.js';
 import { createProgrammaticAuthMiddleware } from './programmatic-auth.middleware.js';
 
 function createMockResponse() {
@@ -17,6 +18,16 @@ function createMockResponse() {
   return res as Response & { statusCode: number; body?: unknown };
 }
 
+function createRegistry(secret = 'test-admin-key') {
+  return createApiTokenRegistry([
+    {
+      id: 'legacy-admin',
+      secret,
+      scopes: ['tools:invoke', 'admin:destructive'],
+    },
+  ]);
+}
+
 describe('createProgrammaticAuthMiddleware', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -24,12 +35,13 @@ describe('createProgrammaticAuthMiddleware', () => {
 
   it('rejects cookie-only requests', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: 'test-admin-key'
+      registry: createRegistry(),
+      requiredScope: 'tools:invoke',
     });
     const req = {
       headers: {
-        cookie: 'memento_admin_session=session-123'
-      }
+        cookie: 'memento_admin_session=session-123',
+      },
     } as Request;
     const res = createMockResponse();
     const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
@@ -39,20 +51,21 @@ describe('createProgrammaticAuthMiddleware', () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.body).toEqual(
       expect.objectContaining({
-        error: 'Unauthorized'
-      })
+        error: 'Unauthorized',
+      }),
     );
     expect(next).not.toHaveBeenCalled();
   });
 
   it('allows requests with a valid Authorization Bearer token', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: 'test-admin-key'
+      registry: createRegistry(),
+      requiredScope: 'tools:invoke',
     });
     const req = {
       headers: {
-        authorization: 'Bearer test-admin-key'
-      }
+        authorization: 'Bearer test-admin-key',
+      },
     } as Request;
     const res = createMockResponse();
     const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
@@ -60,17 +73,22 @@ describe('createProgrammaticAuthMiddleware', () => {
     middleware(req, res, next);
 
     expect(next).toHaveBeenCalledOnce();
+    expect(req.programmaticAuth).toEqual({
+      keyId: 'legacy-admin',
+      scopes: ['tools:invoke', 'admin:destructive'],
+    });
     expect(res.status).not.toHaveBeenCalled();
   });
 
   it('allows requests with a valid X-API-Key header', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: 'test-admin-key'
+      registry: createRegistry(),
+      requiredScope: 'tools:invoke',
     });
     const req = {
       headers: {
-        'x-api-key': 'test-admin-key'
-      }
+        'x-api-key': 'test-admin-key',
+      },
     } as Request;
     const res = createMockResponse();
     const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
@@ -83,13 +101,14 @@ describe('createProgrammaticAuthMiddleware', () => {
 
   it('accepts a valid X-API-Key even when Authorization is invalid', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: 'test-admin-key'
+      registry: createRegistry(),
+      requiredScope: 'tools:invoke',
     });
     const req = {
       headers: {
         authorization: 'Bearer wrong-key',
-        'x-api-key': 'test-admin-key'
-      }
+        'x-api-key': 'test-admin-key',
+      },
     } as Request;
     const res = createMockResponse();
     const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
@@ -100,14 +119,15 @@ describe('createProgrammaticAuthMiddleware', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('returns 401 when ADMIN_API_KEY is missing', () => {
+  it('returns 401 when no API tokens are configured', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: undefined
+      registry: createApiTokenRegistry([]),
+      requiredScope: 'tools:invoke',
     });
     const req = {
       headers: {
-        authorization: 'Bearer test-admin-key'
-      }
+        authorization: 'Bearer test-admin-key',
+      },
     } as Request;
     const res = createMockResponse();
     const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
@@ -118,15 +138,43 @@ describe('createProgrammaticAuthMiddleware', () => {
     expect(res.body).toEqual(
       expect.objectContaining({
         error: 'Unauthorized',
-        message: 'Programmatic API is disabled: ADMIN_API_KEY is not configured.'
-      })
+        message: 'Programmatic API is disabled: configure MEMENTO_API_TOKENS or ADMIN_API_KEY.',
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when token lacks required scope', () => {
+    const middleware = createProgrammaticAuthMiddleware({
+      registry: createApiTokenRegistry([
+        { id: 'tools-only', secret: 'tools-key', scopes: ['tools:invoke'] },
+      ]),
+      requiredScope: 'admin:destructive',
+    });
+    const req = {
+      headers: {
+        authorization: 'Bearer tools-key',
+      },
+    } as Request;
+    const res = createMockResponse();
+    const next = vi.fn<Parameters<NextFunction>, ReturnType<NextFunction>>();
+
+    middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        error: 'Forbidden',
+        message: expect.stringContaining('admin:destructive'),
+      }),
     );
     expect(next).not.toHaveBeenCalled();
   });
 
   it('returns the stable agent API error envelope when requested', () => {
     const middleware = createProgrammaticAuthMiddleware({
-      expectedKey: 'test-admin-key',
+      registry: createRegistry(),
+      requiredScope: 'tools:invoke',
       errorFormat: 'agent',
     });
     const req = { headers: {} } as Request;

--- a/packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts
+++ b/packages/memento-server/src/server/middleware/programmatic-auth.middleware.ts
@@ -1,7 +1,25 @@
+import type { ApiScope } from '@memento/core';
 import type { NextFunction, Request, Response } from 'express';
 
+import {
+  hasScope,
+  type ApiTokenRegistry,
+} from '../auth/api-token-registry.js';
+
+declare global {
+  namespace Express {
+    interface Request {
+      programmaticAuth?: {
+        keyId: string;
+        scopes: ApiScope[];
+      };
+    }
+  }
+}
+
 export type ProgrammaticAuthMiddlewareConfig = {
-  expectedKey: string | undefined | null;
+  registry: ApiTokenRegistry;
+  requiredScope: ApiScope | ApiScope[];
   errorFormat?: 'legacy' | 'agent';
 };
 
@@ -13,15 +31,15 @@ function writeDisabledResponse(
     res.status(401).json({
       status: 401,
       reason_code: 'AUTH_FAILED',
-      message: 'Programmatic API is disabled: ADMIN_API_KEY is not configured.',
+      message: 'Programmatic API is disabled: no API tokens are configured.',
       retryable: false,
     });
     return;
   }
   res.status(401).json({
     error: 'Unauthorized',
-    message: 'Programmatic API is disabled: ADMIN_API_KEY is not configured.',
-    timestamp: new Date().toISOString()
+    message: 'Programmatic API is disabled: configure MEMENTO_API_TOKENS or ADMIN_API_KEY.',
+    timestamp: new Date().toISOString(),
   });
 }
 
@@ -41,7 +59,29 @@ function writeUnauthorized(
   res.status(401).json({
     error: 'Unauthorized',
     message: 'Programmatic routes require Authorization: Bearer <key> or X-API-Key.',
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function writeForbidden(
+  res: Response,
+  requiredScope: ApiScope | ApiScope[],
+  format: ProgrammaticAuthMiddlewareConfig['errorFormat'],
+): void {
+  const required = Array.isArray(requiredScope) ? requiredScope.join(', ') : requiredScope;
+  if (format === 'agent') {
+    res.status(403).json({
+      status: 403,
+      reason_code: 'FORBIDDEN',
+      message: `Insufficient API token scope. Required: ${required}.`,
+      retryable: false,
+    });
+    return;
+  }
+  res.status(403).json({
+    error: 'Forbidden',
+    message: `Insufficient API token scope. Required: ${required}.`,
+    timestamp: new Date().toISOString(),
   });
 }
 
@@ -65,26 +105,54 @@ function readApiKeyHeader(req: Request): string | null {
   return value === '' ? null : value;
 }
 
+function resolveAuthenticatedToken(
+  req: Request,
+  registry: ApiTokenRegistry,
+): ReturnType<ApiTokenRegistry['resolveToken']> {
+  const bearerToken = readBearerToken(req);
+  if (bearerToken) {
+    const resolved = registry.resolveToken(bearerToken);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const apiKeyHeader = readApiKeyHeader(req);
+  if (apiKeyHeader) {
+    return registry.resolveToken(apiKeyHeader);
+  }
+
+  return null;
+}
+
 export function createProgrammaticAuthMiddleware(config: ProgrammaticAuthMiddlewareConfig) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const expectedKey = config.expectedKey?.trim();
-    if (!expectedKey) {
+    if (!config.registry.hasConfiguredTokens()) {
       writeDisabledResponse(res, config.errorFormat);
       return;
     }
 
-    const bearerToken = readBearerToken(req);
-    if (bearerToken === expectedKey) {
-      next();
+    const hasCredential = readBearerToken(req) !== null || readApiKeyHeader(req) !== null;
+    if (!hasCredential) {
+      writeUnauthorized(res, config.errorFormat);
       return;
     }
 
-    const apiKeyHeader = readApiKeyHeader(req);
-    if (apiKeyHeader === expectedKey) {
-      next();
+    const resolved = resolveAuthenticatedToken(req, config.registry);
+    if (!resolved) {
+      writeUnauthorized(res, config.errorFormat);
       return;
     }
 
-    writeUnauthorized(res, config.errorFormat);
+    if (!hasScope(resolved.scopes, config.requiredScope)) {
+      writeForbidden(res, config.requiredScope, config.errorFormat);
+      return;
+    }
+
+    req.programmaticAuth = {
+      keyId: resolved.id,
+      scopes: [...resolved.scopes],
+    };
+    next();
   };
 }

--- a/packages/memento-server/src/server/scoped-api-tokens.integration.spec.ts
+++ b/packages/memento-server/src/server/scoped-api-tokens.integration.spec.ts
@@ -1,0 +1,155 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanupTestDatabase,
+  setupTestDatabase,
+  type TestDatabaseContext,
+} from './test/helpers/test-database.js';
+
+type HttpResponse = {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+};
+
+function getRequest(
+  port: number,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method: 'GET',
+        headers: {
+          Connection: 'close',
+          ...headers,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('scoped API tokens integration', () => {
+  let ctx: TestDatabaseContext | null = null;
+  let closeServer: (() => Promise<void>) | null = null;
+
+  async function startRealHttpServer(): Promise<number> {
+    const { __test, cleanup } = await import('./http-server.js');
+    __test.setTestDependencies({
+      database: ctx!.db,
+      serverServices: ctx!.services,
+    });
+    await __test.initializeServer();
+
+    const server = __test.getServer() as http.Server;
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    closeServer = async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await cleanup();
+    };
+
+    return (server.address() as AddressInfo).port;
+  }
+
+  beforeEach(async () => {
+    vi.stubEnv('ADMIN_API_KEY', '');
+    vi.resetModules();
+    ctx = await setupTestDatabase();
+  });
+
+  afterEach(async () => {
+    if (closeServer) {
+      await closeServer();
+      closeServer = null;
+    }
+    await cleanupTestDatabase(ctx);
+    ctx = null;
+    vi.unstubAllEnvs();
+  });
+
+  it('tools token: /tools OK, /api/v1/quality 403', async () => {
+    vi.stubEnv(
+      'MEMENTO_API_TOKENS',
+      JSON.stringify([
+        { id: 'tools-1', secret: 'tools-only-secret', scopes: ['tools:invoke'] },
+      ]),
+    );
+    vi.resetModules();
+
+    const port = await startRealHttpServer();
+
+    const tools = await getRequest(port, '/tools', {
+      Authorization: 'Bearer tools-only-secret',
+    });
+    expect(tools.statusCode).toBe(200);
+
+    const quality = await getRequest(port, '/api/v1/quality/metrics', {
+      Authorization: 'Bearer tools-only-secret',
+    });
+    expect(quality.statusCode).toBe(403);
+    expect(quality.body).toContain('admin:destructive');
+  });
+
+  it('admin token: /tools and /api/v1/quality both OK', async () => {
+    vi.stubEnv(
+      'MEMENTO_API_TOKENS',
+      JSON.stringify([
+        {
+          id: 'admin-1',
+          secret: 'admin-secret',
+          scopes: ['admin:destructive', 'tools:invoke'],
+        },
+      ]),
+    );
+    vi.resetModules();
+
+    const port = await startRealHttpServer();
+
+    const tools = await getRequest(port, '/tools', {
+      Authorization: 'Bearer admin-secret',
+    });
+    expect(tools.statusCode).toBe(200);
+
+    const quality = await getRequest(port, '/api/v1/quality/metrics', {
+      Authorization: 'Bearer admin-secret',
+    });
+    expect(quality.statusCode).toBe(200);
+  });
+
+  it('legacy ADMIN_API_KEY: /tools and /api/v1/quality both OK', async () => {
+    vi.stubEnv('ADMIN_API_KEY', 'legacy-integration-key');
+    vi.resetModules();
+
+    const port = await startRealHttpServer();
+
+    const tools = await getRequest(port, '/tools', {
+      Authorization: 'Bearer legacy-integration-key',
+    });
+    expect(tools.statusCode).toBe(200);
+
+    const quality = await getRequest(port, '/api/v1/quality/metrics', {
+      Authorization: 'Bearer legacy-integration-key',
+    });
+    expect(quality.statusCode).toBe(200);
+  });
+});

--- a/packages/memento-server/src/test/test-http-server-v2.ts
+++ b/packages/memento-server/src/test/test-http-server-v2.ts
@@ -602,6 +602,9 @@ async function runTests() {
   process.env.ADMIN_API_KEY = process.env.ADMIN_API_KEY || TEST_ADMIN_API_KEY;
   process.env.DB_PATH = process.env.DB_PATH || TEST_DB_PATH;
   mementoConfig.adminApiKey = process.env.ADMIN_API_KEY;
+  mementoConfig.apiTokens = process.env.ADMIN_API_KEY
+    ? [{ id: 'legacy-admin', secret: process.env.ADMIN_API_KEY, scopes: ['tools:invoke', 'admin:destructive'] }]
+    : [];
   mementoConfig.dbPath = process.env.DB_PATH;
   
   let testDb: Database.Database | null = null;

--- a/specs/044-http-scoped-api-tokens/plan.md
+++ b/specs/044-http-scoped-api-tokens/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: HTTP Scoped API Tokens (#662)
+
+## Architecture
+
+```text
+MEMENTO_API_TOKENS (env JSON)
+        ↓
+memento-core resolveApiTokens()
+        ↓
+mementoConfig.apiTokens[]
+        ↓
+createApiTokenRegistry() → programmatic-auth / admin-auth middleware
+        ↓
+Route mounts in http-server.ts (scope per prefix)
+```
+
+## Files
+
+| Layer | File | Change |
+|-------|------|--------|
+| core types | `shared/types/api-token.ts` | ApiScope, ApiTokenEntry |
+| core config | `shared/config/api-tokens.ts` | parse + legacy synthesis |
+| core config | `shared/config/index.ts` | `apiTokens` field |
+| server auth | `server/auth/api-token-registry.ts` | resolveToken, hasScope |
+| server | `middleware/programmatic-auth.middleware.ts` | scope-aware auth |
+| server | `middleware/admin-auth.middleware.ts` | admin:destructive wrapper |
+| server | `http-server.ts` | registry + route scopes |
+| tests | `scoped-api-tokens.integration.spec.ts` | matrix |
+| docs | `docs/reference/ko/security.md`, `docs/integrations/_shared/auth.md` | scoped tokens |
+
+## Migration
+
+1. 기존: `ADMIN_API_KEY` only → 동작 유지 (legacy-admin, warn once).
+2. 신규: `MEMENTO_API_TOKENS` JSON — tools 전용 + admin 전용 키 분리.
+3. 원격 바인드: `apiTokens.length > 0` 또는 `ADMIN_API_KEY` 필요.
+
+## Verification
+
+```bash
+npm run build
+npm run test:ci:server -- scoped-api-tokens
+npm run lint && npm run type-check
+```

--- a/specs/044-http-scoped-api-tokens/spec.md
+++ b/specs/044-http-scoped-api-tokens/spec.md
@@ -1,0 +1,44 @@
+# Feature Specification: HTTP Scoped API Tokens
+
+**Feature Branch**: `issue-662-http-scoped-tokens`  
+**Created**: 2026-07-05  
+**Issue**: [#662](https://github.com/jee1/memento/issues/662)
+
+## Problem
+
+단일 `ADMIN_API_KEY`는 모든 programmatic HTTP 표면(`/tools`, `/mcp`, `/api/v1/quality` 등)에 동일 권한을 부여합니다. 에이전트·자동화 클라이언트에는 `tools:invoke`만, 품질·파괴적 admin API에는 `admin:destructive`만 필요합니다.
+
+## User Scenarios
+
+### User Story 1 — 도구 전용 토큰 (P1)
+
+운영자가 MCP/도구 호출 전용 토큰을 발급하면 `/tools`, `/mcp`, `/api/v1/agent`만 접근 가능하고 `/api/v1/quality`는 403입니다.
+
+### User Story 2 — Admin programmatic 토큰 (P1)
+
+`admin:destructive` 스코프 토큰은 quality API와 tools 표면 모두 접근 가능합니다.
+
+### User Story 3 — Legacy ADMIN_API_KEY (P2)
+
+`MEMENTO_API_TOKENS` 미설정 시 기존 `ADMIN_API_KEY`는 synthetic `legacy-admin` 토큰으로 양쪽 스코프를 유지하며 deprecation 경고 1회를 남깁니다.
+
+## Requirements
+
+- **FR-001**: `MEMENTO_API_TOKENS` JSON 배열 — `{ id, secret, scopes[] }`.
+- **FR-002**: 스코프 enum — `tools:invoke`, `admin:destructive`.
+- **FR-003**: 라우트별 최소 스코프 — tools/mcp/agent → `tools:invoke`; quality → `admin:destructive`.
+- **FR-004**: 스코프 부족 시 403, 미인증/잘못된 토큰 401.
+- **FR-005**: legacy `ADMIN_API_KEY` synthetic token + startup deprecation warn once.
+- **FR-006**: integration test scoped token matrix; docs/security.md 갱신.
+
+## Out of Scope
+
+- SQLite `api_keys` 테이블
+- per-user OAuth / JWT refresh
+- Admin UI 토큰 발급 화면
+
+## Success Criteria
+
+- tools-only 토큰: `/tools` 200, `/api/v1/quality/*` 403
+- admin 토큰·legacy key: 양쪽 200
+- lint, type-check, server tests green

--- a/specs/044-http-scoped-api-tokens/tasks.md
+++ b/specs/044-http-scoped-api-tokens/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: HTTP Scoped API Tokens (#662)
+
+- [x] T001 ApiScope / ApiTokenEntry types in memento-core
+- [x] T002 resolveApiTokens + legacy ADMIN_API_KEY synthesis
+- [x] T003 api-token-registry (resolveToken, hasScope)
+- [x] T004 Refactor programmatic-auth middleware (requiredScope, req.programmaticAuth)
+- [x] T005 admin-auth middleware uses admin:destructive scope
+- [x] T006 http-server route mounting + startup messages
+- [x] T007 http-bind-policy accepts apiTokens for remote bind
+- [x] T008 scoped-api-tokens.integration.spec.ts matrix
+- [x] T009 docs/reference/ko/security.md + integrations auth.md
+- [x] T010 env.example MEMENTO_API_TOKENS + CHANGELOG Unreleased


### PR DESCRIPTION
## Summary

Epic #661 Phase 0 — 단일 `ADMIN_API_KEY` 공유 모델을 스코프드 토큰으로 분리합니다.

- `MEMENTO_API_TOKENS` JSON env: `tools:invoke`, `admin:destructive` 스코프
- Legacy `ADMIN_API_KEY` → synthetic `legacy-admin` (양쪽 스코프) + deprecation 경고
- tools-only 토큰은 `/api/v1/quality` 403, `/tools/*` 허용
- Integration test matrix: `scoped-api-tokens.integration.spec.ts`
- Spec Kit: `specs/044-http-scoped-api-tokens/`
- Docs: `docs/reference/ko/security.md`, `docs/integrations/_shared/auth.md`

Closes #662

## Test plan

- [x] `npm run test:ci:server` (503 tests)
- [ ] tools token → `/tools` OK, `/api/v1/quality` 403
- [ ] admin/legacy token → both OK

## Merge note

#663(audit)과 병합 시 `req.programmaticAuth.keyId` 활용 가능 — #662 선행 권장.


Made with [Cursor](https://cursor.com)