### PR TITLE
feat(consolidation): close #655 completion gaps for #656-#660

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Memento를 다른 앱이나 에이전트에 붙일 때는, **무엇을 호출할
 | 관계 그래프 API | [relation-graph-api.md](api/ko/relation-graph-api.md) | [relation-graph-api.md](api/en/relation-graph-api.md) |
 | 관계 타입 표준 | [relation-type-vocabulary.md](reference/ko/relation-type-vocabulary.md) | - |
 | 리소스 URI | [resource-uri.md](reference/ko/resource-uri.md) | - |
+| 이벤트 Outbox | [event-outbox.md](reference/ko/event-outbox.md) | [event-outbox.md](reference/en/event-outbox.md) |
 | 감사 해시 체인 | [audit-log.md](reference/ko/audit-log.md) | [audit-log.md](reference/en/audit-log.md) |
 | 보안 | [security.md](reference/ko/security.md) | [security.md](reference/en/security.md) |
 | 외부 비서 통합 | [integrations/README.md](integrations/README.md) | — |

--- a/docs/guides/ko/embedding-configuration.md
+++ b/docs/guides/ko/embedding-configuration.md
@@ -89,6 +89,34 @@ EMBEDDING_DIMENSIONS=384
 
 단순히 환경 변수만 바꾸고 기존 데이터를 그대로 사용하면 검색 품질이 저하될 수 있습니다.
 
+환경 변수를 바꾼 뒤에는 파생 임베딩을 재생성하세요. 명령의 provider 값과 환경 변수 값을 동일하게 맞춰야 합니다. 폴백이 발생하면 요청한 provider로 조용히 저장되는 대신 실패한 행으로 보고됩니다.
+
+```bash
+npm run reindex-embeddings -- --provider minilm --dry-run
+npm run reindex-embeddings -- --provider minilm --batch-size 100
+npm run reindex-embeddings -- --provider minilm --owner-id agent-42
+```
+
+JSON 결과에는 누락된 임베딩, 차원 불일치, provider drift 개수가 담깁니다. 재색인은 요청한 provider의 네이티브 임베딩만 기록하며, 벡터 provider를 사용할 수 없는 동안에도 FTS는 계속 사용할 수 있습니다.
+
+환경 변수만 바꾸고 기존 데이터를 그대로 두지 마세요.
+
+### HTTP 관리 API
+
+로컬 CLI를 사용할 수 없는 환경에서는 HTTP 서버가 동일한 작업을 비동기로 실행할 수 있습니다. `admin:destructive` 스코프 토큰이 필요하며, 완료 여부는 응답의 `statusUrl`로 확인합니다.
+
+```bash
+curl -sS -X POST http://127.0.0.1:9001/api/v1/maintenance/reindex \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"provider":"minilm","batchSize":100}'
+
+curl -sS -H "Authorization: Bearer $ADMIN_API_KEY" \
+  http://127.0.0.1:9001/api/v1/maintenance/reindex/<job-id>
+```
+
+작업과 상태는 HTTP 서버 프로세스 메모리에 보관됩니다. 서버를 재시작하면 작업 이력은 사라지지만, 이미 SQLite에 기록된 임베딩은 롤백되지 않습니다. provider를 바꿀 때는 먼저 `--dry-run`으로 실행한 뒤, 완료 후 `missingEmbeddingCount`, `dimensionMismatchCount`, `providerDriftCount`를 확인하세요.
+
 ## 완성된 설정 예시
 
 ### 로컬 전용 (API 없음, 권장 기본 설정)

--- a/docs/reference/en/event-outbox.md
+++ b/docs/reference/en/event-outbox.md
@@ -11,6 +11,7 @@
 | `memory.recalled` | `memory.search.selected` | selected `memory_id`, `query_hash`, `target_uri` |
 | `memory.forgotten` | new external event | deletion type, reason, `target_uri` |
 | `relation.added` | new external event | relation source, target, and `target_uri` |
+| `consolidation.completed` | `consolidation.performed` | `cluster_id`, `semantic_id`, `episodic_count`, `merged`, `method`, `target_uri` |
 
 Every row has a canonical `target_uri` such as `memento://owner-a/memory/mem_123`, a JSON payload containing the same `target_uri`, and a caller-provided idempotency key.
 
@@ -19,3 +20,7 @@ Every row has a canonical `target_uri` such as `memento://owner-a/memory/mem_123
 `EventOutboxService.publishPending()` polls rows due for delivery through an `EventOutboxPublisher` adapter. It marks `processed_at` only after `publish()` resolves. Failures increment `attempts`, retain `last_error`, and delay the next attempt with bounded exponential backoff, so delivery is at-least-once.
 
 The core does not configure a network destination. Redis Streams and webhook publishers belong behind the adapter interface and can be deployed independently. The outbox table is SQLite state, so include it in normal database backups.
+
+## Consolidation as a Decoupled Consumer (PoC)
+
+`SleepConsolidationService` enqueues `consolidation.completed` for every semantic memory it creates or merges, instead of calling downstream logic directly. `ConsolidationOutboxWorker` (`packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts`) implements `EventOutboxPublisher` and only reacts to that event type, proving that consolidation follow-up (notification, export, external aggregation) can run as a separate outbox consumer instead of being embedded in `BatchScheduler`. See `consolidation-outbox-worker.spec.ts` for the end-to-end example.

--- a/docs/reference/ko/event-outbox.md
+++ b/docs/reference/ko/event-outbox.md
@@ -11,6 +11,7 @@
 | `memory.recalled` | `memory.search.selected` | 선택된 `memory_id`, `query_hash`, `target_uri` |
 | `memory.forgotten` | 신규 외부 이벤트 | 삭제 방식, 사유, `target_uri` |
 | `relation.added` | 신규 외부 이벤트 | 관계 source, target, `target_uri` |
+| `consolidation.completed` | `consolidation.performed` | `cluster_id`, `semantic_id`, `episodic_count`, `merged`, `method`, `target_uri` |
 
 모든 row는 `memento://owner-a/memory/mem_123` 형태의 canonical `target_uri`, 같은 URI를 포함하는 JSON payload, 호출자가 지정한 idempotency key를 보관합니다.
 
@@ -19,3 +20,7 @@
 `EventOutboxService.publishPending()`은 `EventOutboxPublisher` adapter로 전달할 시점이 된 row를 polling합니다. `publish()`가 성공한 뒤에만 `processed_at`을 기록하고, 실패하면 `attempts`와 `last_error`를 갱신한 뒤 bounded exponential backoff로 재시도하므로 at-least-once 전달을 제공합니다.
 
 core는 네트워크 목적지를 구성하지 않습니다. Redis Stream과 webhook은 adapter interface 뒤에서 독립 배포하며, outbox 테이블은 SQLite 백업 대상에 포함해야 합니다.
+
+## Consolidation을 분리된 consumer로 (PoC)
+
+`SleepConsolidationService`는 시맨틱 기억을 생성하거나 병합할 때마다 후속 로직을 직접 호출하는 대신 `consolidation.completed`를 outbox에 적재합니다. `ConsolidationOutboxWorker`(`packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts`)는 `EventOutboxPublisher`를 구현해 이 이벤트 유형에만 반응하며, consolidation 후속 작업(알림, export, 외부 집계)이 `BatchScheduler`에 내장되지 않고 별도 outbox consumer로 분리될 수 있음을 보여줍니다. 전체 예시는 `consolidation-outbox-worker.spec.ts`를 참고하세요.

--- a/packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts
+++ b/packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { SleepConsolidationService } from './sleep-consolidation-service.js';
+import { ConsolidationOutboxWorker } from './consolidation-outbox-worker.js';
+import { applyConsolidationTestSchema } from '../__tests__/consolidation-test-schema.js';
+import { EventOutboxMigration } from '../../../infrastructure/database/database/migration/migrations/039-event-outbox.js';
+import { EventOutboxService } from '../../telemetry/services/event-outbox-service.js';
+import { DatabaseUtils } from '../../../shared/utils/database.js';
+
+function insertEpisodic(db: Database.Database, id: string, owner: string) {
+  DatabaseUtils.run(
+    db,
+    `INSERT INTO memory_item (id, type, content, owner_id, created_at) VALUES (?, 'episodic', ?, ?, datetime('now', '-1 day'))`,
+    [id, `body-${id}`, owner]
+  );
+}
+
+function insertEmbedding(db: Database.Database, memoryId: string, vec: number[]) {
+  DatabaseUtils.run(
+    db,
+    `INSERT INTO memory_embedding (memory_id, embedding, dim, embedding_provider) VALUES (?, ?, ?, 'tfidf')`,
+    [memoryId, JSON.stringify(vec), vec.length]
+  );
+}
+
+describe('consolidation outbox PoC (#659)', () => {
+  let db: Database.Database;
+
+  beforeEach(async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('CONSOLIDATION_SIMILARITY_THRESHOLD', '0.75');
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    db = new Database(':memory:');
+    applyConsolidationTestSchema(db);
+    await new EventOutboxMigration().up(db);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    db.close();
+  });
+
+  it('does nothing when the outbox feature flag is disabled', async () => {
+    const emb = [1, 0, 0, 0];
+    for (let i = 0; i < 10; i++) {
+      insertEpisodic(db, `e${i}`, 'agent-x');
+      insertEmbedding(db, `e${i}`, emb);
+    }
+    const { createRelationGraph } = await import('../../../infrastructure/relation-graph-factory.js');
+    const svc = new SleepConsolidationService(db, { relationGraph: createRelationGraph(db) });
+    const result = await svc.run({ ownerIdFilter: 'agent-x' });
+    expect(result.semanticsCreated).toBe(1);
+
+    const rows = new EventOutboxService(db).pending();
+    expect(rows).toHaveLength(0);
+  });
+
+  it('enqueues consolidation.completed and lets a decoupled worker consume it', async () => {
+    vi.stubEnv('MEMENTO_EVENT_OUTBOX_ENABLED', 'true');
+    const emb = [1, 0, 0, 0];
+    for (let i = 0; i < 10; i++) {
+      insertEpisodic(db, `e${i}`, 'agent-x');
+      insertEmbedding(db, `e${i}`, emb);
+    }
+    const { createRelationGraph } = await import('../../../infrastructure/relation-graph-factory.js');
+    const svc = new SleepConsolidationService(db, { relationGraph: createRelationGraph(db) });
+    const result = await svc.run({ ownerIdFilter: 'agent-x' });
+    expect(result.semanticsCreated).toBe(1);
+
+    const sem = DatabaseUtils.get(
+      db,
+      `SELECT id FROM memory_item WHERE type = 'semantic' LIMIT 1`
+    ) as { id: string };
+
+    const outbox = new EventOutboxService(db);
+    const pendingBefore = outbox.pending();
+    expect(pendingBefore).toHaveLength(1);
+    expect(pendingBefore[0]).toMatchObject({
+      eventType: 'consolidation.completed',
+      targetUri: `memento://agent-x/memory/${sem.id}`,
+      ownerId: 'agent-x',
+    });
+    expect(pendingBefore[0]!.payload).toMatchObject({ semantic_id: sem.id, episodic_count: 10, merged: false });
+
+    const handled: unknown[] = [];
+    const worker = new ConsolidationOutboxWorker(input => {
+      handled.push(input);
+    });
+    const publishResult = await outbox.publishPending(worker);
+
+    expect(publishResult).toEqual({ published: 1, failed: 0 });
+    expect(worker.handled).toBe(1);
+    expect(handled).toEqual([
+      {
+        targetUri: `memento://agent-x/memory/${sem.id}`,
+        ownerId: 'agent-x',
+        payload: expect.objectContaining({ semantic_id: sem.id }),
+      },
+    ]);
+    expect(outbox.pending()).toHaveLength(0);
+  });
+
+  it('ignores unrelated outbox event types', async () => {
+    vi.stubEnv('MEMENTO_EVENT_OUTBOX_ENABLED', 'true');
+    const outbox = new EventOutboxService(db);
+    outbox.enqueue({
+      eventType: 'memory.remembered',
+      targetUri: 'memento://agent-x/memory/mem_1',
+      ownerId: 'agent-x',
+      payload: {},
+      idempotencyKey: 'memory.remembered:mem_1',
+    });
+
+    const handled: unknown[] = [];
+    const worker = new ConsolidationOutboxWorker(input => {
+      handled.push(input);
+    });
+    const publishResult = await outbox.publishPending(worker);
+
+    expect(publishResult).toEqual({ published: 1, failed: 0 });
+    expect(worker.handled).toBe(0);
+    expect(handled).toHaveLength(0);
+  });
+});

--- a/packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts
+++ b/packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts
@@ -1,0 +1,41 @@
+/**
+ * #659 PoC: sleep consolidation을 core에 내장하지 않고 outbox consumer로 분리할 수 있음을 보인다.
+ * SleepConsolidationService는 완료 시 `consolidation.completed`를 event_outbox에 적재하고(#659),
+ * 이 worker는 EventOutboxPublisher로서 그 이벤트만 소비해 외부 액션(알림, export, 후속 집계 등)에
+ * 연결한다. BatchScheduler나 SleepConsolidationService에 직접 의존하지 않는다.
+ */
+
+import type {
+  EventOutboxEvent,
+  EventOutboxPublisher,
+} from '../../telemetry/services/event-outbox-service.js';
+
+export interface ConsolidationCompletedHandlerInput {
+  targetUri: string;
+  ownerId: string | null;
+  payload: Record<string, unknown>;
+}
+
+export class ConsolidationOutboxWorker implements EventOutboxPublisher {
+  private handledCount = 0;
+
+  constructor(
+    private readonly onConsolidationCompleted?: (input: ConsolidationCompletedHandlerInput) => void | Promise<void>
+  ) {}
+
+  async publish(event: EventOutboxEvent): Promise<void> {
+    if (event.eventType !== 'consolidation.completed') {
+      return;
+    }
+    await this.onConsolidationCompleted?.({
+      targetUri: event.targetUri,
+      ownerId: event.ownerId,
+      payload: event.payload,
+    });
+    this.handledCount += 1;
+  }
+
+  get handled(): number {
+    return this.handledCount;
+  }
+}

--- a/packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts
+++ b/packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts
@@ -8,10 +8,12 @@ import type { SleepConsolidationRunResult } from '../../../shared/types/consolid
 import type { RelationType } from '../../../shared/types/relation.js';
 import type { MemoryType } from '../../../shared/types/index.js';
 import { DatabaseUtils } from '../../../shared/utils/database.js';
+import { formatMementoResourceUri } from '../../../shared/utils/memento-resource-uri.js';
 import { MemoryEmbeddingService } from '../../memory/services/memory-embedding-service.js';
 import { ConsolidationRepository, type EpisodicCandidateRow } from '../repositories/consolidation-repository.js';
 import { ClusteringService } from './clustering-service.js';
 import { SummarizationService } from './summarization-service.js';
+import { EventOutboxService } from '../../telemetry/services/event-outbox-service.js';
 import type { TelemetryService } from '../../telemetry/services/telemetry-service.js';
 import type { Outcome } from '../../telemetry/types/telemetry.types.js';
 
@@ -126,6 +128,36 @@ export class SleepConsolidationService {
    */
   isRunning(): boolean {
     return this.activeRun !== null;
+  }
+
+  /**
+   * #659 PoC: consolidation 산출물을 outbox에 태워, 외부 consumer(예: ConsolidationOutboxWorker)가
+   * BatchScheduler에 직접 결합하지 않고도 완료 이벤트를 구독할 수 있게 한다. 기본은 비활성화(feature flag).
+   */
+  private enqueueConsolidationCompleted(
+    clusterId: string,
+    semanticId: string,
+    ownerId: string | null,
+    detail: { episodicCount: number; merged: boolean; method: string }
+  ): void {
+    try {
+      const targetUri = formatMementoResourceUri({ ownerId, kind: 'memory', id: semanticId });
+      new EventOutboxService(this.db).enqueue({
+        eventType: 'consolidation.completed',
+        targetUri,
+        ownerId,
+        payload: {
+          cluster_id: clusterId,
+          semantic_id: semanticId,
+          episodic_count: detail.episodicCount,
+          merged: detail.merged,
+          method: detail.method,
+        },
+        idempotencyKey: `consolidation.completed:${targetUri}:${clusterId}`,
+      });
+    } catch {
+      // best-effort — consolidation 결과는 이미 커밋되어 있고, outbox 실패가 이를 롤백하지 않는다.
+    }
   }
 
   async run(options: SleepConsolidationRunOptions = {}): Promise<SleepConsolidationRunResult> {
@@ -269,6 +301,11 @@ export class SleepConsolidationService {
               result.clustersProcessed++;
               result.semanticsMerged++;
               result.episodicsConsolidated += cluster.episodicIds.length;
+              this.enqueueConsolidationCompleted(clusterId, mergeTarget.id, cluster.ownerId, {
+                episodicCount: cluster.episodicIds.length,
+                merged: true,
+                method: merged.method,
+              });
               continue;
             }
           }
@@ -336,6 +373,11 @@ export class SleepConsolidationService {
           result.clustersProcessed++;
           result.semanticsCreated++;
           result.episodicsConsolidated += cluster.episodicIds.length;
+          this.enqueueConsolidationCompleted(clusterId, semanticId, cluster.ownerId, {
+            episodicCount: cluster.episodicIds.length,
+            merged: false,
+            method,
+          });
         } catch (e) {
           result.clustersSkipped++;
           result.errors.push({

--- a/packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts
+++ b/packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts
@@ -8,7 +8,8 @@ export type EventOutboxEventType =
   | 'memory.recalled'
   | 'memory.forgotten'
   | 'relation.added'
-  | 'procedure.updated';
+  | 'procedure.updated'
+  | 'consolidation.completed';
 
 export interface EventOutboxEvent {
   id: string;


### PR DESCRIPTION
## Summary

- PR #694 (merged just before this work started) already delivered nearly all of #655's AKB-pattern proposals: the `memento://` URI model (#656), relation type vocabulary (#657), embedding reindex CLI/admin API (#658), event outbox schema + producers (#659), and the hash-chained audit log (#660). Those issues were still open only because #694 didn't reference closing keywords.
- This PR audits each issue's explicit 완료 기준 checklist against the current code/docs and closes the two gaps found:
  - **#658**: `docs/guides/ko/embedding-configuration.md` had no `reindex-embeddings` runbook section (the `en` guide did) — ported the CLI + HTTP maintenance API section.
  - **#659**: the "consolidation worker가 outbox consumer로 분리 가능한 PoC" criterion had no code. `SleepConsolidationService` now enqueues a feature-flagged, best-effort `consolidation.completed` event per created/merged semantic memory; `ConsolidationOutboxWorker` implements `EventOutboxPublisher` and only reacts to that event, proving consolidation follow-up can run as a separate consumer instead of being embedded in `BatchScheduler`.
- Also added the missing `docs/reference/*/event-outbox.md` link to `docs/README.md`'s doc index (the file existed but wasn't discoverable from the nav).
- Verified #656, #657, and #660 are already fully satisfied in code (no changes needed): `memento-resource-uri.ts` utils + `uri` fields on recall/feedback/relation responses; the `038-relation-type-registry-seeds` migration test asserts registry rows match `ALL_RELATION_TYPES` exactly; `audit-hash-chain-service.spec.ts` covers both best-effort `incomplete` coverage and strict-mode fail-closed behavior.

## Test plan

- [x] `npm run type-check` (all workspaces)
- [x] `npm run lint` (0 errors)
- [x] `npm run test:ci` (430 files, 4712 passed, 1 skipped)
- [x] New tests: `consolidation-outbox-worker.spec.ts` (3 cases — feature flag off, enqueue+consume, ignores unrelated event types)

Closes #656
Closes #657
Closes #658
Closes #659
Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)