### PR TITLE
fix(remember): allow agent source ids (#696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **remember source agent id** (#696): `agent:<id>` URI와 bare 워크플로/에이전트 식별자(`paperclip-ceo-heartbeat` 등)를 허용·`agent:`로 정규화해 운영 WARN 노이즈를 제거합니다. personal-knowledge-agent 저장 `source`도 `agent:personal-knowledge-agent`로 통일합니다.
+
 ### Added
 
 - **MCP transport parity spec** (#681): `runtime-transport-parity.spec.ts` — stdio·HTTP·WebSocket `tools/call`이 동일한 `ToolResult`를 반환하는지 검증.

--- a/docs/reference/ko/source-field.md
+++ b/docs/reference/ko/source-field.md
@@ -1,4 +1,4 @@
-# source 필드 표준 (#671)
+# source 필드 표준 (#671, #696)
 
 `remember`·`remember_procedure`의 `source` 파라미터는 기억의 **출처(provenance)** 를 기계가 파싱 가능한 URI로 기록합니다. 자유 텍스트 대신 아래 형식을 사용하면 recall·export·감사 로그에서 일관되게 추적할 수 있습니다.
 
@@ -10,14 +10,17 @@
 | `https://` | `https://github.com/org/repo/pull/42` | 웹 문서·이슈·PR |
 | `commit:` | `commit:abc1234def5678` | Git 커밋 SHA (7–64자 hex) |
 | `doc:` | `doc:security-guide-v2` | 내부 문서 ID |
+| `agent:` | `agent:paperclip-ceo-heartbeat` | 에이전트·워크플로 식별자 (#696) |
 | `memento://{owner}/{kind}/{id}` | `memento://agent-a/memory/mem_123_abc` | 다른 Memento 리소스 참조 |
 | `memento://memory/` | `memento://memory/mem_123_abc` | 기존 source 값용 legacy alias |
 
 `source`는 **선택 필드**입니다. 생략하면 `NULL`로 저장됩니다.
 
+`doc:`·`agent:`의 `<id>`는 `[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}` 입니다. 같은 charset의 **bare 식별자**(예: `paperclip-ceo-heartbeat`)는 저장 시 `agent:<id>`로 정규화됩니다. 공백 등이 포함된 free-text는 유효하지 않습니다.
+
 ## 검증 동작
 
-- **기본 (관대)**: 형식이 맞지 않으면 **경고 로그**만 남기고 저장을 계속합니다.
+- **기본 (관대)**: 형식이 맞지 않으면 **경고 로그**만 남기고 저장을 계속합니다. bare agent id는 경고 없이 `agent:`로 정규화합니다.
 - **strict**: `MEMENTO_SOURCE_STRICT=true` 이면 잘못된 `source`로 **remember 요청을 거절**합니다.
 
 ```bash

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-07-12)
+# Graph Report - .  (2026-07-24)
 
 ## Corpus Check
-- 1427 files · ~1,565,297 words
+- 1429 files · ~1,567,612 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6581 nodes · 7509 edges · 1419 communities detected
+- 6590 nodes · 7517 edges · 1421 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1429,6 +1429,8 @@
 - [[_COMMUNITY_Community 1416|Community 1416]]
 - [[_COMMUNITY_Community 1417|Community 1417]]
 - [[_COMMUNITY_Community 1418|Community 1418]]
+- [[_COMMUNITY_Community 1419|Community 1419]]
+- [[_COMMUNITY_Community 1420|Community 1420]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 47 edges
@@ -1838,7 +1840,7 @@ Nodes (1): EmbeddingMigration
 
 ### Community 95 - "Community 95"
 Cohesion: 0.15
-Nodes (0):
+Nodes (0): 
 
 ### Community 96 - "Community 96"
 Cohesion: 0.15
@@ -1882,7 +1884,7 @@ Nodes (11): executeTelemetry(), fmt(), fmtMs(), fmtPct(), formatMemoryQuality(),
 
 ### Community 106 - "Community 106"
 Cohesion: 0.17
-Nodes (0):
+Nodes (0): 
 
 ### Community 107 - "Community 107"
 Cohesion: 0.33
@@ -1945,76 +1947,76 @@ Cohesion: 0.29
 Nodes (8): buildScoreBreakdown(), computeStaleDays(), isMemoryRowActive(), isNonEmptyDeletedAt(), isTruthyFlag(), parseSqliteInstant(), passesEligibility(), resolveStaleAnchor()
 
 ### Community 122 - "Community 122"
+Cohesion: 0.24
+Nodes (6): ConsolidationAlreadyRunningError, cosineSimilarity(), getMergeSimilarityThreshold(), mergeOriginSourceJson(), newSemanticId(), SleepConsolidationService
+
+### Community 123 - "Community 123"
 Cohesion: 0.32
 Nodes (11): aggregateJudgeResults(), assertJudgeResults(), createManifest(), graphRrfStatus(), main(), parseCli(), readJsonLines(), runLongMemEvalValidation() (+3 more)
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.35
 Nodes (10): batchProcessingExample(), benchmarkExample(), cachingExample(), compressedSearchExample(), memoryOptimizationExample(), parallelSearchExample(), processPageData(), realTimeMonitoringExample() (+2 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.36
 Nodes (10): attachMemoryNeighbors(), createServerToolContext(), handlePromptsCall(), handleResourcesList(), handleResourcesRead(), handleToolsCall(), handleToolsList(), memoryInjectionPromptDefinition() (+2 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.22
 Nodes (5): buildEmbeddingMapResponse(), distSq(), EmbeddingMapBuildError, getCacheKey(), kMeans()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.35
 Nodes (10): collectPersistenceBlock(), createAgentAskLlm(), runAgentAskInvocation(), runAgentAskMain(), runAgentAskWithCore(), runAgentAskWithInterrupts(), teardownAgentAsk(), writeAgentAskSuccess() (+2 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.31
 Nodes (2): CaptureRuntime, TimeoutError
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.18
 Nodes (5): AuthenticationError, ConnectionError, MementoError, NotFoundError, ValidationError
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.31
 Nodes (1): AriGraphSchemaExpansionMigration
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.27
 Nodes (1): ProceduralMemoryEnhancementMigration
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.33
 Nodes (1): AddCoreMemoryVersionMigration
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.27
 Nodes (1): QualityAssuranceSchemaMigration
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.24
 Nodes (1): TripleCacheService
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.25
 Nodes (1): LoggingHelper
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.29
 Nodes (7): resolveBoolean(), resolveEnv(), resolveNumber(), resolveOptionalNumber(), resolveOptionalString(), resolveString(), toArray()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.24
 Nodes (1): AnchorManager
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.18
 Nodes (1): AnchorCacheService
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.35
 Nodes (1): VectorSearchService
-
-### Community 139 - "Community 139"
-Cohesion: 0.25
-Nodes (6): ConsolidationAlreadyRunningError, cosineSimilarity(), getMergeSimilarityThreshold(), mergeOriginSourceJson(), newSemanticId(), SleepConsolidationService
 
 ### Community 140 - "Community 140"
 Cohesion: 0.18
@@ -2058,7 +2060,7 @@ Nodes (9): checkDatabaseExists(), checkMigrationStatus(), log(), logError(), log
 
 ### Community 150 - "Community 150"
 Cohesion: 0.2
-Nodes (0):
+Nodes (0): 
 
 ### Community 151 - "Community 151"
 Cohesion: 0.33
@@ -2262,7 +2264,7 @@ Nodes (2): DefaultSearchLogger, HybridSearchFactory
 
 ### Community 201 - "Community 201"
 Cohesion: 0.22
-Nodes (0):
+Nodes (0): 
 
 ### Community 202 - "Community 202"
 Cohesion: 0.36
@@ -2378,7 +2380,7 @@ Nodes (6): buildRecentEvents(), handleGetOperationsStatus(), queryInjectionCount
 
 ### Community 230 - "Community 230"
 Cohesion: 0.25
-Nodes (0):
+Nodes (0): 
 
 ### Community 231 - "Community 231"
 Cohesion: 0.39
@@ -2454,7 +2456,7 @@ Nodes (2): isPIIMaskingEnabled(), PIIMasker
 
 ### Community 249 - "Community 249"
 Cohesion: 0.25
-Nodes (0):
+Nodes (0): 
 
 ### Community 250 - "Community 250"
 Cohesion: 0.25
@@ -2574,7 +2576,7 @@ Nodes (1): RetryQueue
 
 ### Community 279 - "Community 279"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 280 - "Community 280"
 Cohesion: 0.52
@@ -2626,7 +2628,7 @@ Nodes (2): connectClient(), healthCheck()
 
 ### Community 292 - "Community 292"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 293 - "Community 293"
 Cohesion: 0.43
@@ -2678,7 +2680,7 @@ Nodes (1): AgentIntegrationProvenanceStore
 
 ### Community 305 - "Community 305"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 306 - "Community 306"
 Cohesion: 0.43
@@ -2702,7 +2704,7 @@ Nodes (1): PromptTemplateLoader
 
 ### Community 311 - "Community 311"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 312 - "Community 312"
 Cohesion: 0.29
@@ -2826,7 +2828,7 @@ Nodes (6): buildRequestOptions(), getDashboardAuth(), isProgrammaticToolsRequest
 
 ### Community 342 - "Community 342"
 Cohesion: 0.29
-Nodes (0):
+Nodes (0): 
 
 ### Community 343 - "Community 343"
 Cohesion: 0.67
@@ -2858,7 +2860,7 @@ Nodes (4): getAdmin(), getEmbeddingMapHandler(), seedEmbeddings(), vecJson()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 351 - "Community 351"
 Cohesion: 0.6
@@ -2894,7 +2896,7 @@ Nodes (1): TestMigration
 
 ### Community 359 - "Community 359"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 360 - "Community 360"
 Cohesion: 0.33
@@ -2910,7 +2912,7 @@ Nodes (1): TelemetryEventsMigration
 
 ### Community 363 - "Community 363"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 364 - "Community 364"
 Cohesion: 0.33
@@ -2922,7 +2924,7 @@ Nodes (1): FeedbackRepositorySQLite
 
 ### Community 366 - "Community 366"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 367 - "Community 367"
 Cohesion: 0.47
@@ -2930,7 +2932,7 @@ Nodes (2): generateId(), KgTripleRepositorySqlite
 
 ### Community 368 - "Community 368"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 369 - "Community 369"
 Cohesion: 0.33
@@ -2942,11 +2944,11 @@ Nodes (3): RelationValidatorExecutor, resolveMementoRepoRoot(), resolveTsxComman
 
 ### Community 371 - "Community 371"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 372 - "Community 372"
 Cohesion: 0.33
-Nodes (0):
+Nodes (0): 
 
 ### Community 373 - "Community 373"
 Cohesion: 0.6
@@ -3074,11 +3076,11 @@ Nodes (3): broadcastReviewCandidatesChanged(), buildReviewCandidatesChangedEnvel
 
 ### Community 404 - "Community 404"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 405 - "Community 405"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 406 - "Community 406"
 Cohesion: 0.6
@@ -3098,11 +3100,11 @@ Nodes (1): SseServer
 
 ### Community 410 - "Community 410"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 411 - "Community 411"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 412 - "Community 412"
 Cohesion: 0.6
@@ -3110,7 +3112,7 @@ Nodes (3): parseLimit(), parseQuery(), readSingleQueryValue()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 414 - "Community 414"
 Cohesion: 0.5
@@ -3142,7 +3144,7 @@ Nodes (1): ReflexionProceduralMemoryService
 
 ### Community 421 - "Community 421"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 422 - "Community 422"
 Cohesion: 0.6
@@ -3150,27 +3152,27 @@ Nodes (4): autoReflect(), checkQueueBacklog(), processFailureEvent(), queueFailu
 
 ### Community 423 - "Community 423"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 424 - "Community 424"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 425 - "Community 425"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 426 - "Community 426"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 427 - "Community 427"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 428 - "Community 428"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 429 - "Community 429"
 Cohesion: 0.5
@@ -3178,11 +3180,11 @@ Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 431 - "Community 431"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 432 - "Community 432"
 Cohesion: 0.6
@@ -3194,11 +3196,11 @@ Nodes (2): getStopWords(), isStopWord()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 435 - "Community 435"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 436 - "Community 436"
 Cohesion: 0.4
@@ -3210,15 +3212,15 @@ Nodes (3): getOllamaErrorMessage(), handleOllamaResponse(), testOllamaConnection
 
 ### Community 438 - "Community 438"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 439 - "Community 439"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 440 - "Community 440"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 441 - "Community 441"
 Cohesion: 0.5
@@ -3246,7 +3248,7 @@ Nodes (1): AdaptiveWeightCalculator
 
 ### Community 447 - "Community 447"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 448 - "Community 448"
 Cohesion: 0.5
@@ -3286,7 +3288,7 @@ Nodes (3): getExistingReflectionNotes(), parseReflectionNotes(), prepareReflecti
 
 ### Community 457 - "Community 457"
 Cohesion: 0.4
-Nodes (0):
+Nodes (0): 
 
 ### Community 458 - "Community 458"
 Cohesion: 0.4
@@ -3302,523 +3304,523 @@ Nodes (1): SemanticMemoryCrud
 
 ### Community 461 - "Community 461"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): ConsolidationOutboxWorker
 
 ### Community 462 - "Community 462"
+Cohesion: 0.4
+Nodes (1): FailingRepo
+
+### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (2): AddRelationTool, memoryItemHasOwnerIdColumn()
 
-### Community 463 - "Community 463"
+### Community 464 - "Community 464"
 Cohesion: 0.4
 Nodes (1): RelationGraphQuery
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.5
 Nodes (1): RelationGraphCycleDetector
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.4
 Nodes (1): TokenBucketRateLimiter
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (2): calculateQualityMetrics(), calculateQualityMetricsWithAnalysis()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.5
 Nodes (2): processMigrationRow(), safeParseEmbedding()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.4
 Nodes (1): DatabaseMetricsReader
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.4
 Nodes (1): CpuUsageTracker
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.5
 Nodes (2): analyzeTrend(), getPerformanceSummary()
 
-### Community 473 - "Community 473"
+### Community 474 - "Community 474"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 474 - "Community 474"
+### Community 475 - "Community 475"
 Cohesion: 0.4
 Nodes (1): RelationMetricsCollector
 
-### Community 475 - "Community 475"
+### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (2): calculateMRR(), SearchMetricsCollector
 
-### Community 476 - "Community 476"
+### Community 477 - "Community 477"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.7
 Nodes (4): createSeededBenchmarkDatabase(), mulberry32(), normalizeMemoryType(), seedOneCorpusRow()
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.7
 Nodes (4): createSessionGate(), ensureSessionGate(), resetSessionGate(), unlockSessionGate()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.6
 Nodes (4): buildComparisonHintMarkup(), renderPointSegment(), syncSegmentSelection(), updateComparisonHint()
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.7
 Nodes (4): clearPollTimer(), getReviewQueueBoot(), schedulePollAfterMs(), schedulePollAfterMsUnlessSse()
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.7
 Nodes (4): renderConsolidationPanel(), renderEpisodicSources(), renderSearchComparison(), renderSemanticResult()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.7
 Nodes (4): activateTab(), focusActiveTabButton(), getTabButtons(), setRovingTabindex()
 
-### Community 485 - "Community 485"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 486 - "Community 486"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 487 - "Community 487"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
 
-### Community 488 - "Community 488"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 489 - "Community 489"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 490 - "Community 490"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 491 - "Community 491"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 492 - "Community 492"
 Cohesion: 0.83
 Nodes (3): createOwnerScopeMiddleware(), hasOwnerIdInBody(), isOwnerScopedToolRequest()
 
-### Community 492 - "Community 492"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 493 - "Community 493"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (2): handlePostPersonalRun(), parsePersonalRunBody()
 
-### Community 494 - "Community 494"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 495 - "Community 495"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 496 - "Community 496"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 498 - "Community 498"
-Cohesion: 0.83
-Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
+Cohesion: 0.5
+Nodes (1): BraveSearchProvider
 
 ### Community 499 - "Community 499"
 Cohesion: 0.83
-Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
 
 ### Community 500 - "Community 500"
+Cohesion: 0.83
+Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+
+### Community 501 - "Community 501"
 Cohesion: 0.67
 Nodes (2): fixture(), fixtureUrl()
 
-### Community 501 - "Community 501"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 502 - "Community 502"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 504 - "Community 504"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 505 - "Community 505"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 505 - "Community 505"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 506 - "Community 506"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 507 - "Community 507"
 Cohesion: 0.67
 Nodes (2): attemptRestart(), performHealthCheck()
 
-### Community 507 - "Community 507"
+### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (1): DatabaseOptimizeTool
 
-### Community 508 - "Community 508"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 509 - "Community 509"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 511 - "Community 511"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 512 - "Community 512"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 513 - "Community 513"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 515 - "Community 515"
-Cohesion: 0.67
-Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
-Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
+Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
 
 ### Community 517 - "Community 517"
-Cohesion: 0.5
-Nodes (1): TripleExtractionBatchJob
+Cohesion: 0.67
+Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
-Nodes (1): QualityMeasurementBatchJob
+Nodes (1): TripleExtractionBatchJob
 
 ### Community 519 - "Community 519"
 Cohesion: 0.5
-Nodes (1): SleepConsolidationBatchJob
+Nodes (1): QualityMeasurementBatchJob
 
 ### Community 520 - "Community 520"
 Cohesion: 0.5
-Nodes (1): TelemetryCleanupBatchJob
+Nodes (1): SleepConsolidationBatchJob
 
 ### Community 521 - "Community 521"
-Cohesion: 0.67
-Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
+Cohesion: 0.5
+Nodes (1): TelemetryCleanupBatchJob
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
+Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
 
 ### Community 523 - "Community 523"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
 
 ### Community 524 - "Community 524"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 525 - "Community 525"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
 
-### Community 526 - "Community 526"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 527 - "Community 527"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 528 - "Community 528"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 529 - "Community 529"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 530 - "Community 530"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 531 - "Community 531"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 532 - "Community 532"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 533 - "Community 533"
+Cohesion: 0.5
+Nodes (1): RestoreAnchorsTool
+
+### Community 534 - "Community 534"
 Cohesion: 0.83
 Nodes (3): buildSnapshotsFromFixture(), getFixtureSnapshot(), key()
 
-### Community 534 - "Community 534"
+### Community 535 - "Community 535"
 Cohesion: 0.5
 Nodes (1): SearchResultCombiner
 
-### Community 535 - "Community 535"
+### Community 536 - "Community 536"
 Cohesion: 0.67
 Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.67
 Nodes (2): computeProcessAttributeFit(), toSet()
 
-### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 538 - "Community 538"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 539 - "Community 539"
 Cohesion: 0.83
 Nodes (3): buildFTSQuery(), makeFTSSafe(), preprocessQuery()
 
-### Community 539 - "Community 539"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 540 - "Community 540"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 541 - "Community 541"
 Cohesion: 0.83
 Nodes (3): buildOuterWhereSql(), buildScopeParams(), executeKnnQuery()
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.5
 Nodes (1): ForgettingStatsTool
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.83
 Nodes (3): mapJob(), querySystemMetrics(), toolBucketFromEvents()
 
-### Community 543 - "Community 543"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 544 - "Community 544"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 545 - "Community 545"
 Cohesion: 0.5
 Nodes (1): GetTelemetrySummaryTool
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.5
 Nodes (1): PersonalAgentLlmError
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.5
 Nodes (1): OpenAiChatLlmAdapter
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.5
 Nodes (1): OllamaChatLlmAdapter
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.5
 Nodes (1): GeminiChatLlmAdapter
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.83
 Nodes (3): buildSimilarityWarning(), handleMemoryItem(), persistMemoryItem()
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (1): RememberTool
 
-### Community 552 - "Community 552"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 553 - "Community 553"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (0): 
 
 ### Community 554 - "Community 554"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 555 - "Community 555"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 556 - "Community 556"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 557 - "Community 557"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 558 - "Community 558"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 559 - "Community 559"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 560 - "Community 560"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): RememberProcedureTool
 
 ### Community 561 - "Community 561"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 562 - "Community 562"
 Cohesion: 0.83
 Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
-### Community 562 - "Community 562"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 563 - "Community 563"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (0): 
 
 ### Community 564 - "Community 564"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 565 - "Community 565"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 566 - "Community 566"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): ExtractRelationsTool
 
 ### Community 567 - "Community 567"
+Cohesion: 0.5
+Nodes (1): RelationRetryManager
+
+### Community 568 - "Community 568"
 Cohesion: 0.67
 Nodes (2): filterRelationRows(), filterRelationRowsWithWarning()
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.5
 Nodes (1): RelationGraphTraversal
 
-### Community 569 - "Community 569"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 570 - "Community 570"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 571 - "Community 571"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 571 - "Community 571"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 572 - "Community 572"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 573 - "Community 573"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): TripleNormalizer
 
 ### Community 574 - "Community 574"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 575 - "Community 575"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 576 - "Community 576"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 577 - "Community 577"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 578 - "Community 578"
 Cohesion: 0.83
 Nodes (3): applyRollbackDelete(), applyRollbackRestore(), rollback()
 
-### Community 578 - "Community 578"
+### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (1): GetMetaMemoryStatsTool
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.5
 Nodes (1): PerformanceStatsTool
 
-### Community 580 - "Community 580"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 581 - "Community 581"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 582 - "Community 582"
 Cohesion: 0.5
-Nodes (1): CategoryQualityAggregator
+Nodes (0): 
 
 ### Community 583 - "Community 583"
 Cohesion: 0.5
-Nodes (1): ConsolidationMetricsCollector
+Nodes (1): CategoryQualityAggregator
 
 ### Community 584 - "Community 584"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): ConsolidationMetricsCollector
 
 ### Community 585 - "Community 585"
 Cohesion: 0.5
-Nodes (1): StorageMetricsCollector
+Nodes (0): 
 
 ### Community 586 - "Community 586"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): StorageMetricsCollector
 
 ### Community 587 - "Community 587"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 588 - "Community 588"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 589 - "Community 589"
 Cohesion: 0.67
 Nodes (2): buildBenchmarkCorpus(), normalizeTags()
 
-### Community 589 - "Community 589"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 590 - "Community 590"
-Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 591 - "Community 591"
 Cohesion: 0.83
@@ -3826,19 +3828,19 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.83
-Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 593 - "Community 593"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
 
 ### Community 594 - "Community 594"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 595 - "Community 595"
 Cohesion: 0.83
 Nodes (3): main(), parseArgs(), printHelp()
+
+### Community 595 - "Community 595"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 596 - "Community 596"
 Cohesion: 0.83
@@ -3850,4672 +3852,4680 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 598 - "Community 598"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 599 - "Community 599"
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+
+### Community 600 - "Community 600"
 Cohesion: 1.0
 Nodes (3): checkDatabaseIntegrity(), log(), main()
 
-### Community 600 - "Community 600"
+### Community 601 - "Community 601"
 Cohesion: 0.83
 Nodes (3): findLatestRunDir(), main(), parseReportArgs()
 
-### Community 601 - "Community 601"
+### Community 602 - "Community 602"
 Cohesion: 1.0
 Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
-### Community 602 - "Community 602"
+### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (2): inferLevel(), parseAppLogLine()
 
-### Community 603 - "Community 603"
+### Community 604 - "Community 604"
 Cohesion: 0.67
 Nodes (2): createMonitorRuntime(), runForever()
 
-### Community 604 - "Community 604"
+### Community 605 - "Community 605"
 Cohesion: 0.67
 Nodes (2): main(), runExample()
 
-### Community 605 - "Community 605"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 606 - "Community 606"
-Cohesion: 0.83
-Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 607 - "Community 607"
 Cohesion: 0.83
-Nodes (3): postCandidateAction(), showActionToast(), showError()
+Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
 
 ### Community 608 - "Community 608"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): postCandidateAction(), showActionToast(), showError()
 
 ### Community 609 - "Community 609"
 Cohesion: 0.5
-Nodes (0):
+Nodes (0): 
 
 ### Community 610 - "Community 610"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 611 - "Community 611"
 Cohesion: 0.67
 Nodes (2): ensureTooltip(), showTooltip()
 
-### Community 611 - "Community 611"
+### Community 612 - "Community 612"
 Cohesion: 0.83
 Nodes (3): initAgentSessionsPanel(), on(), wirePanel()
 
-### Community 612 - "Community 612"
+### Community 613 - "Community 613"
 Cohesion: 1.0
 Nodes (3): getSelectedAgentId(), loadAgentIdOptions(), loadMapData()
 
-### Community 613 - "Community 613"
+### Community 614 - "Community 614"
 Cohesion: 0.83
 Nodes (3): renderMemoryGroups(), renderMemoryStats(), renderSnapshot()
 
-### Community 614 - "Community 614"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 615 - "Community 615"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 616 - "Community 616"
 Cohesion: 0.83
 Nodes (3): appendLabeledLine(), closeSidePanel(), openSidePanel()
 
-### Community 616 - "Community 616"
+### Community 617 - "Community 617"
 Cohesion: 0.67
 Nodes (1): SlowTransport
 
-### Community 617 - "Community 617"
+### Community 618 - "Community 618"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 618 - "Community 618"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 619 - "Community 619"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 620 - "Community 620"
 Cohesion: 1.0
 Nodes (2): createMockResponse(), sendOptions()
 
-### Community 620 - "Community 620"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 621 - "Community 621"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 622 - "Community 622"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 623 - "Community 623"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 624 - "Community 624"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 628 - "Community 628"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 631 - "Community 631"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 632 - "Community 632"
 Cohesion: 1.0
 Nodes (2): loadEnv(), resolveEnvPath()
 
-### Community 632 - "Community 632"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 636 - "Community 636"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 637 - "Community 637"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 638 - "Community 638"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): git()
+Nodes (1): NoopSearchProvider
 
 ### Community 641 - "Community 641"
-Cohesion: 1.0
-Nodes (2): invalid(), runClaudeCodeHook()
+Cohesion: 0.67
+Nodes (1): git()
 
 ### Community 642 - "Community 642"
 Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Nodes (2): invalid(), runClaudeCodeHook()
 
 ### Community 643 - "Community 643"
 Cohesion: 1.0
-Nodes (2): hybridSearch(), recall()
+Nodes (2): log(), shouldLog()
 
 ### Community 644 - "Community 644"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hybridSearch(), recall()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 647 - "Community 647"
-Cohesion: 1.0
-Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 648 - "Community 648"
 Cohesion: 1.0
-Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
+Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
 
 ### Community 649 - "Community 649"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
 
 ### Community 650 - "Community 650"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 651 - "Community 651"
 Cohesion: 1.0
 Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
-### Community 651 - "Community 651"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 652 - "Community 652"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 653 - "Community 653"
 Cohesion: 1.0
 Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
-### Community 653 - "Community 653"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 656 - "Community 656"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 657 - "Community 657"
 Cohesion: 1.0
 Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
 
-### Community 657 - "Community 657"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 663 - "Community 663"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 665 - "Community 665"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 668 - "Community 668"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 669 - "Community 669"
 Cohesion: 1.0
 Nodes (2): isTransientCapacityError(), logExternalApiRetry()
 
-### Community 669 - "Community 669"
+### Community 670 - "Community 670"
 Cohesion: 0.67
 Nodes (1): RuleBasedProceduralExtractor
 
-### Community 670 - "Community 670"
+### Community 671 - "Community 671"
 Cohesion: 1.0
 Nodes (2): getVectorTableName(), validateTableName()
 
-### Community 671 - "Community 671"
+### Community 672 - "Community 672"
 Cohesion: 1.0
 Nodes (2): issue(), validateConfiguration()
 
-### Community 672 - "Community 672"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 673 - "Community 673"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 675 - "Community 675"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 676 - "Community 676"
 Cohesion: 1.0
 Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
 
-### Community 676 - "Community 676"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 677 - "Community 677"
 Cohesion: 0.67
-Nodes (1): SearchError
+Nodes (0): 
 
 ### Community 678 - "Community 678"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): SearchError
 
 ### Community 679 - "Community 679"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 680 - "Community 680"
 Cohesion: 1.0
 Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
 
-### Community 680 - "Community 680"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 681 - "Community 681"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 682 - "Community 682"
 Cohesion: 1.0
 Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
-### Community 682 - "Community 682"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 683 - "Community 683"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 685 - "Community 685"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 686 - "Community 686"
 Cohesion: 1.0
 Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
 
-### Community 686 - "Community 686"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 687 - "Community 687"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 690 - "Community 690"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 691 - "Community 691"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 695 - "Community 695"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 696 - "Community 696"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 697 - "Community 697"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 699 - "Community 699"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 700 - "Community 700"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 701 - "Community 701"
 Cohesion: 1.0
 Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
-### Community 700 - "Community 700"
+### Community 702 - "Community 702"
 Cohesion: 1.0
 Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
-### Community 701 - "Community 701"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 702 - "Community 702"
-Cohesion: 0.67
-Nodes (1): AgentIntegrationError
-
 ### Community 703 - "Community 703"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 704 - "Community 704"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AgentIntegrationError
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 706 - "Community 706"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 707 - "Community 707"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 708 - "Community 708"
 Cohesion: 1.0
 Nodes (2): compareToolResults(), testToolConsistency()
 
-### Community 707 - "Community 707"
+### Community 709 - "Community 709"
 Cohesion: 1.0
 Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
-### Community 708 - "Community 708"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 709 - "Community 709"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 710 - "Community 710"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 711 - "Community 711"
-Cohesion: 1.0
-Nodes (2): calculateRanks(), calculateSpearmanRho()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 713 - "Community 713"
 Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Nodes (2): calculateRanks(), calculateSpearmanRho()
 
 ### Community 714 - "Community 714"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 715 - "Community 715"
 Cohesion: 1.0
-Nodes (2): main(), option()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
-Nodes (2): fetchJson(), testDockerServer()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 717 - "Community 717"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): main(), option()
 
 ### Community 718 - "Community 718"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fetchJson(), testDockerServer()
 
 ### Community 719 - "Community 719"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 720 - "Community 720"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 722 - "Community 722"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 723 - "Community 723"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 724 - "Community 724"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 726 - "Community 726"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 727 - "Community 727"
 Cohesion: 0.67
-Nodes (0):
+Nodes (0): 
 
 ### Community 728 - "Community 728"
-Cohesion: 1.0
-Nodes (0):
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 729 - "Community 729"
-Cohesion: 1.0
-Nodes (0):
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 730 - "Community 730"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 731 - "Community 731"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 732 - "Community 732"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 733 - "Community 733"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 734 - "Community 734"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 735 - "Community 735"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 736 - "Community 736"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 737 - "Community 737"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 738 - "Community 738"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 739 - "Community 739"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 740 - "Community 740"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 741 - "Community 741"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 743 - "Community 743"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 744 - "Community 744"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 745 - "Community 745"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 746 - "Community 746"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 747 - "Community 747"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 748 - "Community 748"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 749 - "Community 749"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 750 - "Community 750"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 754 - "Community 754"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 756 - "Community 756"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 757 - "Community 757"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 758 - "Community 758"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 759 - "Community 759"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 760 - "Community 760"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 761 - "Community 761"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 762 - "Community 762"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 763 - "Community 763"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 764 - "Community 764"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 765 - "Community 765"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 766 - "Community 766"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 767 - "Community 767"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 768 - "Community 768"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 769 - "Community 769"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 770 - "Community 770"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 771 - "Community 771"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 772 - "Community 772"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 773 - "Community 773"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 774 - "Community 774"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 775 - "Community 775"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 776 - "Community 776"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 777 - "Community 777"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 778 - "Community 778"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 779 - "Community 779"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 781 - "Community 781"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 782 - "Community 782"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 783 - "Community 783"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 784 - "Community 784"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 785 - "Community 785"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 786 - "Community 786"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 787 - "Community 787"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 788 - "Community 788"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 789 - "Community 789"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 790 - "Community 790"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 791 - "Community 791"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 792 - "Community 792"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 793 - "Community 793"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 794 - "Community 794"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 795 - "Community 795"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 796 - "Community 796"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 797 - "Community 797"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 798 - "Community 798"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 799 - "Community 799"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 800 - "Community 800"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 801 - "Community 801"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 802 - "Community 802"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 803 - "Community 803"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 804 - "Community 804"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 805 - "Community 805"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 806 - "Community 806"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 807 - "Community 807"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 808 - "Community 808"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 809 - "Community 809"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 810 - "Community 810"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 811 - "Community 811"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 812 - "Community 812"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 813 - "Community 813"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 814 - "Community 814"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 815 - "Community 815"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 816 - "Community 816"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 817 - "Community 817"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 818 - "Community 818"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 819 - "Community 819"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 820 - "Community 820"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 821 - "Community 821"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 822 - "Community 822"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 823 - "Community 823"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 824 - "Community 824"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 825 - "Community 825"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 826 - "Community 826"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 827 - "Community 827"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 828 - "Community 828"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 829 - "Community 829"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 830 - "Community 830"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 831 - "Community 831"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 832 - "Community 832"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 833 - "Community 833"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 834 - "Community 834"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 835 - "Community 835"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 836 - "Community 836"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 837 - "Community 837"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 838 - "Community 838"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 839 - "Community 839"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 840 - "Community 840"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 841 - "Community 841"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 842 - "Community 842"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 843 - "Community 843"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 844 - "Community 844"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 845 - "Community 845"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 846 - "Community 846"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 847 - "Community 847"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 848 - "Community 848"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 849 - "Community 849"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 850 - "Community 850"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 851 - "Community 851"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 852 - "Community 852"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 853 - "Community 853"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 854 - "Community 854"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 855 - "Community 855"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 856 - "Community 856"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 857 - "Community 857"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 858 - "Community 858"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 859 - "Community 859"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 860 - "Community 860"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 861 - "Community 861"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 862 - "Community 862"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 863 - "Community 863"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 864 - "Community 864"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 865 - "Community 865"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 866 - "Community 866"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 867 - "Community 867"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 868 - "Community 868"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 869 - "Community 869"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 870 - "Community 870"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 871 - "Community 871"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 872 - "Community 872"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 873 - "Community 873"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 874 - "Community 874"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 875 - "Community 875"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 876 - "Community 876"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 877 - "Community 877"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 878 - "Community 878"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 879 - "Community 879"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 880 - "Community 880"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 881 - "Community 881"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 882 - "Community 882"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 883 - "Community 883"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 884 - "Community 884"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 885 - "Community 885"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 886 - "Community 886"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 887 - "Community 887"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 888 - "Community 888"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 889 - "Community 889"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 890 - "Community 890"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 891 - "Community 891"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 892 - "Community 892"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 893 - "Community 893"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 894 - "Community 894"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 895 - "Community 895"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 896 - "Community 896"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 897 - "Community 897"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 898 - "Community 898"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 899 - "Community 899"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 900 - "Community 900"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 901 - "Community 901"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 902 - "Community 902"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 903 - "Community 903"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 904 - "Community 904"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 905 - "Community 905"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 906 - "Community 906"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 907 - "Community 907"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 908 - "Community 908"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 909 - "Community 909"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 910 - "Community 910"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 911 - "Community 911"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 912 - "Community 912"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 913 - "Community 913"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 914 - "Community 914"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 915 - "Community 915"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 916 - "Community 916"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 917 - "Community 917"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 918 - "Community 918"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 919 - "Community 919"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 920 - "Community 920"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 921 - "Community 921"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 922 - "Community 922"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 923 - "Community 923"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 924 - "Community 924"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 925 - "Community 925"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 926 - "Community 926"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 928 - "Community 928"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 929 - "Community 929"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 930 - "Community 930"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 931 - "Community 931"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 932 - "Community 932"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 933 - "Community 933"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 934 - "Community 934"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 935 - "Community 935"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 936 - "Community 936"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 937 - "Community 937"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 938 - "Community 938"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 939 - "Community 939"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 940 - "Community 940"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 941 - "Community 941"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 942 - "Community 942"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 943 - "Community 943"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 944 - "Community 944"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 945 - "Community 945"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 946 - "Community 946"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 947 - "Community 947"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 948 - "Community 948"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 949 - "Community 949"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 950 - "Community 950"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 951 - "Community 951"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 952 - "Community 952"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 953 - "Community 953"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 954 - "Community 954"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 955 - "Community 955"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 956 - "Community 956"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 957 - "Community 957"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 958 - "Community 958"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 959 - "Community 959"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 960 - "Community 960"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 961 - "Community 961"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 962 - "Community 962"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 963 - "Community 963"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 964 - "Community 964"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 965 - "Community 965"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 966 - "Community 966"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 967 - "Community 967"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 968 - "Community 968"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 969 - "Community 969"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 970 - "Community 970"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 971 - "Community 971"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 972 - "Community 972"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 973 - "Community 973"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 974 - "Community 974"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 975 - "Community 975"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 976 - "Community 976"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 977 - "Community 977"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 978 - "Community 978"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 979 - "Community 979"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 980 - "Community 980"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 981 - "Community 981"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 982 - "Community 982"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 983 - "Community 983"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 984 - "Community 984"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 985 - "Community 985"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 986 - "Community 986"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 987 - "Community 987"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 988 - "Community 988"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 989 - "Community 989"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 990 - "Community 990"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 991 - "Community 991"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 992 - "Community 992"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 993 - "Community 993"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 994 - "Community 994"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 995 - "Community 995"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 996 - "Community 996"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 997 - "Community 997"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 998 - "Community 998"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 999 - "Community 999"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1000 - "Community 1000"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1001 - "Community 1001"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1002 - "Community 1002"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1003 - "Community 1003"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1004 - "Community 1004"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1005 - "Community 1005"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1006 - "Community 1006"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1007 - "Community 1007"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1008 - "Community 1008"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1009 - "Community 1009"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1010 - "Community 1010"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1011 - "Community 1011"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1012 - "Community 1012"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1013 - "Community 1013"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1014 - "Community 1014"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1015 - "Community 1015"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1016 - "Community 1016"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1017 - "Community 1017"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1018 - "Community 1018"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1019 - "Community 1019"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1020 - "Community 1020"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1021 - "Community 1021"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1022 - "Community 1022"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1023 - "Community 1023"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1024 - "Community 1024"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1025 - "Community 1025"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1026 - "Community 1026"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1027 - "Community 1027"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1028 - "Community 1028"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1029 - "Community 1029"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1030 - "Community 1030"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1031 - "Community 1031"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1032 - "Community 1032"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1033 - "Community 1033"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1034 - "Community 1034"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1035 - "Community 1035"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1036 - "Community 1036"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1037 - "Community 1037"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1038 - "Community 1038"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1039 - "Community 1039"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1040 - "Community 1040"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1041 - "Community 1041"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1042 - "Community 1042"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1043 - "Community 1043"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1044 - "Community 1044"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1045 - "Community 1045"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1046 - "Community 1046"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1047 - "Community 1047"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1048 - "Community 1048"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1049 - "Community 1049"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1050 - "Community 1050"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1051 - "Community 1051"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1052 - "Community 1052"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1053 - "Community 1053"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1054 - "Community 1054"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1055 - "Community 1055"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1056 - "Community 1056"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1057 - "Community 1057"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1058 - "Community 1058"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1059 - "Community 1059"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1060 - "Community 1060"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1061 - "Community 1061"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1062 - "Community 1062"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1063 - "Community 1063"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1064 - "Community 1064"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1065 - "Community 1065"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1066 - "Community 1066"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1067 - "Community 1067"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1068 - "Community 1068"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1069 - "Community 1069"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1070 - "Community 1070"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1071 - "Community 1071"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1072 - "Community 1072"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1073 - "Community 1073"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1074 - "Community 1074"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1075 - "Community 1075"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1076 - "Community 1076"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1077 - "Community 1077"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1078 - "Community 1078"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1079 - "Community 1079"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1080 - "Community 1080"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1081 - "Community 1081"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1082 - "Community 1082"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1083 - "Community 1083"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1084 - "Community 1084"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1085 - "Community 1085"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1086 - "Community 1086"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1087 - "Community 1087"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1088 - "Community 1088"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1089 - "Community 1089"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1090 - "Community 1090"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1091 - "Community 1091"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1092 - "Community 1092"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1093 - "Community 1093"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1094 - "Community 1094"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1095 - "Community 1095"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1096 - "Community 1096"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1097 - "Community 1097"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1098 - "Community 1098"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1099 - "Community 1099"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1100 - "Community 1100"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1101 - "Community 1101"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1102 - "Community 1102"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1103 - "Community 1103"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1104 - "Community 1104"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1105 - "Community 1105"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1106 - "Community 1106"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1107 - "Community 1107"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1108 - "Community 1108"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1109 - "Community 1109"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1110 - "Community 1110"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1111 - "Community 1111"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1112 - "Community 1112"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1113 - "Community 1113"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1114 - "Community 1114"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1115 - "Community 1115"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1116 - "Community 1116"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1117 - "Community 1117"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1118 - "Community 1118"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1119 - "Community 1119"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1120 - "Community 1120"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1121 - "Community 1121"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1122 - "Community 1122"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1123 - "Community 1123"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1124 - "Community 1124"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1125 - "Community 1125"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1126 - "Community 1126"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1127 - "Community 1127"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1128 - "Community 1128"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1129 - "Community 1129"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1130 - "Community 1130"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1131 - "Community 1131"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1132 - "Community 1132"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1133 - "Community 1133"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1134 - "Community 1134"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1135 - "Community 1135"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1136 - "Community 1136"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1137 - "Community 1137"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1138 - "Community 1138"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1139 - "Community 1139"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1140 - "Community 1140"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1141 - "Community 1141"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1142 - "Community 1142"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1143 - "Community 1143"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1144 - "Community 1144"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1145 - "Community 1145"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1146 - "Community 1146"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1147 - "Community 1147"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1148 - "Community 1148"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1149 - "Community 1149"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1150 - "Community 1150"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1151 - "Community 1151"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1152 - "Community 1152"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1153 - "Community 1153"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1154 - "Community 1154"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1155 - "Community 1155"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1156 - "Community 1156"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1157 - "Community 1157"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1158 - "Community 1158"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1159 - "Community 1159"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1160 - "Community 1160"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1161 - "Community 1161"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1162 - "Community 1162"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1163 - "Community 1163"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1164 - "Community 1164"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1165 - "Community 1165"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1166 - "Community 1166"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1167 - "Community 1167"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1168 - "Community 1168"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1169 - "Community 1169"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1170 - "Community 1170"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1171 - "Community 1171"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1172 - "Community 1172"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1173 - "Community 1173"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1174 - "Community 1174"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1175 - "Community 1175"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1176 - "Community 1176"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1177 - "Community 1177"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1178 - "Community 1178"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1179 - "Community 1179"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1180 - "Community 1180"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1181 - "Community 1181"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1182 - "Community 1182"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1183 - "Community 1183"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1184 - "Community 1184"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1185 - "Community 1185"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1186 - "Community 1186"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1187 - "Community 1187"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1188 - "Community 1188"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1189 - "Community 1189"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1190 - "Community 1190"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1191 - "Community 1191"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1192 - "Community 1192"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1193 - "Community 1193"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1194 - "Community 1194"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1195 - "Community 1195"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1196 - "Community 1196"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1197 - "Community 1197"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1198 - "Community 1198"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1199 - "Community 1199"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1200 - "Community 1200"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1201 - "Community 1201"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1202 - "Community 1202"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1203 - "Community 1203"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1204 - "Community 1204"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1205 - "Community 1205"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1206 - "Community 1206"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1207 - "Community 1207"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1208 - "Community 1208"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1209 - "Community 1209"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1210 - "Community 1210"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1211 - "Community 1211"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1212 - "Community 1212"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1213 - "Community 1213"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1214 - "Community 1214"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1215 - "Community 1215"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1216 - "Community 1216"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1217 - "Community 1217"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1218 - "Community 1218"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1219 - "Community 1219"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1220 - "Community 1220"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1221 - "Community 1221"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1222 - "Community 1222"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1223 - "Community 1223"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1224 - "Community 1224"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1225 - "Community 1225"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1226 - "Community 1226"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1227 - "Community 1227"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1228 - "Community 1228"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1229 - "Community 1229"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1230 - "Community 1230"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1231 - "Community 1231"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1232 - "Community 1232"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1233 - "Community 1233"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1234 - "Community 1234"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1235 - "Community 1235"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1236 - "Community 1236"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1237 - "Community 1237"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1238 - "Community 1238"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1239 - "Community 1239"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1240 - "Community 1240"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1241 - "Community 1241"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1242 - "Community 1242"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1243 - "Community 1243"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1244 - "Community 1244"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1245 - "Community 1245"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1246 - "Community 1246"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1247 - "Community 1247"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1248 - "Community 1248"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1249 - "Community 1249"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1250 - "Community 1250"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1251 - "Community 1251"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1252 - "Community 1252"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1253 - "Community 1253"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1254 - "Community 1254"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1255 - "Community 1255"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1256 - "Community 1256"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1257 - "Community 1257"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1258 - "Community 1258"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1259 - "Community 1259"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1260 - "Community 1260"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1261 - "Community 1261"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1262 - "Community 1262"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1263 - "Community 1263"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1264 - "Community 1264"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1265 - "Community 1265"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1266 - "Community 1266"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1267 - "Community 1267"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1268 - "Community 1268"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1269 - "Community 1269"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1270 - "Community 1270"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1271 - "Community 1271"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1272 - "Community 1272"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1273 - "Community 1273"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1274 - "Community 1274"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1275 - "Community 1275"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1276 - "Community 1276"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1277 - "Community 1277"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1278 - "Community 1278"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1279 - "Community 1279"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1280 - "Community 1280"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1281 - "Community 1281"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1282 - "Community 1282"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1283 - "Community 1283"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1284 - "Community 1284"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1285 - "Community 1285"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1286 - "Community 1286"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1287 - "Community 1287"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1288 - "Community 1288"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1289 - "Community 1289"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1290 - "Community 1290"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1291 - "Community 1291"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1292 - "Community 1292"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1293 - "Community 1293"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1294 - "Community 1294"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1295 - "Community 1295"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1296 - "Community 1296"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1297 - "Community 1297"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1298 - "Community 1298"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1299 - "Community 1299"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1300 - "Community 1300"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1301 - "Community 1301"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1302 - "Community 1302"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1303 - "Community 1303"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1304 - "Community 1304"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1305 - "Community 1305"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1306 - "Community 1306"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1307 - "Community 1307"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1308 - "Community 1308"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1309 - "Community 1309"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1310 - "Community 1310"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1311 - "Community 1311"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1312 - "Community 1312"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1313 - "Community 1313"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1314 - "Community 1314"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1315 - "Community 1315"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1316 - "Community 1316"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1317 - "Community 1317"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1318 - "Community 1318"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1319 - "Community 1319"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1320 - "Community 1320"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1321 - "Community 1321"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1322 - "Community 1322"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1323 - "Community 1323"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1324 - "Community 1324"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1325 - "Community 1325"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1326 - "Community 1326"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1327 - "Community 1327"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1328 - "Community 1328"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1329 - "Community 1329"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1330 - "Community 1330"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1331 - "Community 1331"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1332 - "Community 1332"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1333 - "Community 1333"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1334 - "Community 1334"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1335 - "Community 1335"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1336 - "Community 1336"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1337 - "Community 1337"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1338 - "Community 1338"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1339 - "Community 1339"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1340 - "Community 1340"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1341 - "Community 1341"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1342 - "Community 1342"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1343 - "Community 1343"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1344 - "Community 1344"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1345 - "Community 1345"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1346 - "Community 1346"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1347 - "Community 1347"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1348 - "Community 1348"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1349 - "Community 1349"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1350 - "Community 1350"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1351 - "Community 1351"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1352 - "Community 1352"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1353 - "Community 1353"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1354 - "Community 1354"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1355 - "Community 1355"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1356 - "Community 1356"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1357 - "Community 1357"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1358 - "Community 1358"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1359 - "Community 1359"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1360 - "Community 1360"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1361 - "Community 1361"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1362 - "Community 1362"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1363 - "Community 1363"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1364 - "Community 1364"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1365 - "Community 1365"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1366 - "Community 1366"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1367 - "Community 1367"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1368 - "Community 1368"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1369 - "Community 1369"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1370 - "Community 1370"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1371 - "Community 1371"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1372 - "Community 1372"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1373 - "Community 1373"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1374 - "Community 1374"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1375 - "Community 1375"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1376 - "Community 1376"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1377 - "Community 1377"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1378 - "Community 1378"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1379 - "Community 1379"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1380 - "Community 1380"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1381 - "Community 1381"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1382 - "Community 1382"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1383 - "Community 1383"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1384 - "Community 1384"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1385 - "Community 1385"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1386 - "Community 1386"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1387 - "Community 1387"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1388 - "Community 1388"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1389 - "Community 1389"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1390 - "Community 1390"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1391 - "Community 1391"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1392 - "Community 1392"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1393 - "Community 1393"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1394 - "Community 1394"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1395 - "Community 1395"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1396 - "Community 1396"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1397 - "Community 1397"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1398 - "Community 1398"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1399 - "Community 1399"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1400 - "Community 1400"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1401 - "Community 1401"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1402 - "Community 1402"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1403 - "Community 1403"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1404 - "Community 1404"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1405 - "Community 1405"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1406 - "Community 1406"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1407 - "Community 1407"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1408 - "Community 1408"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1409 - "Community 1409"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1410 - "Community 1410"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1411 - "Community 1411"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1412 - "Community 1412"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1413 - "Community 1413"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1414 - "Community 1414"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1415 - "Community 1415"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1416 - "Community 1416"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1417 - "Community 1417"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
 
 ### Community 1418 - "Community 1418"
 Cohesion: 1.0
-Nodes (0):
+Nodes (0): 
+
+### Community 1419 - "Community 1419"
+Cohesion: 1.0
+Nodes (0): 
+
+### Community 1420 - "Community 1420"
+Cohesion: 1.0
+Nodes (0): 
 
 ## Knowledge Gaps
 - **2 isolated node(s):** `TimeoutError`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 728`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 730`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 731`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 732`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 733`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 734`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 735`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 736`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 737`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 738`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 739`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
+- **Thin community `Community 740`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 741`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 742`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 743`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
+- **Thin community `Community 744`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `createAnchorSchema()`, `anchor-map.handler.spec.ts`
+- **Thin community `Community 745`** (2 nodes): `createAnchorSchema()`, `anchor-map.handler.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
+- **Thin community `Community 746`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 747`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 748`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
+- **Thin community `Community 749`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 750`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 751`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
+- **Thin community `Community 752`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 753`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
+- **Thin community `Community 754`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
+- **Thin community `Community 755`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
+- **Thin community `Community 756`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
+- **Thin community `Community 757`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 758`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
+- **Thin community `Community 759`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 760`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `request()`, `audit.routes.spec.ts`
+- **Thin community `Community 761`** (2 nodes): `request()`, `audit.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 762`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 763`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
+- **Thin community `Community 764`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 765`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 766`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 767`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 768`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
+- **Thin community `Community 769`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 770`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 771`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 772`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 773`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 774`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
+- **Thin community `Community 775`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
+- **Thin community `Community 776`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `event()`, `codex-hook.spec.ts`
+- **Thin community `Community 777`** (2 nodes): `event()`, `codex-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
+- **Thin community `Community 778`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `agentAskHelpText()`, `help.ts`
+- **Thin community `Community 779`** (2 nodes): `agentAskHelpText()`, `help.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 780`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 781`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 782`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 783`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 784`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 785`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 786`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 787`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 788`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 789`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 790`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 791`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 792`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
+- **Thin community `Community 793`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
+- **Thin community `Community 794`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
+- **Thin community `Community 795`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `runner.ts`, `runCodexHook()`
+- **Thin community `Community 796`** (2 nodes): `runner.ts`, `runCodexHook()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 797`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createMementoClient()`, `factory.ts`
+- **Thin community `Community 798`** (2 nodes): `createMementoClient()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 799`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 800`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 801`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 802`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 803`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 804`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 805`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 806`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 807`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 808`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
+- **Thin community `Community 809`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
+- **Thin community `Community 810`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
+- **Thin community `Community 811`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
+- **Thin community `Community 812`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 813`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 814`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 815`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 816`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 817`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 818`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
+- **Thin community `Community 819`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `log()`, `init-log.ts`
+- **Thin community `Community 820`** (2 nodes): `log()`, `init-log.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 821`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
+- **Thin community `Community 822`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
+- **Thin community `Community 823`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
+- **Thin community `Community 824`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 825`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 826`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 827`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 828`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 829`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 830`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 831`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
+- **Thin community `Community 832`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 833`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 834`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 835`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 836`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 837`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 838`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `runAnchorAutoRefresh()`, `batch-scheduler-anchor-handlers.ts`
+- **Thin community `Community 839`** (2 nodes): `runAnchorAutoRefresh()`, `batch-scheduler-anchor-handlers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
+- **Thin community `Community 840`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 841`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 842`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 843`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
+- **Thin community `Community 844`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
+- **Thin community `Community 845`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 846`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
+- **Thin community `Community 847`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
+- **Thin community `Community 848`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
+- **Thin community `Community 849`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
+- **Thin community `Community 850`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
+- **Thin community `Community 851`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
+- **Thin community `Community 852`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 853`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 854`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 855`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 856`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 857`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 858`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 859`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 860`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 861`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
+- **Thin community `Community 862`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 863`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 864`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `initializeGemini()`, `gemini.ts`
+- **Thin community `Community 865`** (2 nodes): `initializeGemini()`, `gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `initializeOpenAI()`, `openai.ts`
+- **Thin community `Community 866`** (2 nodes): `initializeOpenAI()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `source-uri.ts`, `validateSource()`
+- **Thin community `Community 867`** (2 nodes): `source-uri.ts`, `validateSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 868`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 869`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 870`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 871`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 872`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
+- **Thin community `Community 873`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
+- **Thin community `Community 874`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
+- **Thin community `Community 875`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 876`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 877`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 878`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 879`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
+- **Thin community `Community 880`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 881`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 882`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 883`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 884`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 885`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 886`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
+- **Thin community `Community 887`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 888`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 889`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 890`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 891`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
+- **Thin community `Community 892`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 893`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 894`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
+- **Thin community `Community 895`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
+- **Thin community `Community 896`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 897`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
+- **Thin community `Community 898`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
+- **Thin community `Community 899`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 900`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 901`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
+- **Thin community `Community 902`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 903`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 904`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 905`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 906`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 907`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 908`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 909`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 910`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 911`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 912`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 913`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 914`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 915`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
+- **Thin community `Community 916`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 917`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 918`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 919`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 920`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 921`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 922`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 923`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 924`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 925`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 926`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 927`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 928`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 929`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `matchRelations()`, `matching-rules.ts`
+- **Thin community `Community 930`** (2 nodes): `matchRelations()`, `matching-rules.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
+- **Thin community `Community 931`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
+- **Thin community `Community 932`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 933`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 934`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 935`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 936`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 937`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 938`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 939`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 940`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 941`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 942`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 943`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 944`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 945`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 946`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 947`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 948`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 949`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 950`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 951`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 952`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 953`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 954`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
+- **Thin community `Community 955`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 956`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 957`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 958`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 959`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 960`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 961`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 962`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 963`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 964`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 965`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 966`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 967`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 968`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 969`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 970`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 971`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 972`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 973`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 974`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 975`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 976`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 977`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 978`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 979`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 980`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 981`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 982`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 983`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 984`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 985`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
+- **Thin community `Community 986`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 987`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
+- **Thin community `Community 988`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 989`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
+- **Thin community `Community 990`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
+- **Thin community `Community 991`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `vitest.config.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 992`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 993`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 994`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `types.ts`
+- **Thin community `Community 995`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 996`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `index.ts`
+- **Thin community `Community 997`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 998`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 999`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 1000`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 1001`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 1002`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 1003`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `transport.ts`
+- **Thin community `Community 1004`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `index.ts`
+- **Thin community `Community 1005`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 1006`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 1007`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1008`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 1009`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 1010`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 1011`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 1012`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 1013`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 1014`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 1015`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 1016`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 1017`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 1018`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 1019`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 1020`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 1021`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `audit-tool-dispatch.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `audit-tool-dispatch.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 1027`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 1028`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 1029`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 1031`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 1032`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 1033`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `context.ts`
+- **Thin community `Community 1035`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 1036`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `mcp-tool-call-error.spec.ts`
+- **Thin community `Community 1037`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 1038`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 1039`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `index.ts`
+- **Thin community `Community 1041`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 1042`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 1043`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `agent.routes.types.ts`
+- **Thin community `Community 1044`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `agent.routes.constants.ts`
+- **Thin community `Community 1045`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `types.ts`
+- **Thin community `Community 1046`** (1 nodes): `agent.routes.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `runtime-transport-parity.spec.ts`
+- **Thin community `Community 1047`** (1 nodes): `agent.routes.constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 1048`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 1049`** (1 nodes): `runtime-transport-parity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `agent-ask.ts`
+- **Thin community `Community 1050`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `types.ts`
+- **Thin community `Community 1051`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 1052`** (1 nodes): `agent-ask.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 1053`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 1054`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 1055`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1056`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 1057`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 1058`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 1059`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 1060`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 1061`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1062`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 1063`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 1064`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `types.ts`
+- **Thin community `Community 1065`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 1066`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `index.ts`
+- **Thin community `Community 1067`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1068`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1069`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `types.ts`
+- **Thin community `Community 1070`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1071`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1072`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1073`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `types.ts`
+- **Thin community `Community 1074`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1075`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1076`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `utils.ts`
+- **Thin community `Community 1077`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `index.ts`
+- **Thin community `Community 1078`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 1079`** (1 nodes): `utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `feedback.integration.spec.ts`
+- **Thin community `Community 1080`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `client-context.ts`
+- **Thin community `Community 1081`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `async-optimizer.ts`
+- **Thin community `Community 1082`** (1 nodes): `feedback.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `async-optimizer.types.ts`
+- **Thin community `Community 1083`** (1 nodes): `client-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 1084`** (1 nodes): `async-optimizer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 1085`** (1 nodes): `async-optimizer.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 1086`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 1087`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 1088`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 1089`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 1090`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 1091`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 1092`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `types.ts`
+- **Thin community `Community 1093`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 1094`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 1095`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 1096`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 1097`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `037-memory-forgetting-event.spec.ts`
+- **Thin community `Community 1098`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `039-event-outbox.spec.ts`
+- **Thin community `Community 1099`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `040-audit-hash-chain.spec.ts`
+- **Thin community `Community 1100`** (1 nodes): `037-memory-forgetting-event.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 1101`** (1 nodes): `039-event-outbox.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 1102`** (1 nodes): `040-audit-hash-chain.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 1103`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 1104`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 1105`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 1106`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 1107`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 1108`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 1109`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 1110`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
+- **Thin community `Community 1111`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `maintenance-jobs.spec.ts`
+- **Thin community `Community 1112`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `error-handling.spec.ts`
+- **Thin community `Community 1113`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `run-job.spec.ts`
+- **Thin community `Community 1114`** (1 nodes): `maintenance-jobs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `logging.spec.ts`
+- **Thin community `Community 1115`** (1 nodes): `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `env-defaults.spec.ts`
+- **Thin community `Community 1116`** (1 nodes): `run-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `lifecycle.spec.ts`
+- **Thin community `Community 1117`** (1 nodes): `logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `status-diagnostics.spec.ts`
+- **Thin community `Community 1118`** (1 nodes): `env-defaults.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `constructor-config.spec.ts`
+- **Thin community `Community 1119`** (1 nodes): `lifecycle.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `relation-validation.spec.ts`
+- **Thin community `Community 1120`** (1 nodes): `status-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 1121`** (1 nodes): `constructor-config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 1122`** (1 nodes): `relation-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 1123`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 1124`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 1125`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 1126`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 1127`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1128`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `owner-scope-mode.spec.ts`
+- **Thin community `Community 1129`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 1130`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 1131`** (1 nodes): `owner-scope-mode.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 1132`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1133`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 1134`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 1135`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `pii-masker-api-key.spec.ts`
+- **Thin community `Community 1136`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 1137`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 1138`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `memento-resource-uri.spec.ts`
+- **Thin community `Community 1139`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 1140`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1141`** (1 nodes): `memento-resource-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `external-api-retry-logging.spec.ts`
+- **Thin community `Community 1142`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 1143`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 1144`** (1 nodes): `external-api-retry-logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 1145`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 1146`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 1147`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 1148`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 1149`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 1150`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 1151`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1152`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 1153`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 1154`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 1155`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 1156`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 1157`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 1158`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 1159`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `error-types.ts`
+- **Thin community `Community 1160`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 1161`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 1162`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `search.types.ts`
+- **Thin community `Community 1163`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1164`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 1165`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `constants.ts`
+- **Thin community `Community 1166`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 1167`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 1168`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 1169`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 1170`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 1171`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 1172`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 1173`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 1174`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `schema-version.ts`
+- **Thin community `Community 1175`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 1176`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 1177`** (1 nodes): `schema-version.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 1178`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 1179`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 1180`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 1181`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 1182`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 1183`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 1184`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 1185`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 1186`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 1187`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 1188`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 1189`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 1190`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 1191`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 1192`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 1193`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 1194`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 1195`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 1196`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 1197`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 1198`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `types.ts`
+- **Thin community `Community 1199`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `source-uri.spec.ts`
+- **Thin community `Community 1200`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 1201`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 1202`** (1 nodes): `source-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 1203`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 1204`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 1205`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 1206`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 1207`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 1208`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `index.ts`
+- **Thin community `Community 1209`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 1210`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `database-types.ts`
+- **Thin community `Community 1211`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 1212`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 1213`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 1214`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `types.ts`
+- **Thin community `Community 1215`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `index.ts`
+- **Thin community `Community 1216`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `spec.ts`
+- **Thin community `Community 1217`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 1218`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 1219`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 1220`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `hybrid-search-types.ts`
+- **Thin community `Community 1221`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `search-ranking.types.ts`
+- **Thin community `Community 1222`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 1223`** (1 nodes): `hybrid-search-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 1224`** (1 nodes): `search-ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 1225`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 1226`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 1227`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `search-engine.types.ts`
+- **Thin community `Community 1228`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 1229`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1230`** (1 nodes): `search-engine.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 1231`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `forgetting-event-log.spec.ts`
+- **Thin community `Community 1232`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 1233`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 1234`** (1 nodes): `forgetting-event-log.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 1235`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 1236`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 1237`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 1238`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 1239`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 1240`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `index.ts`
+- **Thin community `Community 1241`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 1242`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
+- **Thin community `Community 1243`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `audit-hash-chain-service.spec.ts`
+- **Thin community `Community 1244`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 1245`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `event-outbox-service.spec.ts`
+- **Thin community `Community 1246`** (1 nodes): `audit-hash-chain-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `index.ts`
+- **Thin community `Community 1247`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 1248`** (1 nodes): `event-outbox-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 1249`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 1250`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 1251`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 1252`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `context-port.ts`
+- **Thin community `Community 1253`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 1254`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 1255`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 1256`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1257`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1258`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1259`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 1260`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 1261`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 1262`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 1263`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 1264`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 1265`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 1266`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 1267`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 1268`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 1269`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `remember-tool-schema.ts`
+- **Thin community `Community 1270`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `remember-tool-host.ts`
+- **Thin community `Community 1271`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `remember-tool-types.ts`
+- **Thin community `Community 1272`** (1 nodes): `remember-tool-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 1273`** (1 nodes): `remember-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 1274`** (1 nodes): `remember-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 1275`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 1276`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 1277`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 1278`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1279`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1280`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1281`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1282`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1283`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1284`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1285`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1286`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1287`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1288`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1289`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1290`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1291`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1292`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1293`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `index.ts`
+- **Thin community `Community 1294`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1295`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1296`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1297`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `relation-tools-registry.spec.ts`
+- **Thin community `Community 1298`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1299`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1300`** (1 nodes): `relation-tools-registry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1301`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1302`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1303`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1304`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1305`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1306`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1307`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
+- **Thin community `Community 1308`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1309`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1310`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1311`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1312`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1313`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1314`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1315`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 1316`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `triple-parser.spec.ts`
+- **Thin community `Community 1317`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `types.ts`
+- **Thin community `Community 1318`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `types.ts`
+- **Thin community `Community 1319`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1320`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1321`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1322`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1323`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1324`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1325`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1326`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1327`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1328`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1329`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `embedding-reindex-service.spec.ts`
+- **Thin community `Community 1330`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `types.ts`
+- **Thin community `Community 1331`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1332`** (1 nodes): `embedding-reindex-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1333`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1334`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `performance-monitor-types.ts`
+- **Thin community `Community 1335`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1336`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1337`** (1 nodes): `performance-monitor-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1338`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1339`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1340`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `quality-metrics-types.ts`
+- **Thin community `Community 1341`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `types.ts`
+- **Thin community `Community 1342`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1343`** (1 nodes): `quality-metrics-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1344`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1345`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1346`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1347`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1348`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1349`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1350`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1351`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1352`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1353`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1354`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `vector-search-quality-metrics.ts`
+- **Thin community `Community 1355`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `types.ts`
+- **Thin community `Community 1356`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `memory-export-import.spec.ts`
+- **Thin community `Community 1357`** (1 nodes): `vector-search-quality-metrics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `anchor-map.e2e.ts`
+- **Thin community `Community 1358`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `agent-sessions.e2e.ts`
+- **Thin community `Community 1359`** (1 nodes): `memory-export-import.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1360`** (1 nodes): `anchor-map.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1361`** (1 nodes): `agent-sessions.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1362`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1363`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1364`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `longmemeval-validation.spec.ts`
+- **Thin community `Community 1365`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `acquire-longmemeval.spec.ts`
+- **Thin community `Community 1366`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1367`** (1 nodes): `longmemeval-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1368`** (1 nodes): `acquire-longmemeval.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1369`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1370`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1371`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1372`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1373`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1374`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1375`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1376`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `types.ts`
+- **Thin community `Community 1377`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1378`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1379`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1380`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1381`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1382`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1383`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1384`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1385`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1386`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1387`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1388`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1389`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `review-candidates-panel-poll-fetch.js`
+- **Thin community `Community 1390`** (1 nodes): `entrypoint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `embedding-map-state.js`
+- **Thin community `Community 1391`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1392`** (1 nodes): `review-candidates-panel-poll-fetch.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `dashboard-auth.js`
+- **Thin community `Community 1393`** (1 nodes): `embedding-map-state.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `dashboard-auth-error.js`
+- **Thin community `Community 1394`** (1 nodes): `memory-evolution-demo-shell-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `review-candidates-panel-poll.js`
+- **Thin community `Community 1395`** (1 nodes): `dashboard-auth.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `dashboard-auth-render-message.js`
+- **Thin community `Community 1396`** (1 nodes): `dashboard-auth-error.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `graph.js`
+- **Thin community `Community 1397`** (1 nodes): `review-candidates-panel-poll.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `graph-shared.js`
+- **Thin community `Community 1398`** (1 nodes): `dashboard-auth-render-message.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `dashboard-auth-render-form.js`
+- **Thin community `Community 1399`** (1 nodes): `graph.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1400`** (1 nodes): `graph-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `agent-sessions-panel-render.js`
+- **Thin community `Community 1401`** (1 nodes): `dashboard-auth-render-form.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `anchor-map-shared.js`
+- **Thin community `Community 1402`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `dashboard-auth-render-status.js`
+- **Thin community `Community 1403`** (1 nodes): `agent-sessions-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `review-candidates-panel-poll-toast.js`
+- **Thin community `Community 1404`** (1 nodes): `anchor-map-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `agent-sessions-panel-render-injections.js`
+- **Thin community `Community 1405`** (1 nodes): `dashboard-auth-render-status.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
+- **Thin community `Community 1406`** (1 nodes): `review-candidates-panel-poll-toast.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `review-candidates-panel-health.js`
+- **Thin community `Community 1407`** (1 nodes): `agent-sessions-panel-render-injections.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `agent-sessions-panel-render-provenance.js`
+- **Thin community `Community 1408`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `embedding-map-chart-colors.js`
+- **Thin community `Community 1409`** (1 nodes): `review-candidates-panel-health.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `review-candidates-panel-poll-cycle.js`
+- **Thin community `Community 1410`** (1 nodes): `agent-sessions-panel-render-provenance.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `agent-sessions-panel-render-sessions.js`
+- **Thin community `Community 1411`** (1 nodes): `embedding-map-chart-colors.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `dashboard-auth-requests.js`
+- **Thin community `Community 1412`** (1 nodes): `review-candidates-panel-poll-cycle.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `review-candidates-panel-render.js`
+- **Thin community `Community 1413`** (1 nodes): `agent-sessions-panel-render-sessions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `dashboard-auth-ui.js`
+- **Thin community `Community 1414`** (1 nodes): `dashboard-auth-requests.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `dashboard-auth-render-tabs.js`
+- **Thin community `Community 1415`** (1 nodes): `review-candidates-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `review-candidates-panel-poll-badge.js`
+- **Thin community `Community 1416`** (1 nodes): `dashboard-auth-ui.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `graph-embed-init.js`
+- **Thin community `Community 1417`** (1 nodes): `dashboard-auth-render-tabs.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `dashboard-auth-render.js`
+- **Thin community `Community 1418`** (1 nodes): `review-candidates-panel-poll-badge.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1419`** (1 nodes): `graph-embed-init.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1420`** (1 nodes): `dashboard-auth-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 991
+      "community": 993
     },
     {
       "label": "playwright.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config_ts",
-      "community": 992
+      "community": 994
     },
     {
       "label": "vitest.config.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 993
+      "community": 995
     },
     {
       "label": "assistant.spec.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 994
+      "community": 996
     },
     {
       "label": "types.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 995
+      "community": 997
     },
     {
       "label": "types.spec.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 996
+      "community": 998
     },
     {
       "label": "assistant.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 997
+      "community": 999
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -137,7 +137,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 616
+      "community": 617
     },
     {
       "label": "SlowTransport",
@@ -145,7 +145,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 616
+      "community": 617
     },
     {
       "label": ".recall()",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 616
+      "community": 617
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 998
+      "community": 1000
     },
     {
       "label": "after-assistant-turn.ts",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 728
+      "community": 730
     },
     {
       "label": "before-user-turn.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "beforeUserTurn()",
@@ -193,7 +193,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 617
+      "community": 618
     },
     {
       "label": "withTimeout()",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 617
+      "community": 618
     },
     {
       "label": "auto-recall-policy.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 729
+      "community": 731
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 729
+      "community": 731
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 999
+      "community": 1001
     },
     {
       "label": "auto-remember-policy.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 730
+      "community": 732
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 730
+      "community": 732
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 1000
+      "community": 1002
     },
     {
       "label": "channel-scope.ts",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "scopeRecallFilters()",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 618
+      "community": 619
     },
     {
       "label": "scopeRememberTags()",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 618
+      "community": 619
     },
     {
       "label": "channel-scope.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 1001
+      "community": 1003
     },
     {
       "label": "http-transport.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 1002
+      "community": 1004
     },
     {
       "label": "mock-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 1003
+      "community": 1005
     },
     {
       "label": "transport.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 1004
+      "community": 1006
     },
     {
       "label": "index.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 1005
+      "community": 1007
     },
     {
       "label": "http-transport.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 1006
+      "community": 1008
     },
     {
       "label": "factory.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 731
+      "community": 733
     },
     {
       "label": "createTransportFromEnv()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 731
+      "community": 733
     },
     {
       "label": "stdio-transport.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 1007
+      "community": 1009
     },
     {
       "label": "mock-transport.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "createRateLimitedLogger()",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 485
+      "community": 486
     },
     {
       "label": "levelFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 485
+      "community": 486
     },
     {
       "label": "consoleSink()",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 485
+      "community": 486
     },
     {
       "label": "logger.spec.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 1008
+      "community": 1010
     },
     {
       "label": "retry-queue.spec.ts",
@@ -649,7 +649,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 1009
+      "community": 1011
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -657,7 +657,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 1010
+      "community": 1012
     },
     {
       "label": "retry-queue.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 1011
+      "community": 1013
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 1012
+      "community": 1014
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 1013
+      "community": 1015
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 1014
+      "community": 1016
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 1015
+      "community": 1017
     },
     {
       "label": "http.integration.spec.ts",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 1016
+      "community": 1018
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 1017
+      "community": 1019
     },
     {
       "label": "start-http-server.ts",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "startTestHttpServer()",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 486
+      "community": 487
     },
     {
       "label": "findFreePort()",
@@ -793,7 +793,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 486
+      "community": 487
     },
     {
       "label": "waitForHealth()",
@@ -801,7 +801,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 486
+      "community": 487
     },
     {
       "label": "http-server-runner.js",
@@ -809,7 +809,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 1018
+      "community": 1020
     },
     {
       "label": "test-integration.js",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 732
+      "community": 734
     },
     {
       "label": "testBasicFunctionality()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 732
+      "community": 734
     },
     {
       "label": "performance-optimizer.js",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 733
+      "community": 735
     },
     {
       "label": "basicUsageExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 733
+      "community": 735
     },
     {
       "label": "performance-examples.ts",
@@ -1137,7 +1137,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_performance_examples_ts",
-      "community": 123
+      "community": 124
     },
     {
       "label": "batchProcessingExample()",
@@ -1145,7 +1145,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L25",
       "id": "performance_examples_batchprocessingexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "parallelSearchExample()",
@@ -1153,7 +1153,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L54",
       "id": "performance_examples_parallelsearchexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "cachingExample()",
@@ -1161,7 +1161,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L87",
       "id": "performance_examples_cachingexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "streamingSearchExample()",
@@ -1169,7 +1169,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L118",
       "id": "performance_examples_streamingsearchexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "compressedSearchExample()",
@@ -1177,7 +1177,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L152",
       "id": "performance_examples_compressedsearchexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "benchmarkExample()",
@@ -1185,7 +1185,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L183",
       "id": "performance_examples_benchmarkexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "memoryOptimizationExample()",
@@ -1193,7 +1193,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L209",
       "id": "performance_examples_memoryoptimizationexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "realTimeMonitoringExample()",
@@ -1201,7 +1201,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L285",
       "id": "performance_examples_realtimemonitoringexample",
-      "community": 123
+      "community": 124
     },
     {
       "label": "processPageData()",
@@ -1209,7 +1209,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L367",
       "id": "performance_examples_processpagedata",
-      "community": 123
+      "community": 124
     },
     {
       "label": "runPerformanceExamples()",
@@ -1217,7 +1217,7 @@
       "source_file": "packages/mcp-client/examples/performance-examples.ts",
       "source_location": "L373",
       "id": "performance_examples_runperformanceexamples",
-      "community": 123
+      "community": 124
     },
     {
       "label": "advanced-usage.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 734
+      "community": 736
     },
     {
       "label": "advancedUsageExample()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 734
+      "community": 736
     },
     {
       "label": "migration-guide.ts",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "makeNullRunner()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 735
+      "community": 737
     },
     {
       "label": "telemetry-cli.ts",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 1019
+      "community": 1021
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 1020
+      "community": 1022
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 1021
+      "community": 1023
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "readShellSources()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L47",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 736
+      "community": 738
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "getRepoRoot()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 487
+      "community": 488
     },
     {
       "label": "collectEnvKeys()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 487
+      "community": 488
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 487
+      "community": 488
     },
     {
       "label": "server-info.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 1022
+      "community": 1024
     },
     {
       "label": "audit-tool-dispatch.spec.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/audit-tool-dispatch.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_audit_tool_dispatch_spec_ts",
-      "community": 1023
+      "community": 1025
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "createMockResponse()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 619
+      "community": 620
     },
     {
       "label": "sendOptions()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 619
+      "community": 620
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "readReviewCandidatesPanelSources()",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L44",
       "id": "dashboard_review_candidates_panel_spec_readreviewcandidatespanelsources",
-      "community": 620
+      "community": 621
     },
     {
       "label": "createPollHarness()",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L67",
       "id": "dashboard_review_candidates_panel_spec_createpollharness",
-      "community": 620
+      "community": 621
     },
     {
       "label": "index-factory.spec.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 1024
+      "community": 1026
     },
     {
       "label": "context.spec.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 1025
+      "community": 1027
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 1026
+      "community": 1028
     },
     {
       "label": "server-factory.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "createServerFactory()",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 737
+      "community": 739
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "readRepoFile()",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 621
+      "community": 622
     },
     {
       "label": "sectionBetween()",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 621
+      "community": 622
     },
     {
       "label": "http-server.spec.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 1027
+      "community": 1029
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 1028
+      "community": 1030
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_websocket_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "setupWebSocketServer()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L20",
       "id": "http_server_websocket_setupwebsocketserver",
-      "community": 738
+      "community": 740
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 739
+      "community": 741
     },
     {
       "label": "startStdioServer()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 739
+      "community": 741
     },
     {
       "label": "audit-tool-dispatch.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 1029
+      "community": 1031
     },
     {
       "label": "server-state.spec.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 1030
+      "community": 1032
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_owner_scope_integration_spec_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "postJson()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L16",
       "id": "owner_scope_integration_spec_postjson",
-      "community": 488
+      "community": 489
     },
     {
       "label": "seedOwnerScopedMemories()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L56",
       "id": "owner_scope_integration_spec_seedownerscopedmemories",
-      "community": 488
+      "community": 489
     },
     {
       "label": "startRealHttpServer()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L69",
       "id": "owner_scope_integration_spec_startrealhttpserver",
-      "community": 488
+      "community": 489
     },
     {
       "label": "server-info.spec.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 1031
+      "community": 1033
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 740
+      "community": 742
     },
     {
       "label": "http-server-lifecycle.ts",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_lifecycle_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "createRuntimeDiagnosticsWriter()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L18",
       "id": "http_server_lifecycle_createruntimediagnosticswriter",
-      "community": 489
+      "community": 490
     },
     {
       "label": "performCleanup()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L37",
       "id": "http_server_lifecycle_performcleanup",
-      "community": 489
+      "community": 490
     },
     {
       "label": "registerCleanupHandlers()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L106",
       "id": "http_server_lifecycle_registercleanuphandlers",
-      "community": 489
+      "community": 490
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "createMockResponse()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 622
+      "community": 623
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 622
+      "community": 623
     },
     {
       "label": "server-state.ts",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 1032
+      "community": 1034
     },
     {
       "label": "bootstrap.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 1033
+      "community": 1035
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 1034
+      "community": 1036
     },
     {
       "label": "sse-server-impl.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "startSseServer()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 490
+      "community": 491
     },
     {
       "label": "stopSseServer()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 490
+      "community": 491
     },
     {
       "label": "cleanupSseServer()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 490
+      "community": 491
     },
     {
       "label": "http-server.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 1035
+      "community": 1037
     },
     {
       "label": "batch-run-history.ts",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 623
+      "community": 624
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 623
+      "community": 624
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 1036
+      "community": 1038
     },
     {
       "label": "mcp-tool-call-error.spec.ts",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
-      "community": 1037
+      "community": 1039
     },
     {
       "label": "mcp-tool-call-error.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 741
+      "community": 743
     },
     {
       "label": "tool-result.utils.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_tool_result_utils_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "extractToolResultPayload()",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L6",
       "id": "tool_result_utils_extracttoolresultpayload",
-      "community": 742
+      "community": 744
     },
     {
       "label": "anchor-map.handler.spec.ts",
@@ -3321,7 +3321,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "createAnchorSchema()",
@@ -3329,7 +3329,7 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
       "source_location": "L6",
       "id": "anchor_map_handler_spec_createanchorschema",
-      "community": 743
+      "community": 745
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3393,7 +3393,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 1038
+      "community": 1040
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3401,7 +3401,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 1039
+      "community": 1041
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3409,7 +3409,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 1040
+      "community": 1042
     },
     {
       "label": "http-rate-limit.middleware.spec.ts",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_rate_limit_middleware_spec_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "getRequest()",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L8",
       "id": "http_rate_limit_middleware_spec_getrequest",
-      "community": 744
+      "community": 746
     },
     {
       "label": "owner-scope.middleware.ts",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "hasOwnerIdInBody()",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L10",
       "id": "owner_scope_middleware_hasowneridinbody",
-      "community": 491
+      "community": 492
     },
     {
       "label": "isOwnerScopedToolRequest()",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L27",
       "id": "owner_scope_middleware_isownerscopedtoolrequest",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createOwnerScopeMiddleware()",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L36",
       "id": "owner_scope_middleware_createownerscopemiddleware",
-      "community": 491
+      "community": 492
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "makeMocks()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L13",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 624
+      "community": 625
     },
     {
       "label": "createMiddleware()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L23",
       "id": "admin_auth_middleware_spec_createmiddleware",
-      "community": 624
+      "community": 625
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3713,7 +3713,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3721,7 +3721,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L33",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 745
+      "community": 747
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3729,7 +3729,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "createMockResponse()",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 746
+      "community": 748
     },
     {
       "label": "index.ts",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 1041
+      "community": 1043
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "readCookie()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 492
+      "community": 493
     },
     {
       "label": "writeUnauthorized()",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 492
+      "community": 493
     },
     {
       "label": "http-audit.middleware.spec.ts",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_audit_middleware_spec_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "createMockResponse()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L18",
       "id": "http_audit_middleware_spec_createmockresponse",
-      "community": 747
+      "community": 749
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "createServiceInjector()",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 748
+      "community": 750
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L16",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 749
+      "community": 751
     },
     {
       "label": "http-rate-limit.middleware.ts",
@@ -3889,7 +3889,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createMockResponse()",
@@ -3897,7 +3897,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createRegistry()",
@@ -3905,7 +3905,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "programmatic_auth_middleware_spec_createregistry",
-      "community": 625
+      "community": 626
     },
     {
       "label": "owner-scope.middleware.spec.ts",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_spec_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "runMiddleware()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L18",
       "id": "owner_scope_middleware_spec_runmiddleware",
-      "community": 750
+      "community": 752
     },
     {
       "label": "session-store.spec.ts",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 1042
+      "community": 1044
     },
     {
       "label": "session-store.ts",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "createSessionStore()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 751
+      "community": 753
     },
     {
       "label": "stdio-server.ts",
@@ -4057,7 +4057,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "createAgentRouter()",
@@ -4065,7 +4065,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L44",
       "id": "agent_routes_createagentrouter",
-      "community": 752
+      "community": 754
     },
     {
       "label": "quality.routes.spec.ts",
@@ -4073,7 +4073,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 1043
+      "community": 1045
     },
     {
       "label": "agent.routes.validation.ts",
@@ -4137,7 +4137,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_personal_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "parsePersonalRunBody()",
@@ -4145,7 +4145,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L15",
       "id": "agent_routes_personal_parsepersonalrunbody",
-      "community": 493
+      "community": 494
     },
     {
       "label": "handlePostPersonalRun()",
@@ -4153,7 +4153,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L27",
       "id": "agent_routes_personal_handlepostpersonalrun",
-      "community": 493
+      "community": 494
     },
     {
       "label": "handlePostPersonalPersistApproved()",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L50",
       "id": "agent_routes_personal_handlepostpersonalpersistapproved",
-      "community": 493
+      "community": 494
     },
     {
       "label": "maintenance.routes.spec.ts",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_maintenance_routes_spec_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "request()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L8",
       "id": "maintenance_routes_spec_request",
-      "community": 753
+      "community": 755
     },
     {
       "label": "agent.routes.spec.ts",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "event()",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L13",
       "id": "agent_routes_spec_event",
-      "community": 626
+      "community": 627
     },
     {
       "label": "invoke()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L159",
       "id": "agent_routes_spec_invoke",
-      "community": 626
+      "community": 627
     },
     {
       "label": "agent-transcript-import.spec.ts",
@@ -4329,7 +4329,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_personal_routes_spec_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "invoke()",
@@ -4337,7 +4337,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L33",
       "id": "agent_personal_routes_spec_invoke",
-      "community": 754
+      "community": 756
     },
     {
       "label": "agent.routes.promotions.ts",
@@ -4489,7 +4489,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_events_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "prepareEvent()",
@@ -4497,7 +4497,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L14",
       "id": "agent_routes_events_prepareevent",
-      "community": 755
+      "community": 757
     },
     {
       "label": "agent.routes.types.ts",
@@ -4505,7 +4505,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_types_ts",
-      "community": 1044
+      "community": 1046
     },
     {
       "label": "admin.routes.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "createAdminRouter()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L29",
       "id": "admin_routes_createadminrouter",
-      "community": 756
+      "community": 758
     },
     {
       "label": "agent.routes.status.ts",
@@ -4673,7 +4673,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.constants.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_constants_ts",
-      "community": 1045
+      "community": 1047
     },
     {
       "label": "mcp.routes.ts",
@@ -4681,7 +4681,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_routes_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "createMcpRouter()",
@@ -4689,7 +4689,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L17",
       "id": "mcp_routes_createmcprouter",
-      "community": 757
+      "community": 759
     },
     {
       "label": "admin.routes.spec.ts",
@@ -4945,7 +4945,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "createToolsRouter()",
@@ -4953,7 +4953,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L19",
       "id": "tools_routes_createtoolsrouter",
-      "community": 758
+      "community": 760
     },
     {
       "label": "agent.routes.injection.ts",
@@ -4961,7 +4961,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_injection_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "initialInjectionQuery()",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L5",
       "id": "agent_routes_injection_initialinjectionquery",
-      "community": 494
+      "community": 495
     },
     {
       "label": "injectionScope()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L16",
       "id": "agent_routes_injection_injectionscope",
-      "community": 494
+      "community": 495
     },
     {
       "label": "buildInjectionDetails()",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L25",
       "id": "agent_routes_injection_buildinjectiondetails",
-      "community": 494
+      "community": 495
     },
     {
       "label": "audit.routes.spec.ts",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_audit_routes_spec_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "request()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L8",
       "id": "audit_routes_spec_request",
-      "community": 759
+      "community": 761
     },
     {
       "label": "api.routes.ts",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "createApiRouter()",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L24",
       "id": "api_routes_createapirouter",
-      "community": 760
+      "community": 762
     },
     {
       "label": "agent.routes.utils.ts",
@@ -5121,7 +5121,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "createQualityRouter()",
@@ -5129,7 +5129,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 761
+      "community": 763
     },
     {
       "label": "agent.routes.context.ts",
@@ -5305,7 +5305,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_types_ts",
-      "community": 1046
+      "community": 1048
     },
     {
       "label": "handlers.ts",
@@ -5377,7 +5377,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/runtime-transport-parity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_runtime_transport_parity_spec_ts",
-      "community": 1047
+      "community": 1049
     },
     {
       "label": "json-rpc.ts",
@@ -5385,7 +5385,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_json_rpc_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "isJsonRpcNotification()",
@@ -5393,7 +5393,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L3",
       "id": "json_rpc_isjsonrpcnotification",
-      "community": 495
+      "community": 496
     },
     {
       "label": "isInitializeRequest()",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L7",
       "id": "json_rpc_isinitializerequest",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createJsonRpcError()",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L11",
       "id": "json_rpc_createjsonrpcerror",
-      "community": 495
+      "community": 496
     },
     {
       "label": "message-processor.ts",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_message_processor_ts",
-      "community": 124
+      "community": 125
     },
     {
       "label": "processMcpMessage()",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L54",
       "id": "message_processor_processmcpmessage",
-      "community": 124
+      "community": 125
     },
     {
       "label": "memoryInjectionPromptDefinition()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L134",
       "id": "message_processor_memoryinjectionpromptdefinition",
-      "community": 124
+      "community": 125
     },
     {
       "label": "createServerToolContext()",
@@ -5441,7 +5441,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L162",
       "id": "message_processor_createservertoolcontext",
-      "community": 124
+      "community": 125
     },
     {
       "label": "handleToolsList()",
@@ -5449,7 +5449,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L172",
       "id": "message_processor_handletoolslist",
-      "community": 124
+      "community": 125
     },
     {
       "label": "handleToolsCall()",
@@ -5457,7 +5457,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L194",
       "id": "message_processor_handletoolscall",
-      "community": 124
+      "community": 125
     },
     {
       "label": "handlePromptsCall()",
@@ -5465,7 +5465,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L238",
       "id": "message_processor_handlepromptscall",
-      "community": 124
+      "community": 125
     },
     {
       "label": "handleResourcesList()",
@@ -5473,7 +5473,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L269",
       "id": "message_processor_handleresourceslist",
-      "community": 124
+      "community": 125
     },
     {
       "label": "handleResourcesRead()",
@@ -5481,7 +5481,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L309",
       "id": "message_processor_handleresourcesread",
-      "community": 124
+      "community": 125
     },
     {
       "label": "readMemoryResource()",
@@ -5489,7 +5489,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L354",
       "id": "message_processor_readmemoryresource",
-      "community": 124
+      "community": 125
     },
     {
       "label": "attachMemoryNeighbors()",
@@ -5497,7 +5497,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/message-processor.ts",
       "source_location": "L399",
       "id": "message_processor_attachmemoryneighbors",
-      "community": 124
+      "community": 125
     },
     {
       "label": "admin-evolution-demo.routes.ts",
@@ -5505,7 +5505,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "registerAdminEvolutionDemoRoutes()",
@@ -5513,7 +5513,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L13",
       "id": "admin_evolution_demo_routes_registeradminevolutiondemoroutes",
-      "community": 762
+      "community": 764
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -5521,7 +5521,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L33",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 496
+      "community": 497
     },
     {
       "label": "parseBulkSelector()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L45",
       "id": "admin_memory_review_routes_parsebulkselector",
-      "community": 496
+      "community": 497
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L83",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 496
+      "community": 497
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -5601,7 +5601,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "parseParams()",
@@ -5609,7 +5609,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 627
+      "community": 628
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -5617,7 +5617,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 627
+      "community": 628
     },
     {
       "label": "admin-evolution-demo.routes.spec.ts",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "listen()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L11",
       "id": "admin_evolution_demo_routes_spec_listen",
-      "community": 628
+      "community": 629
     },
     {
       "label": "getAdmin()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L25",
       "id": "admin_evolution_demo_routes_spec_getadmin",
-      "community": 628
+      "community": 629
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 763
+      "community": 765
     },
     {
       "label": "admin-graph-response.ts",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "buildGraphResponse()",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L75",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 764
+      "community": 766
     },
     {
       "label": "admin-tools.routes.ts",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 765
+      "community": 767
     },
     {
       "label": "admin-batch.routes.ts",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 766
+      "community": 768
     },
     {
       "label": "admin-forgetting.routes.ts",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_forgetting_routes_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "registerAdminForgettingRoutes()",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L11",
       "id": "admin_forgetting_routes_registeradminforgettingroutes",
-      "community": 767
+      "community": 769
     },
     {
       "label": "admin-graph.routes.ts",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 768
+      "community": 770
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "parseCleanupParams()",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 629
+      "community": 630
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 629
+      "community": 630
     },
     {
       "label": "admin-relations.routes.ts",
@@ -5817,7 +5817,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -5825,7 +5825,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 769
+      "community": 771
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -5833,7 +5833,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 770
+      "community": 772
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 771
+      "community": 773
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_response_ts",
-      "community": 125
+      "community": 126
     },
     {
       "label": "EmbeddingMapBuildError",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L55",
       "id": "admin_embedding_map_response_embeddingmapbuilderror",
-      "community": 125
+      "community": 126
     },
     {
       "label": ".constructor()",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L56",
       "id": "admin_embedding_map_response_embeddingmapbuilderror_constructor",
-      "community": 125
+      "community": 126
     },
     {
       "label": "clearEmbeddingMapCacheForTests()",
@@ -5889,7 +5889,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L66",
       "id": "admin_embedding_map_response_clearembeddingmapcachefortests",
-      "community": 125
+      "community": 126
     },
     {
       "label": "getCacheKey()",
@@ -5897,7 +5897,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L75",
       "id": "admin_embedding_map_response_getcachekey",
-      "community": 125
+      "community": 126
     },
     {
       "label": "distSq()",
@@ -5905,7 +5905,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L79",
       "id": "admin_embedding_map_response_distsq",
-      "community": 125
+      "community": 126
     },
     {
       "label": "hash32()",
@@ -5913,7 +5913,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L89",
       "id": "admin_embedding_map_response_hash32",
-      "community": 125
+      "community": 126
     },
     {
       "label": "mulberry32()",
@@ -5921,7 +5921,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L99",
       "id": "admin_embedding_map_response_mulberry32",
-      "community": 125
+      "community": 126
     },
     {
       "label": "kMeans()",
@@ -5929,7 +5929,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L112",
       "id": "admin_embedding_map_response_kmeans",
-      "community": 125
+      "community": 126
     },
     {
       "label": "parseTags()",
@@ -5937,7 +5937,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L198",
       "id": "admin_embedding_map_response_parsetags",
-      "community": 125
+      "community": 126
     },
     {
       "label": "buildEmbeddingMapResponse()",
@@ -5945,7 +5945,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map-response.ts",
       "source_location": "L207",
       "id": "admin_embedding_map_response_buildembeddingmapresponse",
-      "community": 125
+      "community": 126
     },
     {
       "label": "admin-export.routes.ts",
@@ -5953,7 +5953,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_export_routes_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "parseTypesQuery()",
@@ -5961,7 +5961,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L12",
       "id": "admin_export_routes_parsetypesquery",
-      "community": 630
+      "community": 631
     },
     {
       "label": "registerAdminExportRoutes()",
@@ -5969,7 +5969,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L21",
       "id": "admin_export_routes_registeradminexportroutes",
-      "community": 630
+      "community": 631
     },
     {
       "label": "claude-code-hook.ts",
@@ -6017,7 +6017,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "argv()",
@@ -6025,7 +6025,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 772
+      "community": 774
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -6073,7 +6073,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 1048
+      "community": 1050
     },
     {
       "label": "agent-ops-demo.ts",
@@ -6081,7 +6081,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_demo_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "runDemo()",
@@ -6089,7 +6089,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L11",
       "id": "agent_ops_demo_rundemo",
-      "community": 773
+      "community": 775
     },
     {
       "label": "env-loader.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "resolveEnvPath()",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 631
+      "community": 632
     },
     {
       "label": "loadEnv()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 631
+      "community": 632
     },
     {
       "label": "codex-connect.spec.ts",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 1049
+      "community": 1051
     },
     {
       "label": "codex-hook.ts",
@@ -6217,7 +6217,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "runCli()",
@@ -6225,7 +6225,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L68",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 632
+      "community": 633
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6233,7 +6233,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L99",
       "id": "cli_ac5_ac6_spec_createreviewqueuedatabase",
-      "community": 632
+      "community": 633
     },
     {
       "label": "agent-ask.ts",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_ts",
-      "community": 1050
+      "community": 1052
     },
     {
       "label": "agent-ops.spec.ts",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_spec_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "response()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L9",
       "id": "agent_ops_spec_response",
-      "community": 633
+      "community": 634
     },
     {
       "label": "baseDependencies()",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L13",
       "id": "agent_ops_spec_basedependencies",
-      "community": 633
+      "community": 634
     },
     {
       "label": "review-queue-cleanup.spec.ts",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_review_queue_cleanup_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L13",
       "id": "review_queue_cleanup_spec_createreviewqueuedatabase",
-      "community": 634
+      "community": 635
     },
     {
       "label": "pendingCount()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L54",
       "id": "review_queue_cleanup_spec_pendingcount",
-      "community": 634
+      "community": 635
     },
     {
       "label": "claude-code-connect.ts",
@@ -6385,7 +6385,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_spec_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "event()",
@@ -6393,7 +6393,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L7",
       "id": "claude_code_hook_spec_event",
-      "community": 774
+      "community": 776
     },
     {
       "label": "agent-ops.ts",
@@ -6457,7 +6457,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_spec_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "event()",
@@ -6465,7 +6465,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L7",
       "id": "codex_hook_spec_event",
-      "community": 775
+      "community": 777
     },
     {
       "label": "agent-ops-core.ts",
@@ -6657,7 +6657,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_runtime_ts",
-      "community": 126
+      "community": 127
     },
     {
       "label": "teardownAgentAsk()",
@@ -6665,7 +6665,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L44",
       "id": "runtime_teardownagentask",
-      "community": 126
+      "community": 127
     },
     {
       "label": "createAgentAskLlm()",
@@ -6673,7 +6673,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L58",
       "id": "runtime_createagentaskllm",
-      "community": 126
+      "community": 127
     },
     {
       "label": "runAgentAskMain()",
@@ -6681,7 +6681,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L98",
       "id": "runtime_runagentaskmain",
-      "community": 126
+      "community": 127
     },
     {
       "label": "runAgentAskInvocation()",
@@ -6689,7 +6689,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L135",
       "id": "runtime_runagentaskinvocation",
-      "community": 126
+      "community": 127
     },
     {
       "label": "runAgentAskWithInterrupts()",
@@ -6697,7 +6697,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L178",
       "id": "runtime_runagentaskwithinterrupts",
-      "community": 126
+      "community": 127
     },
     {
       "label": "writeUsageFailure()",
@@ -6705,7 +6705,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L221",
       "id": "runtime_writeusagefailure",
-      "community": 126
+      "community": 127
     },
     {
       "label": "runAgentAskWithCore()",
@@ -6713,7 +6713,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L231",
       "id": "runtime_runagentaskwithcore",
-      "community": 126
+      "community": 127
     },
     {
       "label": "writeLlmBootstrapFailure()",
@@ -6721,7 +6721,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L291",
       "id": "runtime_writellmbootstrapfailure",
-      "community": 126
+      "community": 127
     },
     {
       "label": "collectPersistenceBlock()",
@@ -6729,7 +6729,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L318",
       "id": "runtime_collectpersistenceblock",
-      "community": 126
+      "community": 127
     },
     {
       "label": "writeAgentAskSuccess()",
@@ -6737,7 +6737,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/runtime.ts",
       "source_location": "L393",
       "id": "runtime_writeagentasksuccess",
-      "community": 126
+      "community": 127
     },
     {
       "label": "parse.ts",
@@ -6793,7 +6793,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_approval_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "promptApproveInteractive()",
@@ -6801,7 +6801,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L7",
       "id": "approval_promptapproveinteractive",
-      "community": 776
+      "community": 778
     },
     {
       "label": "help.ts",
@@ -6809,7 +6809,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_help_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "agentAskHelpText()",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "help_agentaskhelptext",
-      "community": 777
+      "community": 779
     },
     {
       "label": "types.ts",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 1051
+      "community": 1053
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 635
+      "community": 636
     },
     {
       "label": "runQualityMeasurement()",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 635
+      "community": 636
     },
     {
       "label": "test-simple-alerts.ts",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "testSimpleAlerts()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "testBasicFunctionality()",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 779
+      "community": 781
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 780
+      "community": 782
     },
     {
       "label": "test-server-synchronization.ts",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "compareServices()",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 636
+      "community": 637
     },
     {
       "label": "testServerSynchronization()",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-error-logging.ts",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "testErrorLogging()",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 781
+      "community": 783
     },
     {
       "label": "debug-http-v2.ts",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "testFetch()",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 782
+      "community": 784
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "initializeTestDatabase()",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 783
+      "community": 785
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 1052
+      "community": 1054
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 1053
+      "community": 1055
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "testReflexionE2E()",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 784
+      "community": 786
     },
     {
       "label": "test-alerts-direct.ts",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "testAlertsDirect()",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 785
+      "community": 787
     },
     {
       "label": "test-client.ts",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "assert()",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testMementoClient()",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-performance-monitor.ts",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 1054
+      "community": 1056
     },
     {
       "label": "test-http-server-v2.ts",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "testPerformanceAlerts()",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "testPathTraversalE2E()",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 787
+      "community": 789
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 788
+      "community": 790
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 1055
+      "community": 1057
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "createBaseSchema()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 638
+      "community": 639
     },
     {
       "label": "createTestMemory()",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 638
+      "community": 639
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -7265,7 +7265,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 1056
+      "community": 1058
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -7273,7 +7273,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 1057
+      "community": 1059
     },
     {
       "label": "brave-search-provider.ts",
@@ -7281,7 +7281,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "BraveSearchProvider",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 497
+      "community": 498
     },
     {
       "label": ".constructor()",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 497
+      "community": 498
     },
     {
       "label": ".search()",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 497
+      "community": 498
     },
     {
       "label": "noop-search-provider.ts",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "NoopSearchProvider",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 639
+      "community": 640
     },
     {
       "label": ".search()",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 639
+      "community": 640
     },
     {
       "label": "search-factory.ts",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "createSearchProvider()",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 789
+      "community": 791
     },
     {
       "label": "search-provider.ts",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 1058
+      "community": 1060
     },
     {
       "label": "llm-provider.ts",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 1059
+      "community": 1061
     },
     {
       "label": "claude-provider.spec.ts",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 1060
+      "community": 1062
     },
     {
       "label": "types.ts",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "loadAgentConfig()",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 790
+      "community": 792
     },
     {
       "label": "system-prompt.ts",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 1061
+      "community": 1063
     },
     {
       "label": "vitest.config.ts",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 1062
+      "community": 1064
     },
     {
       "label": "injection-contract.spec.ts",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 1063
+      "community": 1065
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_queue_runtime_spec_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "transport()",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L179",
       "id": "queue_runtime_spec_transport",
-      "community": 791
+      "community": 793
     },
     {
       "label": "redaction-size.spec.ts",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 1064
+      "community": 1066
     },
     {
       "label": "injection-contract.ts",
@@ -7561,7 +7561,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 1065
+      "community": 1067
     },
     {
       "label": "runtime.ts",
@@ -7569,7 +7569,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_runtime_ts",
-      "community": 127
+      "community": 128
     },
     {
       "label": "TimeoutError",
@@ -7577,7 +7577,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L37",
       "id": "runtime_timeouterror",
-      "community": 127
+      "community": 128
     },
     {
       "label": "CaptureRuntime",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L39",
       "id": "runtime_captureruntime",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".constructor()",
@@ -7593,7 +7593,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L48",
       "id": "runtime_captureruntime_constructor",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".capture()",
@@ -7601,7 +7601,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L58",
       "id": "runtime_captureruntime_capture",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".drain()",
@@ -7609,7 +7609,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L125",
       "id": "runtime_captureruntime_drain",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".captureResult()",
@@ -7617,7 +7617,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L169",
       "id": "runtime_captureruntime_captureresult",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".dispatchTelemetry()",
@@ -7625,7 +7625,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L185",
       "id": "runtime_captureruntime_dispatchtelemetry",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".emit()",
@@ -7633,7 +7633,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L197",
       "id": "runtime_captureruntime_emit",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".sendWithTimeout()",
@@ -7641,7 +7641,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L205",
       "id": "runtime_captureruntime_sendwithtimeout",
-      "community": 127
+      "community": 128
     },
     {
       "label": ".delay()",
@@ -7649,7 +7649,7 @@
       "source_file": "packages/memento-agent-integration/src/runtime.ts",
       "source_location": "L226",
       "id": "runtime_captureruntime_delay",
-      "community": 127
+      "community": 128
     },
     {
       "label": "test-fixtures.ts",
@@ -7657,7 +7657,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_test_fixtures_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "eventFixture()",
@@ -7665,7 +7665,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L15",
       "id": "test_fixtures_eventfixture",
-      "community": 792
+      "community": 794
     },
     {
       "label": "schema-normalize.spec.ts",
@@ -7673,7 +7673,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 1066
+      "community": 1068
     },
     {
       "label": "normalize.ts",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_normalize_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "normalizeJson()",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L4",
       "id": "normalize_normalizejson",
-      "community": 498
+      "community": 499
     },
     {
       "label": "canonicalize()",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L33",
       "id": "normalize_canonicalize",
-      "community": 498
+      "community": 499
     },
     {
       "label": "normalizeAgentEvent()",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L47",
       "id": "normalize_normalizeagentevent",
-      "community": 498
+      "community": 499
     },
     {
       "label": "index.ts",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 1067
+      "community": 1069
     },
     {
       "label": "priority-queue.ts",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "git()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L22",
       "id": "scope_spec_git",
-      "community": 640
+      "community": 641
     },
     {
       "label": "runner.spec.ts",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 1068
+      "community": 1070
     },
     {
       "label": "adapter.ts",
@@ -8033,7 +8033,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 1069
+      "community": 1071
     },
     {
       "label": "types.ts",
@@ -8041,7 +8041,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 1070
+      "community": 1072
     },
     {
       "label": "scope.ts",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 1071
+      "community": 1073
     },
     {
       "label": "diagnostics.ts",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "diagnoseCodex()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L21",
       "id": "diagnostics_diagnosecodex",
-      "community": 793
+      "community": 795
     },
     {
       "label": "settings.ts",
@@ -8161,7 +8161,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "runCodexHook()",
@@ -8169,7 +8169,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L6",
       "id": "runner_runcodexhook",
-      "community": 794
+      "community": 796
     },
     {
       "label": "adapter.spec.ts",
@@ -8177,7 +8177,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_adapter_spec_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "fixture()",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L12",
       "id": "adapter_spec_fixture",
-      "community": 500
+      "community": 501
     },
     {
       "label": "scope.spec.ts",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "runner.spec.ts",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 1072
+      "community": 1074
     },
     {
       "label": "adapter.ts",
@@ -8273,7 +8273,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 1073
+      "community": 1075
     },
     {
       "label": "types.ts",
@@ -8281,7 +8281,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 1074
+      "community": 1076
     },
     {
       "label": "scope.ts",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 1075
+      "community": 1077
     },
     {
       "label": "diagnostics.ts",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "parseVersion()",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L19",
       "id": "diagnostics_parseversion",
-      "community": 499
+      "community": 500
     },
     {
       "label": "versionAtLeast()",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L31",
       "id": "diagnostics_versionatleast",
-      "community": 499
+      "community": 500
     },
     {
       "label": "diagnoseClaudeCode()",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L42",
       "id": "diagnostics_diagnoseclaudecode",
-      "community": 499
+      "community": 500
     },
     {
       "label": "settings.ts",
@@ -8393,7 +8393,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "invalid()",
@@ -8401,7 +8401,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L6",
       "id": "runner_invalid",
-      "community": 641
+      "community": 642
     },
     {
       "label": "runClaudeCodeHook()",
@@ -8409,7 +8409,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L10",
       "id": "runner_runclaudecodehook",
-      "community": 641
+      "community": 642
     },
     {
       "label": "adapter.spec.ts",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_adapter_spec_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "fixtureUrl()",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L9",
       "id": "adapter_spec_fixtureurl",
-      "community": 500
+      "community": 501
     },
     {
       "label": "vitest.config.ts",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 1076
+      "community": 1078
     },
     {
       "label": "utils.spec.ts",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "buildMemory()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 795
+      "community": 797
     },
     {
       "label": "context-injector.ts",
@@ -8609,7 +8609,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_types_ts",
-      "community": 128
+      "community": 129
     },
     {
       "label": "MementoError",
@@ -8617,7 +8617,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L305",
       "id": "types_mementoerror",
-      "community": 128
+      "community": 129
     },
     {
       "label": ".constructor()",
@@ -8625,7 +8625,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L306",
       "id": "types_mementoerror_constructor",
-      "community": 128
+      "community": 129
     },
     {
       "label": "ConnectionError",
@@ -8633,7 +8633,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L317",
       "id": "types_connectionerror",
-      "community": 128
+      "community": 129
     },
     {
       "label": ".constructor()",
@@ -8641,7 +8641,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L318",
       "id": "types_connectionerror_constructor",
-      "community": 128
+      "community": 129
     },
     {
       "label": "AuthenticationError",
@@ -8649,7 +8649,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L324",
       "id": "types_authenticationerror",
-      "community": 128
+      "community": 129
     },
     {
       "label": ".constructor()",
@@ -8657,7 +8657,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L325",
       "id": "types_authenticationerror_constructor",
-      "community": 128
+      "community": 129
     },
     {
       "label": "ValidationError",
@@ -8665,7 +8665,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L331",
       "id": "types_validationerror",
-      "community": 128
+      "community": 129
     },
     {
       "label": ".constructor()",
@@ -8673,7 +8673,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L332",
       "id": "types_validationerror_constructor",
-      "community": 128
+      "community": 129
     },
     {
       "label": "NotFoundError",
@@ -8681,7 +8681,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L338",
       "id": "types_notfounderror",
-      "community": 128
+      "community": 129
     },
     {
       "label": ".constructor()",
@@ -8689,7 +8689,7 @@
       "source_file": "packages/memento-client/src/types.ts",
       "source_location": "L339",
       "id": "types_notfounderror_constructor",
-      "community": 128
+      "community": 129
     },
     {
       "label": "memory-manager.ts",
@@ -9193,7 +9193,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_ts",
-      "community": 1077
+      "community": 1079
     },
     {
       "label": "index.ts",
@@ -9201,7 +9201,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 1078
+      "community": 1080
     },
     {
       "label": "agent-api.spec.ts",
@@ -9209,7 +9209,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 1079
+      "community": 1081
     },
     {
       "label": "logger.ts",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "shouldLog()",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 642
+      "community": 643
     },
     {
       "label": "log()",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 642
+      "community": 643
     },
     {
       "label": "feedback.integration.spec.ts",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/memento-client/src/__tests__/feedback.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_tests_feedback_integration_spec_ts",
-      "community": 1080
+      "community": 1082
     },
     {
       "label": "http-transport.ts",
@@ -9305,7 +9305,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_client_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "recall()",
@@ -9313,7 +9313,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L16",
       "id": "search_client_recall",
-      "community": 643
+      "community": 644
     },
     {
       "label": "hybridSearch()",
@@ -9321,7 +9321,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L49",
       "id": "search_client_hybridsearch",
-      "community": 643
+      "community": 644
     },
     {
       "label": "client-context.ts",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/memento-client/src/client/client-context.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_client_context_ts",
-      "community": 1081
+      "community": 1083
     },
     {
       "label": "tools-client.ts",
@@ -9489,7 +9489,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_format_utils_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "toSafeCSVCell()",
@@ -9497,7 +9497,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L6",
       "id": "format_utils_tosafecsvcell",
-      "community": 501
+      "community": 502
     },
     {
       "label": "memoriesToCSV()",
@@ -9505,7 +9505,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L17",
       "id": "format_utils_memoriestocsv",
-      "community": 501
+      "community": 502
     },
     {
       "label": "memoriesToMarkdown()",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L52",
       "id": "format_utils_memoriestomarkdown",
-      "community": 501
+      "community": 502
     },
     {
       "label": "memory-utils.ts",
@@ -9577,7 +9577,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_utils_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "normalizeQuery()",
@@ -9585,7 +9585,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L6",
       "id": "search_utils_normalizequery",
-      "community": 502
+      "community": 503
     },
     {
       "label": "normalizeScore()",
@@ -9593,7 +9593,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L17",
       "id": "search_utils_normalizescore",
-      "community": 502
+      "community": 503
     },
     {
       "label": "groupSearchResults()",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L25",
       "id": "search_utils_groupsearchresults",
-      "community": 502
+      "community": 503
     },
     {
       "label": "memory-client.ts",
@@ -9665,7 +9665,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_time_utils_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "getRelativeTime()",
@@ -9673,7 +9673,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L4",
       "id": "time_utils_getrelativetime",
-      "community": 644
+      "community": 645
     },
     {
       "label": "createDateRangeFilter()",
@@ -9681,7 +9681,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L26",
       "id": "time_utils_createdaterangefilter",
-      "community": 644
+      "community": 645
     },
     {
       "label": "validation-utils.ts",
@@ -9737,7 +9737,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_factory_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "createMementoClient()",
@@ -9745,7 +9745,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L7",
       "id": "factory_createmementoclient",
-      "community": 796
+      "community": 798
     },
     {
       "label": "bootstrap.spec.ts",
@@ -9753,7 +9753,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "constructor()",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L234",
       "id": "bootstrap_spec_constructor",
-      "community": 503
+      "community": 504
     },
     {
       "label": "loadBootstrap()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L257",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 503
+      "community": 504
     },
     {
       "label": "installTimeoutSpy()",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L261",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 503
+      "community": 504
     },
     {
       "label": "index.ts",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "createMementoCore()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 645
+      "community": 646
     },
     {
       "label": "closeDatabase()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 645
+      "community": 646
     },
     {
       "label": "bootstrap.ts",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "initializeServices()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 797
+      "community": 799
     },
     {
       "label": "context.ts",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createServerContext()",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L17",
       "id": "context_createservercontext",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createToolContext()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L26",
       "id": "context_createtoolcontext",
-      "community": 504
+      "community": 505
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L39",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 504
+      "community": 505
     },
     {
       "label": "write-and-meta.ts",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 798
+      "community": 800
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L14",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 799
+      "community": 801
     },
     {
       "label": "anchor-stack.ts",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "createAnchorStack()",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 800
+      "community": 802
     },
     {
       "label": "failure-reflexion.ts",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "startFailureAndReflexion()",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 801
+      "community": 803
     },
     {
       "label": "search-and-embedding.ts",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 802
+      "community": 804
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 803
+      "community": 805
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 804
+      "community": 806
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -10273,7 +10273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_ts",
-      "community": 1082
+      "community": 1084
     },
     {
       "label": "consolidation-score-service.spec.ts",
@@ -10281,7 +10281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "createInput()",
@@ -10289,7 +10289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 805
+      "community": 807
     },
     {
       "label": "reflexion-procedural-memory-service.ts",
@@ -10505,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "createRelationGraph()",
@@ -10513,7 +10513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 806
+      "community": 808
     },
     {
       "label": "consolidation-score-service.ts",
@@ -10913,7 +10913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_parsers_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "failedTaskDataToTaskFields()",
@@ -10921,7 +10921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L4",
       "id": "async_optimizer_parsers_failedtaskdatatotaskfields",
-      "community": 505
+      "community": 506
     },
     {
       "label": "parseMemoryOperationTaskData()",
@@ -10929,7 +10929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L50",
       "id": "async_optimizer_parsers_parsememoryoperationtaskdata",
-      "community": 505
+      "community": 506
     },
     {
       "label": "parseFailureEventTaskData()",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L69",
       "id": "async_optimizer_parsers_parsefailureeventtaskdata",
-      "community": 505
+      "community": 506
     },
     {
       "label": "async-optimizer.types.ts",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_types_ts",
-      "community": 1083
+      "community": 1085
     },
     {
       "label": "async-task-worker.ts",
@@ -11049,7 +11049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 1084
+      "community": 1086
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -11169,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_health_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "startHealthCheck()",
@@ -11177,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L20",
       "id": "reflexion_worker_health_starthealthcheck",
-      "community": 506
+      "community": 507
     },
     {
       "label": "performHealthCheck()",
@@ -11185,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L30",
       "id": "reflexion_worker_health_performhealthcheck",
-      "community": 506
+      "community": 507
     },
     {
       "label": "attemptRestart()",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L61",
       "id": "reflexion_worker_health_attemptrestart",
-      "community": 506
+      "community": 507
     },
     {
       "label": "reflexion-worker-failure-handler.ts",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_failure_handler_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "registerHandler()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L14",
       "id": "reflexion_worker_failure_handler_registerhandler",
-      "community": 646
+      "community": 647
     },
     {
       "label": "updateProceduralMemory()",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L22",
       "id": "reflexion_worker_failure_handler_updateproceduralmemory",
-      "community": 646
+      "community": 647
     },
     {
       "label": "reflexion-worker-metrics.ts",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_metrics_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "getReflexionMetrics()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L14",
       "id": "reflexion_worker_metrics_getreflexionmetrics",
-      "community": 647
+      "community": 648
     },
     {
       "label": "getIntegratedMetrics()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L42",
       "id": "reflexion_worker_metrics_getintegratedmetrics",
-      "community": 647
+      "community": 648
     },
     {
       "label": "reflexion-procedural-create.ts",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_create_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "createProceduralMemory()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_create_createproceduralmemory",
-      "community": 807
+      "community": 809
     },
     {
       "label": "reflexion-procedural-update-replace.ts",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_replace_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "updateProceduralMemoryReplace()",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_replace_updateproceduralmemoryreplace",
-      "community": 808
+      "community": 810
     },
     {
       "label": "reflexion-procedural-extraction.ts",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_extraction_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "resolveExtractedProceduralMemory()",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_extraction_resolveextractedproceduralmemory",
-      "community": 809
+      "community": 811
     },
     {
       "label": "reflexion-procedural-update-versioned.ts",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_versioned_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "updateProceduralMemoryVersioned()",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L11",
       "id": "reflexion_procedural_update_versioned_updateproceduralmemoryversioned",
-      "community": 810
+      "community": 812
     },
     {
       "label": "reflexion-procedural-update-incremental.ts",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_incremental_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "mergeProceduralSteps()",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_incremental_mergeproceduralsteps",
-      "community": 648
+      "community": 649
     },
     {
       "label": "updateProceduralMemoryIncremental()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L33",
       "id": "reflexion_procedural_update_incremental_updateproceduralmemoryincremental",
-      "community": 648
+      "community": 649
     },
     {
       "label": "database-optimize-tool.ts",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 507
+      "community": 508
     },
     {
       "label": ".constructor()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 507
+      "community": 508
     },
     {
       "label": ".handle()",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 507
+      "community": 508
     },
     {
       "label": "migration-history-service.ts",
@@ -11681,7 +11681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "createBaseSchema()",
@@ -11689,7 +11689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 649
+      "community": 650
     },
     {
       "label": "measureTime()",
@@ -11697,7 +11697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 649
+      "community": 650
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "createBaseSchema()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 811
+      "community": 813
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -11817,7 +11817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -11825,7 +11825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 812
+      "community": 814
     },
     {
       "label": "migration-monitor-service.ts",
@@ -11929,7 +11929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "openLockTestDatabase()",
@@ -11937,7 +11937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 813
+      "community": 815
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -11945,7 +11945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 508
+      "community": 509
     },
     {
       "label": "createPlan()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 508
+      "community": 509
     },
     {
       "label": "createResult()",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 508
+      "community": 509
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "createProgress()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 814
+      "community": 816
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 1085
+      "community": 1087
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 1086
+      "community": 1088
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 815
+      "community": 817
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 1087
+      "community": 1089
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "createCoreMemoryTable()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 816
+      "community": 818
     },
     {
       "label": "init-bootstrap-new-db.ts",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_bootstrap_new_db_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "bootstrapNewDatabaseSchema()",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L14",
       "id": "init_bootstrap_new_db_bootstrapnewdatabaseschema",
-      "community": 817
+      "community": 819
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "addMissingColumn()",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 650
+      "community": 651
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 650
+      "community": 651
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -12089,7 +12089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 1088
+      "community": 1090
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -12193,7 +12193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_log_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "log()",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L5",
       "id": "init_log_log",
-      "community": 818
+      "community": 820
     },
     {
       "label": "init.spec.ts",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 1089
+      "community": 1091
     },
     {
       "label": "init.ts",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "initializeDatabase()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L29",
       "id": "init_initializedatabase",
-      "community": 651
+      "community": 652
     },
     {
       "label": "closeDatabase()",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L116",
       "id": "init_closedatabase",
-      "community": 651
+      "community": 652
     },
     {
       "label": "db-integrity-preflight.spec.ts",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "createDbPath()",
@@ -12249,7 +12249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 819
+      "community": 821
     },
     {
       "label": "init-migrate-existing.ts",
@@ -12257,7 +12257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migrate_existing_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "migrateExistingDatabaseIfNeeded()",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L6",
       "id": "init_migrate_existing_migrateexistingdatabaseifneeded",
-      "community": 820
+      "community": 822
     },
     {
       "label": "migrate.spec.ts",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 1090
+      "community": 1092
     },
     {
       "label": "init-migration-baseline.ts",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migration_baseline_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "recordBundledSchemaSqlMigrationBaseline()",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L11",
       "id": "init_migration_baseline_recordbundledschemasqlmigrationbaseline",
-      "community": 821
+      "community": 823
     },
     {
       "label": "init-sqlite-session.ts",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_sqlite_session_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "configureSqliteSession()",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L8",
       "id": "init_sqlite_session_configuresqlitesession",
-      "community": 822
+      "community": 824
     },
     {
       "label": "init-legacy-schema.ts",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "isDuplicateColumnError()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 652
+      "community": 653
     },
     {
       "label": "migrateDatabase()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 652
+      "community": 653
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 1091
+      "community": 1093
     },
     {
       "label": "migration-runner.ts",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "createBaseSchema()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 823
+      "community": 825
     },
     {
       "label": "migration-logger.spec.ts",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 1092
+      "community": 1094
     },
     {
       "label": "migration-detector.ts",
@@ -12681,7 +12681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 1093
+      "community": 1095
     },
     {
       "label": "migration-detector.spec.ts",
@@ -12689,7 +12689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 1094
+      "community": 1096
     },
     {
       "label": "backup-manager.ts",
@@ -12777,7 +12777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 1095
+      "community": 1097
     },
     {
       "label": "dependency-validator.ts",
@@ -12881,7 +12881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 1096
+      "community": 1098
     },
     {
       "label": "schema-version-manager.ts",
@@ -12969,7 +12969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 1097
+      "community": 1099
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -12977,7 +12977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createMemoryItemTable()",
@@ -12985,7 +12985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 509
+      "community": 510
     },
     {
       "label": "columnExists()",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 509
+      "community": 510
     },
     {
       "label": "indexExists()",
@@ -13001,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 509
+      "community": 510
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -13009,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_ts",
-      "community": 129
+      "community": 130
     },
     {
       "label": "AriGraphSchemaExpansionMigration",
@@ -13017,7 +13017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L27",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".loadSQLFile()",
@@ -13025,7 +13025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L35",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_loadsqlfile",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".executeSQL()",
@@ -13033,7 +13033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L44",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_executesql",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".tableExists()",
@@ -13041,7 +13041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L69",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_tableexists",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".columnExists()",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L80",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_columnexists",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".indexExists()",
@@ -13057,7 +13057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L88",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_indexexists",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".validateBefore()",
@@ -13065,7 +13065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L99",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_validatebefore",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".up()",
@@ -13073,7 +13073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L175",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_up",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".down()",
@@ -13081,7 +13081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L192",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_down",
-      "community": 129
+      "community": 130
     },
     {
       "label": ".validateAfter()",
@@ -13089,7 +13089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.ts",
       "source_location": "L219",
       "id": "008_arigraph_schema_expansion_arigraphschemaexpansionmigration_validateafter",
-      "community": 129
+      "community": 130
     },
     {
       "label": "004-anchor-table.ts",
@@ -13801,7 +13801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "createBaseSchema()",
@@ -13809,7 +13809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 824
+      "community": 826
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "createBaseSchema()",
@@ -14057,7 +14057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 825
+      "community": 827
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -14265,7 +14265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_ts",
-      "community": 130
+      "community": 131
     },
     {
       "label": "ProceduralMemoryEnhancementMigration",
@@ -14273,7 +14273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L26",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".loadSQLFile()",
@@ -14281,7 +14281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L34",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_loadsqlfile",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".executeSQL()",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L43",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_executesql",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".tableExists()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L68",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_tableexists",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".columnExists()",
@@ -14305,7 +14305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L79",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_columnexists",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".indexExists()",
@@ -14313,7 +14313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L89",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_indexexists",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".validateBefore()",
@@ -14321,7 +14321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L100",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_validatebefore",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".up()",
@@ -14329,7 +14329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L153",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_up",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".down()",
@@ -14337,7 +14337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L248",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_down",
-      "community": 130
+      "community": 131
     },
     {
       "label": ".validateAfter()",
@@ -14345,7 +14345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.ts",
       "source_location": "L306",
       "id": "007_procedural_memory_enhancement_proceduralmemoryenhancementmigration_validateafter",
-      "community": 130
+      "community": 131
     },
     {
       "label": "009-quality-assurance-schema.spec.ts",
@@ -14353,7 +14353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "createBaseSchema()",
@@ -14361,7 +14361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 826
+      "community": 828
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -14521,7 +14521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/037-memory-forgetting-event.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_037_memory_forgetting_event_spec_ts",
-      "community": 1098
+      "community": 1100
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -14529,7 +14529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_ts",
-      "community": 131
+      "community": 132
     },
     {
       "label": "AddCoreMemoryVersionMigration",
@@ -14537,7 +14537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L27",
       "id": "010_add_core_memory_version_addcorememoryversionmigration",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".loadSQLFile()",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L38",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_loadsqlfile",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".executeSQL()",
@@ -14553,7 +14553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L64",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_executesql",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".tableExists()",
@@ -14561,7 +14561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L89",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_tableexists",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".indexExists()",
@@ -14569,7 +14569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L100",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_indexexists",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".columnExists()",
@@ -14577,7 +14577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L111",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_columnexists",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".validateBefore()",
@@ -14585,7 +14585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L119",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_validatebefore",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".up()",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L137",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_up",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".down()",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L149",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_down",
-      "community": 131
+      "community": 132
     },
     {
       "label": ".validateAfter()",
@@ -14609,7 +14609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.ts",
       "source_location": "L181",
       "id": "010_add_core_memory_version_addcorememoryversionmigration_validateafter",
-      "community": 131
+      "community": 132
     },
     {
       "label": "030-triple-extraction-fields.ts",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/039-event-outbox.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_039_event_outbox_spec_ts",
-      "community": 1099
+      "community": 1101
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/040-audit-hash-chain.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_040_audit_hash_chain_spec_ts",
-      "community": 1100
+      "community": 1102
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_ts",
-      "community": 132
+      "community": 133
     },
     {
       "label": "QualityAssuranceSchemaMigration",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L27",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".loadSQLFile()",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L35",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_loadsqlfile",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".executeSQL()",
@@ -14801,7 +14801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L44",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_executesql",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".tableExists()",
@@ -14809,7 +14809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L69",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_tableexists",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".indexExists()",
@@ -14817,7 +14817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L80",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_indexexists",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".columnExists()",
@@ -14825,7 +14825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L91",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_columnexists",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".validateBefore()",
@@ -14833,7 +14833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L99",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_validatebefore",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".up()",
@@ -14841,7 +14841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L130",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_up",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".down()",
@@ -14849,7 +14849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L142",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_down",
-      "community": 132
+      "community": 133
     },
     {
       "label": ".validateAfter()",
@@ -14857,7 +14857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.ts",
       "source_location": "L172",
       "id": "009_quality_assurance_schema_qualityassuranceschemamigration_validateafter",
-      "community": 132
+      "community": 133
     },
     {
       "label": "033-memory-review-candidate-schema.spec.ts",
@@ -14865,7 +14865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "createMemoryItemTable()",
@@ -14873,7 +14873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 653
+      "community": 654
     },
     {
       "label": "tableExists()",
@@ -14881,7 +14881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 653
+      "community": 654
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "createMemoryItemTable()",
@@ -15129,7 +15129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 654
+      "community": 655
     },
     {
       "label": "tableExists()",
@@ -15137,7 +15137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 654
+      "community": 655
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "createBaseSchema()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 827
+      "community": 829
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -15329,7 +15329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "createSchemaWith018()",
@@ -15337,7 +15337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 828
+      "community": 830
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -15345,7 +15345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "createBaseSchema()",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 829
+      "community": 831
     },
     {
       "label": "037-memory-forgetting-event.ts",
@@ -15417,7 +15417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -15425,7 +15425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createMemoryLinkTable()",
@@ -15433,7 +15433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createSchemaVersionTable()",
@@ -15441,7 +15441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 510
+      "community": 511
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -15625,7 +15625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_038_relation_type_registry_seeds_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "applicableTypesFor()",
@@ -15633,7 +15633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L12",
       "id": "038_relation_type_registry_seeds_spec_applicabletypesfor",
-      "community": 830
+      "community": 832
     },
     {
       "label": "013-procedural-version-fields.ts",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 1101
+      "community": 1103
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -16049,7 +16049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 1102
+      "community": 1104
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -16121,7 +16121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "createBaseSchema()",
@@ -16129,7 +16129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 831
+      "community": 833
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -16257,7 +16257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "createBaseSchema()",
@@ -16265,7 +16265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 832
+      "community": 834
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -16273,7 +16273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "applicableTypesFor()",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L12",
       "id": "005_relation_engine_schema_spec_applicabletypesfor",
-      "community": 511
+      "community": 512
     },
     {
       "label": "createBaseSchema()",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L21",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 511
+      "community": 512
     },
     {
       "label": "createMemoryLinkTable()",
@@ -16297,7 +16297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L122",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 511
+      "community": 512
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "createBaseSchema()",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 833
+      "community": 835
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createSchemaVersionTable()",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 512
+      "community": 513
     },
     {
       "label": "getIndexNames()",
@@ -16417,7 +16417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 512
+      "community": 513
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -16425,7 +16425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "createSchemaWith019()",
@@ -16433,7 +16433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 513
+      "community": 514
     },
     {
       "label": "tableExists()",
@@ -16441,7 +16441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 513
+      "community": 514
     },
     {
       "label": "columnExists()",
@@ -16449,7 +16449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 513
+      "community": 514
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -16601,7 +16601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 1103
+      "community": 1105
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -16609,7 +16609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_sqlite_agent_integration_repository_spec_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "createSession()",
@@ -16617,7 +16617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L27",
       "id": "sqlite_agent_integration_repository_spec_createsession",
-      "community": 655
+      "community": 656
     },
     {
       "label": "createObservation()",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L59",
       "id": "sqlite_agent_integration_repository_spec_createobservation",
-      "community": 655
+      "community": 656
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -17689,7 +17689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 1104
+      "community": 1106
     },
     {
       "label": "cache-service.ts",
@@ -18017,7 +18017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 1105
+      "community": 1107
     },
     {
       "label": "batch-scheduler.ts",
@@ -18409,7 +18409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -18417,7 +18417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 514
+      "community": 515
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -18425,7 +18425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 514
+      "community": 515
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -18433,7 +18433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 514
+      "community": 515
     },
     {
       "label": "health-checker.ts",
@@ -18489,7 +18489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -18497,7 +18497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 834
+      "community": 836
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -18505,7 +18505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 835
+      "community": 837
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "readRunDetails()",
@@ -18529,7 +18529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L15",
       "id": "memory_review_candidates_run_diagnostics_readrundetails",
-      "community": 656
+      "community": 657
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -18537,7 +18537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L46",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 656
+      "community": 657
     },
     {
       "label": "relation-validator-executor.ts",
@@ -18593,7 +18593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 1106
+      "community": 1108
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -18601,7 +18601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "validateBatchJobConfig()",
@@ -18609,7 +18609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 836
+      "community": 838
     },
     {
       "label": "retry-manager.ts",
@@ -18825,7 +18825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_timeout_resolver_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "isTripleExtractionQueueJob()",
@@ -18833,7 +18833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L5",
       "id": "batch_job_timeout_resolver_istripleextractionqueuejob",
-      "community": 515
+      "community": 516
     },
     {
       "label": "isJobTimeoutError()",
@@ -18841,7 +18841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L9",
       "id": "batch_job_timeout_resolver_isjobtimeouterror",
-      "community": 515
+      "community": 516
     },
     {
       "label": "resolveBatchJobTimeout()",
@@ -18849,7 +18849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L18",
       "id": "batch_job_timeout_resolver_resolvebatchjobtimeout",
-      "community": 515
+      "community": 516
     },
     {
       "label": "job-queue.ts",
@@ -19105,7 +19105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "createBaseSchema()",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L12",
       "id": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
-      "community": 657
+      "community": 658
     },
     {
       "label": "createContext()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L41",
       "id": "batch_scheduler_review_meta_handlers_spec_createcontext",
-      "community": 657
+      "community": 658
     },
     {
       "label": "batch-scheduler-anchor-handlers.ts",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "runAnchorAutoRefresh()",
@@ -19137,7 +19137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_anchor_handlers_runanchorautorefresh",
-      "community": 837
+      "community": 839
     },
     {
       "label": "batch-scheduler-consolidation-relation-handlers.ts",
@@ -19185,7 +19185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 1107
+      "community": 1109
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -19193,7 +19193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -19201,7 +19201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 658
+      "community": 659
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -19209,7 +19209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 658
+      "community": 659
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -19217,7 +19217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -19225,7 +19225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 659
+      "community": 660
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -19233,7 +19233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 659
+      "community": 660
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -19241,7 +19241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -19249,7 +19249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L21",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 516
+      "community": 517
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -19257,7 +19257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L55",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 516
+      "community": 517
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -19265,7 +19265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L143",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 516
+      "community": 517
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -19313,7 +19313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 1108
+      "community": 1110
     },
     {
       "label": "batch-job-execution-coordinator.spec.ts",
@@ -19321,7 +19321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_execution_coordinator_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "createCoordinator()",
@@ -19329,7 +19329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L7",
       "id": "batch_job_execution_coordinator_spec_createcoordinator",
-      "community": 838
+      "community": 840
     },
     {
       "label": "health-checker.spec.ts",
@@ -19337,7 +19337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 1109
+      "community": 1111
     },
     {
       "label": "retry-manager.spec.ts",
@@ -19345,7 +19345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "shouldRetry()",
@@ -19353,7 +19353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 839
+      "community": 841
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -19361,7 +19361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "baseResult()",
@@ -19369,7 +19369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 840
+      "community": 842
     },
     {
       "label": "job-queue.spec.ts",
@@ -19417,7 +19417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 1110
+      "community": 1112
     },
     {
       "label": "batch-job-timeout-resolver.spec.ts",
@@ -19425,7 +19425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_timeout_resolver_spec_ts",
-      "community": 1111
+      "community": 1113
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -19433,7 +19433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "initializeTestDatabase()",
@@ -19441,7 +19441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 841
+      "community": 843
     },
     {
       "label": "maintenance-jobs.spec.ts",
@@ -19449,7 +19449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/maintenance-jobs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_maintenance_jobs_spec_ts",
-      "community": 1112
+      "community": 1114
     },
     {
       "label": "error-handling.spec.ts",
@@ -19457,7 +19457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_error_handling_spec_ts",
-      "community": 1113
+      "community": 1115
     },
     {
       "label": "concurrency-queue.spec.ts",
@@ -19521,7 +19521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/run-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_run_job_spec_ts",
-      "community": 1114
+      "community": 1116
     },
     {
       "label": "logging.spec.ts",
@@ -19529,7 +19529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_logging_spec_ts",
-      "community": 1115
+      "community": 1117
     },
     {
       "label": "env-defaults.spec.ts",
@@ -19537,7 +19537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/env-defaults.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_env_defaults_spec_ts",
-      "community": 1116
+      "community": 1118
     },
     {
       "label": "lifecycle.spec.ts",
@@ -19545,7 +19545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/lifecycle.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_lifecycle_spec_ts",
-      "community": 1117
+      "community": 1119
     },
     {
       "label": "job-execution-retry.spec.ts",
@@ -19553,7 +19553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_job_execution_retry_spec_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "failingJob()",
@@ -19561,7 +19561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L359",
       "id": "job_execution_retry_spec_failingjob",
-      "community": 842
+      "community": 844
     },
     {
       "label": "status-diagnostics.spec.ts",
@@ -19569,7 +19569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/status-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_status_diagnostics_spec_ts",
-      "community": 1118
+      "community": 1120
     },
     {
       "label": "constructor-config.spec.ts",
@@ -19577,7 +19577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/constructor-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_constructor_config_spec_ts",
-      "community": 1119
+      "community": 1121
     },
     {
       "label": "relation-validation.spec.ts",
@@ -19585,7 +19585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/relation-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_relation_validation_spec_ts",
-      "community": 1120
+      "community": 1122
     },
     {
       "label": "batch-scheduler.test-setup.ts",
@@ -19593,7 +19593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_batch_scheduler_test_setup_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "executionCoordinator()",
@@ -19601,7 +19601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L4",
       "id": "batch_scheduler_test_setup_executioncoordinator",
-      "community": 843
+      "community": 845
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -19609,7 +19609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "TripleExtractionBatchJob",
@@ -19617,7 +19617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L31",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob",
-      "community": 517
+      "community": 518
     },
     {
       "label": ".constructor()",
@@ -19625,7 +19625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_constructor",
-      "community": 517
+      "community": 518
     },
     {
       "label": ".execute()",
@@ -19633,7 +19633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L58",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_execute",
-      "community": 517
+      "community": 518
     },
     {
       "label": "telemetry-cleanup-batch-job.spec.ts",
@@ -19641,7 +19641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 1121
+      "community": 1123
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -19649,7 +19649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -19657,7 +19657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 518
+      "community": 519
     },
     {
       "label": ".constructor()",
@@ -19665,7 +19665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 518
+      "community": 519
     },
     {
       "label": ".execute()",
@@ -19673,7 +19673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 518
+      "community": 519
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -19681,7 +19681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 1122
+      "community": 1124
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -19689,7 +19689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -19697,7 +19697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 519
+      "community": 520
     },
     {
       "label": ".constructor()",
@@ -19705,7 +19705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 519
+      "community": 520
     },
     {
       "label": ".execute()",
@@ -19713,7 +19713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 519
+      "community": 520
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -19721,7 +19721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -19729,7 +19729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 520
+      "community": 521
     },
     {
       "label": ".constructor()",
@@ -19737,7 +19737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 520
+      "community": 521
     },
     {
       "label": ".execute()",
@@ -19745,7 +19745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 520
+      "community": 521
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -19753,7 +19753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "generateId()",
@@ -19761,7 +19761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 660
+      "community": 661
     },
     {
       "label": "initializeTestDatabase()",
@@ -19769,7 +19769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 660
+      "community": 661
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -19777,7 +19777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 844
+      "community": 846
     },
     {
       "label": "createQualityTables()",
@@ -19785,7 +19785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 844
+      "community": 846
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -19793,7 +19793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "generateId()",
@@ -19801,7 +19801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 661
+      "community": 662
     },
     {
       "label": "initializeTestDatabase()",
@@ -19809,7 +19809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 661
+      "community": 662
     },
     {
       "label": "triple-extraction-batch-job-chunk.ts",
@@ -19817,7 +19817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_chunk_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "splitTripleExtractionIntoChunks()",
@@ -19825,7 +19825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L25",
       "id": "triple_extraction_batch_job_chunk_splittripleextractionintochunks",
-      "community": 662
+      "community": 663
     },
     {
       "label": "processTripleExtractionChunk()",
@@ -19833,7 +19833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L42",
       "id": "triple_extraction_batch_job_chunk_processtripleextractionchunk",
-      "community": 662
+      "community": 663
     },
     {
       "label": "triple-extraction-batch-job.types.ts",
@@ -19841,7 +19841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_types_ts",
-      "community": 845
+      "community": 847
     },
     {
       "label": "getErrorCode()",
@@ -19849,7 +19849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L3",
       "id": "triple_extraction_batch_job_types_geterrorcode",
-      "community": 845
+      "community": 847
     },
     {
       "label": "triple-extraction-batch-job-memory-status.ts",
@@ -19857,7 +19857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_memory_status_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "updateTripleExtractionMemoryStatus()",
@@ -19865,7 +19865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L8",
       "id": "triple_extraction_batch_job_memory_status_updatetripleextractionmemorystatus",
-      "community": 663
+      "community": 664
     },
     {
       "label": "calculateTripleExtractionAverageConfidence()",
@@ -19873,7 +19873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L43",
       "id": "triple_extraction_batch_job_memory_status_calculatetripleextractionaverageconfidence",
-      "community": 663
+      "community": 664
     },
     {
       "label": "triple-extraction-batch-job-retry.ts",
@@ -19881,7 +19881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_retry_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "getTripleExtractionRetryCount()",
@@ -19889,7 +19889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L12",
       "id": "triple_extraction_batch_job_retry_gettripleextractionretrycount",
-      "community": 521
+      "community": 522
     },
     {
       "label": "shouldRetryTripleExtraction()",
@@ -19897,7 +19897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L35",
       "id": "triple_extraction_batch_job_retry_shouldretrytripleextraction",
-      "community": 521
+      "community": 522
     },
     {
       "label": "getTripleExtractionTargetMemories()",
@@ -19905,7 +19905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L81",
       "id": "triple_extraction_batch_job_retry_gettripleextractiontargetmemories",
-      "community": 521
+      "community": 522
     },
     {
       "label": "batch-scheduler-job-control.ts",
@@ -19961,7 +19961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_context_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "createMutableJobRef()",
@@ -19969,7 +19969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L72",
       "id": "batch_scheduler_context_createmutablejobref",
-      "community": 522
+      "community": 523
     },
     {
       "label": "buildBatchSchedulerRunContext()",
@@ -19977,7 +19977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L86",
       "id": "batch_scheduler_context_buildbatchschedulerruncontext",
-      "community": 522
+      "community": 523
     },
     {
       "label": "buildBatchRecurringScheduleContext()",
@@ -19985,7 +19985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L124",
       "id": "batch_scheduler_context_buildbatchrecurringschedulecontext",
-      "community": 522
+      "community": 523
     },
     {
       "label": "batch-scheduler-diagnostics.ts",
@@ -19993,7 +19993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_diagnostics_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "writeBatchSchedulerDiagnosticsEvent()",
@@ -20001,7 +20001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L6",
       "id": "batch_scheduler_diagnostics_writebatchschedulerdiagnosticsevent",
-      "community": 664
+      "community": 665
     },
     {
       "label": "emitMemoryReviewCandidatesRunRecord()",
@@ -20009,7 +20009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L28",
       "id": "batch_scheduler_diagnostics_emitmemoryreviewcandidatesrunrecord",
-      "community": 664
+      "community": 665
     },
     {
       "label": "batch-scheduler-job-processor.ts",
@@ -20081,7 +20081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_singleton_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "getBatchScheduler()",
@@ -20089,7 +20089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L6",
       "id": "batch_scheduler_singleton_getbatchscheduler",
-      "community": 523
+      "community": 524
     },
     {
       "label": "createBatchScheduler()",
@@ -20097,7 +20097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L13",
       "id": "batch_scheduler_singleton_createbatchscheduler",
-      "community": 523
+      "community": 524
     },
     {
       "label": "resetBatchScheduler()",
@@ -20105,7 +20105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L17",
       "id": "batch_scheduler_singleton_resetbatchscheduler",
-      "community": 523
+      "community": 524
     },
     {
       "label": "batch-scheduler-logging.ts",
@@ -20113,7 +20113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_logging_ts",
-      "community": 846
+      "community": 848
     },
     {
       "label": "logBatchSchedulerMessage()",
@@ -20121,7 +20121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L18",
       "id": "batch_scheduler_logging_logbatchschedulermessage",
-      "community": 846
+      "community": 848
     },
     {
       "label": "batch-scheduler-health.ts",
@@ -20129,7 +20129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_health_ts",
-      "community": 847
+      "community": 849
     },
     {
       "label": "checkBatchSchedulerHealth()",
@@ -20137,7 +20137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L17",
       "id": "batch_scheduler_health_checkbatchschedulerhealth",
-      "community": 847
+      "community": 849
     },
     {
       "label": "batch-scheduler-status.ts",
@@ -20313,7 +20313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_lifecycle_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "startBatchScheduler()",
@@ -20321,7 +20321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L30",
       "id": "batch_scheduler_lifecycle_startbatchscheduler",
-      "community": 665
+      "community": 666
     },
     {
       "label": "stopBatchScheduler()",
@@ -20329,7 +20329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L76",
       "id": "batch_scheduler_lifecycle_stopbatchscheduler",
-      "community": 665
+      "community": 666
     },
     {
       "label": "batch-scheduler-stats.ts",
@@ -20337,7 +20337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_stats_ts",
-      "community": 848
+      "community": 850
     },
     {
       "label": "getBatchSchedulerDetailedStats()",
@@ -20345,7 +20345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L18",
       "id": "batch_scheduler_stats_getbatchschedulerdetailedstats",
-      "community": 848
+      "community": 850
     },
     {
       "label": "batch-scheduler-interval.ts",
@@ -20353,7 +20353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_interval_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "scheduleBatchJob()",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L16",
       "id": "batch_scheduler_interval_schedulebatchjob",
-      "community": 666
+      "community": 667
     },
     {
       "label": "waitForRunningBatchJobs()",
@@ -20369,7 +20369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L36",
       "id": "batch_scheduler_interval_waitforrunningbatchjobs",
-      "community": 666
+      "community": 667
     },
     {
       "label": "batch-scheduler-job-runners.ts",
@@ -20377,7 +20377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_job_runners_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "createBatchSchedulerJobRunners()",
@@ -20385,7 +20385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L39",
       "id": "batch_scheduler_job_runners_createbatchschedulerjobrunners",
-      "community": 667
+      "community": 668
     },
     {
       "label": "runManualBatchSchedulerJob()",
@@ -20393,7 +20393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L61",
       "id": "batch_scheduler_job_runners_runmanualbatchschedulerjob",
-      "community": 667
+      "community": 668
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -20401,7 +20401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 1123
+      "community": 1125
     },
     {
       "label": "owner-scope-mode.ts",
@@ -20409,7 +20409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_ts",
-      "community": 849
+      "community": 851
     },
     {
       "label": "parseOwnerScopeMode()",
@@ -20417,7 +20417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L11",
       "id": "owner_scope_mode_parseownerscopemode",
-      "community": 849
+      "community": 851
     },
     {
       "label": "jsonl-rotation.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_jsonl_rotation_ts",
-      "community": 850
+      "community": 852
     },
     {
       "label": "rotateJsonlIfNeeded()",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L3",
       "id": "jsonl_rotation_rotatejsonlifneeded",
-      "community": 850
+      "community": 852
     },
     {
       "label": "external-api-retry-logging.ts",
@@ -20441,7 +20441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_external_api_retry_logging_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "isTransientCapacityError()",
@@ -20449,7 +20449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L21",
       "id": "external_api_retry_logging_istransientcapacityerror",
-      "community": 668
+      "community": 669
     },
     {
       "label": "logExternalApiRetry()",
@@ -20457,7 +20457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L26",
       "id": "external_api_retry_logging_logexternalapiretry",
-      "community": 668
+      "community": 669
     },
     {
       "label": "stopwords.spec.ts",
@@ -20465,7 +20465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 1124
+      "community": 1126
     },
     {
       "label": "type-guards.ts",
@@ -20545,7 +20545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -20553,7 +20553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L39",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 669
+      "community": 670
     },
     {
       "label": ".extract()",
@@ -20561,7 +20561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L40",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 669
+      "community": 670
     },
     {
       "label": "sql-security-validator.ts",
@@ -20569,7 +20569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "validateTableName()",
@@ -20577,7 +20577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 670
+      "community": 671
     },
     {
       "label": "getVectorTableName()",
@@ -20585,7 +20585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 670
+      "community": 671
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -20593,7 +20593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 851
+      "community": 853
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -20601,7 +20601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 851
+      "community": 853
     },
     {
       "label": "environment-check.ts",
@@ -20609,7 +20609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "isTestEnvironment()",
@@ -20617,7 +20617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 524
+      "community": 525
     },
     {
       "label": "isValidationDisabled()",
@@ -20625,7 +20625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 524
+      "community": 525
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -20633,7 +20633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 524
+      "community": 525
     },
     {
       "label": "db-path.spec.ts",
@@ -20641,7 +20641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 1125
+      "community": 1127
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -20649,7 +20649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 1126
+      "community": 1128
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -20793,7 +20793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 852
+      "community": 854
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -20801,7 +20801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 852
+      "community": 854
     },
     {
       "label": "error-handling.spec.ts",
@@ -20809,7 +20809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 853
+      "community": 855
     },
     {
       "label": "operation()",
@@ -20817,7 +20817,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 853
+      "community": 855
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -21057,7 +21057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 1127
+      "community": 1129
     },
     {
       "label": "relation-visualizer.ts",
@@ -21225,7 +21225,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_triple_cache_ts",
-      "community": 133
+      "community": 134
     },
     {
       "label": "TripleCacheService",
@@ -21233,7 +21233,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L19",
       "id": "triple_cache_triplecacheservice",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".constructor()",
@@ -21241,7 +21241,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L28",
       "id": "triple_cache_triplecacheservice_constructor",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".generateCacheKey()",
@@ -21249,7 +21249,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L44",
       "id": "triple_cache_triplecacheservice_generatecachekey",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".get()",
@@ -21257,7 +21257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L61",
       "id": "triple_cache_triplecacheservice_get",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".set()",
@@ -21265,7 +21265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L76",
       "id": "triple_cache_triplecacheservice_set",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".delete()",
@@ -21273,7 +21273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L91",
       "id": "triple_cache_triplecacheservice_delete",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".clear()",
@@ -21281,7 +21281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L99",
       "id": "triple_cache_triplecacheservice_clear",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".getStats()",
@@ -21289,7 +21289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L108",
       "id": "triple_cache_triplecacheservice_getstats",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".cleanup()",
@@ -21297,7 +21297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L121",
       "id": "triple_cache_triplecacheservice_cleanup",
-      "community": 133
+      "community": 134
     },
     {
       "label": ".size()",
@@ -21305,7 +21305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/triple-cache.ts",
       "source_location": "L132",
       "id": "triple_cache_triplecacheservice_size",
-      "community": 133
+      "community": 134
     },
     {
       "label": "database.ts",
@@ -21417,7 +21417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "issue()",
@@ -21425,7 +21425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L42",
       "id": "configuration_validator_issue",
-      "community": 671
+      "community": 672
     },
     {
       "label": "validateConfiguration()",
@@ -21433,7 +21433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L46",
       "id": "configuration_validator_validateconfiguration",
-      "community": 671
+      "community": 672
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -21441,7 +21441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 1128
+      "community": 1130
     },
     {
       "label": "owner-scope-mode.spec.ts",
@@ -21449,7 +21449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_spec_ts",
-      "community": 1129
+      "community": 1131
     },
     {
       "label": "cache-key-generator.ts",
@@ -21505,7 +21505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "transactionFn()",
@@ -21513,7 +21513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 672
+      "community": 673
     },
     {
       "label": "outerTransaction()",
@@ -21521,7 +21521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 672
+      "community": 673
     },
     {
       "label": "write-coalescing.ts",
@@ -21609,7 +21609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "validateReflectionNote()",
@@ -21617,7 +21617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 525
+      "community": 526
     },
     {
       "label": "validateReflectionNotes()",
@@ -21625,7 +21625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 525
+      "community": 526
     },
     {
       "label": "formatValidationErrors()",
@@ -21633,7 +21633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 525
+      "community": 526
     },
     {
       "label": "environment-check.spec.ts",
@@ -21641,7 +21641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 1130
+      "community": 1132
     },
     {
       "label": "path-validator.ts",
@@ -21705,7 +21705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 854
+      "community": 856
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -21713,7 +21713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 854
+      "community": 856
     },
     {
       "label": "error-handling.ts",
@@ -21721,7 +21721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 855
+      "community": 857
     },
     {
       "label": "withErrorHandling()",
@@ -21729,7 +21729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 855
+      "community": 857
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -21737,7 +21737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 1131
+      "community": 1133
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -21745,7 +21745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 1132
+      "community": 1134
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -21953,7 +21953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 856
+      "community": 858
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -21961,7 +21961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 856
+      "community": 858
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -21969,7 +21969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "createValidReflectionNote()",
@@ -21977,7 +21977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 673
+      "community": 674
     },
     {
       "label": "createLargeNote()",
@@ -21985,7 +21985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 673
+      "community": 674
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -21993,7 +21993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 857
+      "community": 859
     },
     {
       "label": "initializeTestDatabase()",
@@ -22001,7 +22001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 857
+      "community": 859
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -22009,7 +22009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 858
+      "community": 860
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -22017,7 +22017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 858
+      "community": 860
     },
     {
       "label": "procedural-memory-field-extractors.ts",
@@ -22073,7 +22073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_helpers_ts",
-      "community": 134
+      "community": 135
     },
     {
       "label": "LoggingHelper",
@@ -22081,7 +22081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L49",
       "id": "logging_helpers_logginghelper",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".constructor()",
@@ -22089,7 +22089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L52",
       "id": "logging_helpers_logginghelper_constructor",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".updateContext()",
@@ -22097,7 +22097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L59",
       "id": "logging_helpers_logginghelper_updatecontext",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".getContext()",
@@ -22105,7 +22105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L66",
       "id": "logging_helpers_logginghelper_getcontext",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".mergeContext()",
@@ -22113,7 +22113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L73",
       "id": "logging_helpers_logginghelper_mergecontext",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".debug()",
@@ -22121,7 +22121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L83",
       "id": "logging_helpers_logginghelper_debug",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".info()",
@@ -22129,7 +22129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L90",
       "id": "logging_helpers_logginghelper_info",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".warn()",
@@ -22137,7 +22137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L97",
       "id": "logging_helpers_logginghelper_warn",
-      "community": 134
+      "community": 135
     },
     {
       "label": ".error()",
@@ -22145,7 +22145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L104",
       "id": "logging_helpers_logginghelper_error",
-      "community": 134
+      "community": 135
     },
     {
       "label": "createLogger()",
@@ -22153,7 +22153,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-helpers.ts",
       "source_location": "L191",
       "id": "logging_helpers_createlogger",
-      "community": 134
+      "community": 135
     },
     {
       "label": "logger.spec.ts",
@@ -22161,7 +22161,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 1133
+      "community": 1135
     },
     {
       "label": "pii-masker.ts",
@@ -22273,7 +22273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 1134
+      "community": 1136
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -22281,7 +22281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 1135
+      "community": 1137
     },
     {
       "label": "pii-masker-api-key.spec.ts",
@@ -22289,7 +22289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
-      "community": 1136
+      "community": 1138
     },
     {
       "label": "path-validator.spec.ts",
@@ -22297,7 +22297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 1137
+      "community": 1139
     },
     {
       "label": "triple-cache.spec.ts",
@@ -22305,7 +22305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 1138
+      "community": 1140
     },
     {
       "label": "memento-resource-uri.spec.ts",
@@ -22313,7 +22313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/memento-resource-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_memento_resource_uri_spec_ts",
-      "community": 1139
+      "community": 1141
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -22321,7 +22321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 1140
+      "community": 1142
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -22329,7 +22329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 1141
+      "community": 1143
     },
     {
       "label": "external-api-retry-logging.spec.ts",
@@ -22337,7 +22337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/external-api-retry-logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_external_api_retry_logging_spec_ts",
-      "community": 1142
+      "community": 1144
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -22345,7 +22345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 1143
+      "community": 1145
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 1144
+      "community": 1146
     },
     {
       "label": "logger-schema.spec.ts",
@@ -22361,7 +22361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 1145
+      "community": 1147
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -22369,7 +22369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 1146
+      "community": 1148
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -22377,7 +22377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 859
+      "community": 861
     },
     {
       "label": "initializeTestDatabase()",
@@ -22385,7 +22385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 859
+      "community": 861
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -22393,7 +22393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 1147
+      "community": 1149
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -22401,7 +22401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 1148
+      "community": 1150
     },
     {
       "label": "database-error-helpers.ts",
@@ -22537,7 +22537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_wal_and_status_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "isDatabaseOpen()",
@@ -22545,7 +22545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L7",
       "id": "wal_and_status_isdatabaseopen",
-      "community": 526
+      "community": 527
     },
     {
       "label": "checkpointWAL()",
@@ -22553,7 +22553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L23",
       "id": "wal_and_status_checkpointwal",
-      "community": 526
+      "community": 527
     },
     {
       "label": "getDatabaseStatus()",
@@ -22561,7 +22561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L33",
       "id": "wal_and_status_getdatabasestatus",
-      "community": 526
+      "community": 527
     },
     {
       "label": "schema-initialization.ts",
@@ -22569,7 +22569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_schema_initialization_ts",
-      "community": 860
+      "community": 862
     },
     {
       "label": "initializeDatabase()",
@@ -22577,7 +22577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L8",
       "id": "schema_initialization_initializedatabase",
-      "community": 860
+      "community": 862
     },
     {
       "label": "benchmark.types.ts",
@@ -22585,7 +22585,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 861
+      "community": 863
     },
     {
       "label": "assertMacroCategory()",
@@ -22593,7 +22593,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L28",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 861
+      "community": 863
     },
     {
       "label": "migration.types.ts",
@@ -22601,7 +22601,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 1149
+      "community": 1151
     },
     {
       "label": "consolidation-score.types.ts",
@@ -22609,7 +22609,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 1150
+      "community": 1152
     },
     {
       "label": "consolidation.types.ts",
@@ -22617,7 +22617,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 1151
+      "community": 1153
     },
     {
       "label": "vector-search.types.ts",
@@ -22625,7 +22625,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 1152
+      "community": 1154
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -22633,7 +22633,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 1153
+      "community": 1155
     },
     {
       "label": "procedural-versioning.ts",
@@ -22641,7 +22641,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 1154
+      "community": 1156
     },
     {
       "label": "triple-extraction.ts",
@@ -22649,7 +22649,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 1155
+      "community": 1157
     },
     {
       "label": "feedback.types.ts",
@@ -22657,7 +22657,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 1156
+      "community": 1158
     },
     {
       "label": "embedding.types.ts",
@@ -22665,7 +22665,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 1157
+      "community": 1159
     },
     {
       "label": "relation-graph.ts",
@@ -22673,7 +22673,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 1158
+      "community": 1160
     },
     {
       "label": "failure-event.ts",
@@ -22681,7 +22681,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 1159
+      "community": 1161
     },
     {
       "label": "index.ts",
@@ -22689,7 +22689,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "isMemoryItemType()",
@@ -22697,7 +22697,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 674
+      "community": 675
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -22705,7 +22705,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 674
+      "community": 675
     },
     {
       "label": "error-types.ts",
@@ -22713,7 +22713,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 1160
+      "community": 1162
     },
     {
       "label": "ranking.types.ts",
@@ -22721,7 +22721,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 1161
+      "community": 1163
     },
     {
       "label": "alerts.types.ts",
@@ -22729,7 +22729,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 1162
+      "community": 1164
     },
     {
       "label": "relation.ts",
@@ -22737,7 +22737,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "isApplicableRelationType()",
@@ -22745,7 +22745,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L155",
       "id": "relation_isapplicablerelationtype",
-      "community": 527
+      "community": 528
     },
     {
       "label": "getRelationCategory()",
@@ -22753,7 +22753,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L165",
       "id": "relation_getrelationcategory",
-      "community": 527
+      "community": 528
     },
     {
       "label": "getRelationBoost()",
@@ -22761,7 +22761,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L172",
       "id": "relation_getrelationboost",
-      "community": 527
+      "community": 528
     },
     {
       "label": "search.types.ts",
@@ -22769,7 +22769,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 1163
+      "community": 1165
     },
     {
       "label": "index.spec.ts",
@@ -22777,7 +22777,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 1164
+      "community": 1166
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -22785,7 +22785,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 1165
+      "community": 1167
     },
     {
       "label": "constants.ts",
@@ -22793,7 +22793,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 1166
+      "community": 1168
     },
     {
       "label": "environment.ts",
@@ -22801,7 +22801,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_environment_ts",
-      "community": 135
+      "community": 136
     },
     {
       "label": "toArray()",
@@ -22809,7 +22809,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L70",
       "id": "environment_toarray",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveEnv()",
@@ -22817,7 +22817,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L73",
       "id": "environment_resolveenv",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveString()",
@@ -22825,7 +22825,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L101",
       "id": "environment_resolvestring",
-      "community": 135
+      "community": 136
     },
     {
       "label": "expandHomeDirPath()",
@@ -22833,7 +22833,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L108",
       "id": "environment_expandhomedirpath",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveOptionalString()",
@@ -22841,7 +22841,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L120",
       "id": "environment_resolveoptionalstring",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveNumber()",
@@ -22849,7 +22849,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L141",
       "id": "environment_resolvenumber",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveOptionalNumber()",
@@ -22857,7 +22857,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L167",
       "id": "environment_resolveoptionalnumber",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveBoolean()",
@@ -22865,7 +22865,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L195",
       "id": "environment_resolveboolean",
-      "community": 135
+      "community": 136
     },
     {
       "label": "resolveValidatedNumber()",
@@ -22873,7 +22873,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L222",
       "id": "environment_resolvevalidatednumber",
-      "community": 135
+      "community": 136
     },
     {
       "label": "getRawEnvValue()",
@@ -22881,7 +22881,7 @@
       "source_file": "packages/memento-core/src/shared/config/environment.ts",
       "source_location": "L248",
       "id": "environment_getrawenvvalue",
-      "community": 135
+      "community": 136
     },
     {
       "label": "ranking-weights-loader.ts",
@@ -22937,7 +22937,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 1167
+      "community": 1169
     },
     {
       "label": "retry-options-loader.ts",
@@ -22993,7 +22993,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_llm_model_resolver_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "resolveProviderDefaultModel()",
@@ -23001,7 +23001,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L28",
       "id": "llm_model_resolver_resolveproviderdefaultmodel",
-      "community": 675
+      "community": 676
     },
     {
       "label": "resolveLlmModel()",
@@ -23009,7 +23009,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L51",
       "id": "llm_model_resolver_resolvellmmodel",
-      "community": 675
+      "community": 676
     },
     {
       "label": "index.ts",
@@ -23017,7 +23017,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 862
+      "community": 864
     },
     {
       "label": "validateConfig()",
@@ -23025,7 +23025,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L170",
       "id": "index_validateconfig",
-      "community": 862
+      "community": 864
     },
     {
       "label": "config-loader-utils.ts",
@@ -23097,7 +23097,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 1168
+      "community": 1170
     },
     {
       "label": "constants.spec.ts",
@@ -23105,7 +23105,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 1169
+      "community": 1171
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -23113,7 +23113,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 1170
+      "community": 1172
     },
     {
       "label": "config-validation.spec.ts",
@@ -23121,7 +23121,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 1171
+      "community": 1173
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -23129,7 +23129,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 1172
+      "community": 1174
     },
     {
       "label": "environment-paths.spec.ts",
@@ -23137,7 +23137,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 1173
+      "community": 1175
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -23145,7 +23145,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 1174
+      "community": 1176
     },
     {
       "label": "schema-version.ts",
@@ -23153,7 +23153,7 @@
       "source_file": "packages/memento-core/src/shared/constants/schema-version.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_schema_version_ts",
-      "community": 1175
+      "community": 1177
     },
     {
       "label": "relation-constants.ts",
@@ -23161,7 +23161,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 1176
+      "community": 1178
     },
     {
       "label": "introspection-constants.ts",
@@ -23169,7 +23169,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 1177
+      "community": 1179
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -23177,7 +23177,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 1178
+      "community": 1180
     },
     {
       "label": "http-bind-policy.ts",
@@ -23257,7 +23257,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 1179
+      "community": 1181
     },
     {
       "label": "retry-manager.interface.ts",
@@ -23265,7 +23265,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 1180
+      "community": 1182
     },
     {
       "label": "cache.interface.ts",
@@ -23273,7 +23273,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 1181
+      "community": 1183
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -23281,7 +23281,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 1182
+      "community": 1184
     },
     {
       "label": "error-logging.interface.ts",
@@ -23289,7 +23289,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 1183
+      "community": 1185
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -23297,7 +23297,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 1184
+      "community": 1186
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -23305,7 +23305,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 1185
+      "community": 1187
     },
     {
       "label": "database.interface.ts",
@@ -23313,7 +23313,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 1186
+      "community": 1188
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -23321,7 +23321,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 1187
+      "community": 1189
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -23329,7 +23329,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 1188
+      "community": 1190
     },
     {
       "label": "llm-client-initializer.ts",
@@ -23377,7 +23377,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "getMockMementoConfig()",
@@ -23385,7 +23385,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L21",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 676
+      "community": 677
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -23393,7 +23393,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L50",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 676
+      "community": 677
     },
     {
       "label": "initialize.spec.ts",
@@ -23401,7 +23401,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 1189
+      "community": 1191
     },
     {
       "label": "openai-client.spec.ts",
@@ -23409,7 +23409,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 1190
+      "community": 1192
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -23417,7 +23417,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 1191
+      "community": 1193
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -23425,7 +23425,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 1192
+      "community": 1194
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -23433,7 +23433,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 1193
+      "community": 1195
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -23441,7 +23441,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 1194
+      "community": 1196
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -23449,7 +23449,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 1195
+      "community": 1197
     },
     {
       "label": "environment-priority.spec.ts",
@@ -23457,7 +23457,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 1196
+      "community": 1198
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -23465,7 +23465,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 1197
+      "community": 1199
     },
     {
       "label": "gemini-client.spec.ts",
@@ -23473,7 +23473,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 1198
+      "community": 1200
     },
     {
       "label": "provider-resolution.ts",
@@ -23529,7 +23529,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_types_ts",
-      "community": 1199
+      "community": 1201
     },
     {
       "label": "shared-helpers.ts",
@@ -23593,7 +23593,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_gemini_ts",
-      "community": 863
+      "community": 865
     },
     {
       "label": "initializeGemini()",
@@ -23601,7 +23601,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L18",
       "id": "gemini_initializegemini",
-      "community": 863
+      "community": 865
     },
     {
       "label": "ollama.ts",
@@ -23649,7 +23649,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_openai_ts",
-      "community": 864
+      "community": 866
     },
     {
       "label": "initializeOpenAI()",
@@ -23657,7 +23657,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L14",
       "id": "openai_initializeopenai",
-      "community": 864
+      "community": 866
     },
     {
       "label": "source-uri.ts",
@@ -23665,15 +23665,15 @@
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_source_uri_ts",
-      "community": 865
+      "community": 867
     },
     {
       "label": "validateSource()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
-      "source_location": "L33",
+      "source_location": "L42",
       "id": "source_uri_validatesource",
-      "community": 865
+      "community": 867
     },
     {
       "label": "source-uri.spec.ts",
@@ -23681,7 +23681,7 @@
       "source_file": "packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_tests_source_uri_spec_ts",
-      "community": 1200
+      "community": 1202
     },
     {
       "label": "search-local-tool.ts",
@@ -23689,7 +23689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "SearchLocalTool",
@@ -23697,7 +23697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 528
+      "community": 529
     },
     {
       "label": ".constructor()",
@@ -23705,7 +23705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 528
+      "community": 529
     },
     {
       "label": ".handle()",
@@ -23713,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 528
+      "community": 529
     },
     {
       "label": "get-anchor-tool.ts",
@@ -23721,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "GetAnchorTool",
@@ -23729,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 529
+      "community": 530
     },
     {
       "label": ".constructor()",
@@ -23737,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 529
+      "community": 530
     },
     {
       "label": ".handle()",
@@ -23745,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 529
+      "community": 530
     },
     {
       "label": "set-anchor-tool.ts",
@@ -23753,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "SetAnchorTool",
@@ -23761,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 530
+      "community": 531
     },
     {
       "label": ".constructor()",
@@ -23769,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 530
+      "community": 531
     },
     {
       "label": ".handle()",
@@ -23777,7 +23777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 530
+      "community": 531
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -23785,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "ClearAnchorTool",
@@ -23793,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 531
+      "community": 532
     },
     {
       "label": ".constructor()",
@@ -23801,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 531
+      "community": 532
     },
     {
       "label": ".handle()",
@@ -23809,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 531
+      "community": 532
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -23817,7 +23817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "RestoreAnchorsTool",
@@ -23825,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 532
+      "community": 533
     },
     {
       "label": ".constructor()",
@@ -23833,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 532
+      "community": 533
     },
     {
       "label": ".handle()",
@@ -23841,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 532
+      "community": 533
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -23969,7 +23969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 866
+      "community": 868
     },
     {
       "label": "initializeTestDatabase()",
@@ -23977,7 +23977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 866
+      "community": 868
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -23985,7 +23985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 867
+      "community": 869
     },
     {
       "label": "initializeTestDatabase()",
@@ -23993,7 +23993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 867
+      "community": 869
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -24001,7 +24001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 1201
+      "community": 1203
     },
     {
       "label": "query-filter-strategy.ts",
@@ -24049,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 1202
+      "community": 1204
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -24057,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 1203
+      "community": 1205
     },
     {
       "label": "local-search-service.ts",
@@ -24129,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 1204
+      "community": 1206
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -24137,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 1205
+      "community": 1207
     },
     {
       "label": "anchor-interfaces.ts",
@@ -24265,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 1206
+      "community": 1208
     },
     {
       "label": "anchor-reanchor-service.ts",
@@ -24345,7 +24345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 868
+      "community": 870
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -24353,7 +24353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 868
+      "community": 870
     },
     {
       "label": "embedding-types.ts",
@@ -24361,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 1207
+      "community": 1209
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -24369,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 1208
+      "community": 1210
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -24473,7 +24473,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_ts",
-      "community": 136
+      "community": 137
     },
     {
       "label": "AnchorManager",
@@ -24481,7 +24481,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L17",
       "id": "anchor_manager_anchormanager",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".constructor()",
@@ -24489,7 +24489,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L35",
       "id": "anchor_manager_anchormanager_constructor",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".setErrorLoggingService()",
@@ -24497,7 +24497,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L51",
       "id": "anchor_manager_anchormanager_seterrorloggingservice",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".setDatabase()",
@@ -24505,7 +24505,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L58",
       "id": "anchor_manager_anchormanager_setdatabase",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".setAnchor()",
@@ -24513,7 +24513,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L87",
       "id": "anchor_manager_anchormanager_setanchor",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".getAnchor()",
@@ -24521,7 +24521,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L194",
       "id": "anchor_manager_anchormanager_getanchor",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".clearAnchor()",
@@ -24529,7 +24529,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L282",
       "id": "anchor_manager_anchormanager_clearanchor",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".getSlotConfig()",
@@ -24537,7 +24537,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L327",
       "id": "anchor_manager_anchormanager_getslotconfig",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".restoreCacheFromDB()",
@@ -24545,7 +24545,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L335",
       "id": "anchor_manager_anchormanager_restorecachefromdb",
-      "community": 136
+      "community": 137
     },
     {
       "label": ".searchLocal()",
@@ -24553,7 +24553,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.ts",
       "source_location": "L347",
       "id": "anchor_manager_anchormanager_searchlocal",
-      "community": 136
+      "community": 137
     },
     {
       "label": "fallback-search-service.ts",
@@ -24601,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 1209
+      "community": 1211
     },
     {
       "label": "fallback-strategy.ts",
@@ -24769,7 +24769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 1210
+      "community": 1212
     },
     {
       "label": "anchor-cache-service.ts",
@@ -24777,7 +24777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_ts",
-      "community": 137
+      "community": 138
     },
     {
       "label": "AnchorCacheService",
@@ -24785,7 +24785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L15",
       "id": "anchor_cache_service_anchorcacheservice",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".constructor()",
@@ -24793,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L28",
       "id": "anchor_cache_service_anchorcacheservice_constructor",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".setDatabase()",
@@ -24801,7 +24801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L37",
       "id": "anchor_cache_service_anchorcacheservice_setdatabase",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".setEmbeddingService()",
@@ -24809,7 +24809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L47",
       "id": "anchor_cache_service_anchorcacheservice_setembeddingservice",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getAnchorEmbedding()",
@@ -24817,7 +24817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L59",
       "id": "anchor_cache_service_anchorcacheservice_getanchorembedding",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".restoreCacheFromDB()",
@@ -24825,7 +24825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L148",
       "id": "anchor_cache_service_anchorcacheservice_restorecachefromdb",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".updateCache()",
@@ -24833,7 +24833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L206",
       "id": "anchor_cache_service_anchorcacheservice_updatecache",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getCachedAnchor()",
@@ -24841,7 +24841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L221",
       "id": "anchor_cache_service_anchorcacheservice_getcachedanchor",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".getCachedMemoryId()",
@@ -24849,7 +24849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L231",
       "id": "anchor_cache_service_anchorcacheservice_getcachedmemoryid",
-      "community": 137
+      "community": 138
     },
     {
       "label": ".deleteCache()",
@@ -24857,7 +24857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.ts",
       "source_location": "L240",
       "id": "anchor_cache_service_anchorcacheservice_deletecache",
-      "community": 137
+      "community": 138
     },
     {
       "label": "n-hop-search-service.ts",
@@ -24969,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 1211
+      "community": 1213
     },
     {
       "label": "n-hop-linked-memory-service.ts",
@@ -25049,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 1212
+      "community": 1214
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -25057,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 1213
+      "community": 1215
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -25065,7 +25065,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 1214
+      "community": 1216
     },
     {
       "label": "store.ts",
@@ -25073,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_store_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "key()",
@@ -25081,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L13",
       "id": "store_key",
-      "community": 533
+      "community": 534
     },
     {
       "label": "buildSnapshotsFromFixture()",
@@ -25089,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L38",
       "id": "store_buildsnapshotsfromfixture",
-      "community": 533
+      "community": 534
     },
     {
       "label": "getFixtureSnapshot()",
@@ -25097,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L172",
       "id": "store_getfixturesnapshot",
-      "community": 533
+      "community": 534
     },
     {
       "label": "types.ts",
@@ -25105,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 1215
+      "community": 1217
     },
     {
       "label": "index.ts",
@@ -25113,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 1216
+      "community": 1218
     },
     {
       "label": "getters.ts",
@@ -25161,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 1217
+      "community": 1219
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -25169,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 1218
+      "community": 1220
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -25177,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 1219
+      "community": 1221
     },
     {
       "label": "vector-search.factory.ts",
@@ -25305,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 869
+      "community": 871
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -25313,7 +25313,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 869
+      "community": 871
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -25321,7 +25321,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 1220
+      "community": 1222
     },
     {
       "label": "search-result-combiner.ts",
@@ -25329,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "SearchResultCombiner",
@@ -25337,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L24",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 534
+      "community": 535
     },
     {
       "label": ".combine()",
@@ -25345,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L36",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 534
+      "community": 535
     },
     {
       "label": ".generateHybridReason()",
@@ -25353,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L109",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 534
+      "community": 535
     },
     {
       "label": "hybrid-result-ranker.ts",
@@ -25777,7 +25777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -25785,7 +25785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 535
+      "community": 536
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -25793,7 +25793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 535
+      "community": 536
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -25801,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 535
+      "community": 536
     },
     {
       "label": "search-ranking.ts",
@@ -26217,7 +26217,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 870
+      "community": 872
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -26225,7 +26225,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 870
+      "community": 872
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -26281,7 +26281,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_types_ts",
-      "community": 1221
+      "community": 1223
     },
     {
       "label": "search-error.ts",
@@ -26289,7 +26289,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_error_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "SearchError",
@@ -26297,7 +26297,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L11",
       "id": "search_error_searcherror",
-      "community": 677
+      "community": 678
     },
     {
       "label": ".constructor()",
@@ -26305,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L12",
       "id": "search_error_searcherror_constructor",
-      "community": 677
+      "community": 678
     },
     {
       "label": "search-logger.ts",
@@ -26433,7 +26433,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "normalize()",
@@ -26441,7 +26441,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 536
+      "community": 537
     },
     {
       "label": "toSet()",
@@ -26449,7 +26449,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 536
+      "community": 537
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -26457,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 536
+      "community": 537
     },
     {
       "label": "search-ranking.types.ts",
@@ -26465,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking/search-ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_ranking_search_ranking_types_ts",
-      "community": 1222
+      "community": 1224
     },
     {
       "label": "search-ranking-composite.ts",
@@ -26729,7 +26729,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 1223
+      "community": 1225
     },
     {
       "label": "search-ranking.spec.ts",
@@ -26737,7 +26737,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 1224
+      "community": 1226
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -26745,7 +26745,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "initializeTestDatabase()",
@@ -26753,7 +26753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 678
+      "community": 679
     },
     {
       "label": "createValidReflectionNote()",
@@ -26761,7 +26761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 678
+      "community": 679
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -26841,7 +26841,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 1225
+      "community": 1227
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -26849,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 1226
+      "community": 1228
     },
     {
       "label": "search-engine.spec.ts",
@@ -26857,7 +26857,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createCountingSearchDb()",
@@ -26865,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -26873,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 537
+      "community": 538
     },
     {
       "label": "createSearchRows()",
@@ -26881,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 537
+      "community": 538
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -26889,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 1227
+      "community": 1229
     },
     {
       "label": "search-engine-ranking.ts",
@@ -26937,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_fts_query_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "buildFTSQuery()",
@@ -26945,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L9",
       "id": "search_engine_fts_query_buildftsquery",
-      "community": 538
+      "community": 539
     },
     {
       "label": "preprocessQuery()",
@@ -26953,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L38",
       "id": "search_engine_fts_query_preprocessquery",
-      "community": 538
+      "community": 539
     },
     {
       "label": "makeFTSSafe()",
@@ -26961,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L53",
       "id": "search_engine_fts_query_makeftssafe",
-      "community": 538
+      "community": 539
     },
     {
       "label": "search-engine.types.ts",
@@ -26969,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_types_ts",
-      "community": 1228
+      "community": 1230
     },
     {
       "label": "search-engine-sql-builder.ts",
@@ -26977,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_sql_builder_ts",
-      "community": 871
+      "community": 873
     },
     {
       "label": "buildSearchStatement()",
@@ -26985,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L7",
       "id": "search_engine_sql_builder_buildsearchstatement",
-      "community": 871
+      "community": 873
     },
     {
       "label": "search-engine-fts-availability.ts",
@@ -27233,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 1229
+      "community": 1231
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -27241,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 872
+      "community": 874
     },
     {
       "label": "seedScopedHybridMemories()",
@@ -27249,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L407",
       "id": "vector_search_repository_spec_seedscopedhybridmemories",
-      "community": 872
+      "community": 874
     },
     {
       "label": "vector-search.types.ts",
@@ -27257,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_types_ts",
-      "community": 1230
+      "community": 1232
     },
     {
       "label": "vector-search-result-mapper.ts",
@@ -27265,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_result_mapper_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "safeParseTags()",
@@ -27273,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L10",
       "id": "vector_search_result_mapper_safeparsetags",
-      "community": 539
+      "community": 540
     },
     {
       "label": "mapKnnResults()",
@@ -27281,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L25",
       "id": "vector_search_result_mapper_mapknnresults",
-      "community": 539
+      "community": 540
     },
     {
       "label": "mapHybridResults()",
@@ -27289,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L53",
       "id": "vector_search_result_mapper_maphybridresults",
-      "community": 539
+      "community": 540
     },
     {
       "label": "vector-search-knn-query.ts",
@@ -27297,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_knn_query_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "buildScopeParams()",
@@ -27305,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L25",
       "id": "vector_search_knn_query_buildscopeparams",
-      "community": 540
+      "community": 541
     },
     {
       "label": "buildOuterWhereSql()",
@@ -27313,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L38",
       "id": "vector_search_knn_query_buildouterwheresql",
-      "community": 540
+      "community": 541
     },
     {
       "label": "executeKnnQuery()",
@@ -27321,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L54",
       "id": "vector_search_knn_query_executeknnquery",
-      "community": 540
+      "community": 541
     },
     {
       "label": "vector-search-runtime-context.ts",
@@ -27433,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_scope_ts",
-      "community": 873
+      "community": 875
     },
     {
       "label": "parseVectorSearchScope()",
@@ -27441,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L8",
       "id": "vector_search_scope_parsevectorsearchscope",
-      "community": 873
+      "community": 875
     },
     {
       "label": "vector-search-hybrid-query.ts",
@@ -27489,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_ts",
-      "community": 138
+      "community": 139
     },
     {
       "label": "VectorSearchService",
@@ -27497,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L20",
       "id": "vector_search_service_vectorsearchservice",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".constructor()",
@@ -27505,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L21",
       "id": "vector_search_service_vectorsearchservice_constructor",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".search()",
@@ -27513,7 +27513,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L29",
       "id": "vector_search_service_vectorsearchservice_search",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".hybridSearch()",
@@ -27521,7 +27521,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L42",
       "id": "vector_search_service_vectorsearchservice_hybridsearch",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".providerHybridSearch()",
@@ -27529,7 +27529,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L52",
       "id": "vector_search_service_vectorsearchservice_providerhybridsearch",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".unifiedSearch()",
@@ -27537,7 +27537,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L131",
       "id": "vector_search_service_vectorsearchservice_unifiedsearch",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".validateQuery()",
@@ -27545,7 +27545,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L146",
       "id": "vector_search_service_vectorsearchservice_validatequery",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".validateProviderHybridQuery()",
@@ -27553,7 +27553,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L157",
       "id": "vector_search_service_vectorsearchservice_validateproviderhybridquery",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".getExpectedDimensions()",
@@ -27561,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L164",
       "id": "vector_search_service_vectorsearchservice_getexpecteddimensions",
-      "community": 138
+      "community": 139
     },
     {
       "label": ".applyDefaultOptions()",
@@ -27569,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.ts",
       "source_location": "L175",
       "id": "vector_search_service_vectorsearchservice_applydefaultoptions",
-      "community": 138
+      "community": 139
     },
     {
       "label": "vector-performance-tester.spec.ts",
@@ -27577,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 874
+      "community": 876
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -27585,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 874
+      "community": 876
     },
     {
       "label": "vector-performance-tester.ts",
@@ -27649,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 875
+      "community": 877
     },
     {
       "label": "createMockRepository()",
@@ -27657,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 875
+      "community": 877
     },
     {
       "label": "vector-index-manager.ts",
@@ -27961,7 +27961,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 876
+      "community": 878
     },
     {
       "label": "createMockRepositories()",
@@ -27969,7 +27969,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 876
+      "community": 878
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -27977,7 +27977,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 1231
+      "community": 1233
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -27985,7 +27985,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 877
+      "community": 879
     },
     {
       "label": "createMockIndexRepository()",
@@ -27993,7 +27993,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 877
+      "community": 879
     },
     {
       "label": "forgetting-event-log.spec.ts",
@@ -28001,7 +28001,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/__tests__/forgetting-event-log.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tests_forgetting_event_log_spec_ts",
-      "community": 1232
+      "community": 1234
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -28177,7 +28177,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 1233
+      "community": 1235
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -28185,7 +28185,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 1234
+      "community": 1236
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -28193,7 +28193,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 1235
+      "community": 1237
     },
     {
       "label": "spaced-repetition.ts",
@@ -28521,7 +28521,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 1236
+      "community": 1238
     },
     {
       "label": "forgetting-event-repository.ts",
@@ -28585,7 +28585,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "ForgettingStatsTool",
@@ -28593,7 +28593,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 541
+      "community": 542
     },
     {
       "label": ".constructor()",
@@ -28601,7 +28601,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 541
+      "community": 542
     },
     {
       "label": ".handle()",
@@ -28609,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 541
+      "community": 542
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -28617,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 1237
+      "community": 1239
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -28753,7 +28753,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 1238
+      "community": 1240
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -28761,7 +28761,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 1239
+      "community": 1241
     },
     {
       "label": "priority-calculation.service.ts",
@@ -29641,7 +29641,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 1240
+      "community": 1242
     },
     {
       "label": "recall-probability.service.ts",
@@ -29745,7 +29745,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 1241
+      "community": 1243
     },
     {
       "label": "telemetry.types.ts",
@@ -29753,7 +29753,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 1242
+      "community": 1244
     },
     {
       "label": "telemetry-system-metrics-query.ts",
@@ -29761,7 +29761,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_system_metrics_query_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "toolBucketFromEvents()",
@@ -29769,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L15",
       "id": "telemetry_system_metrics_query_toolbucketfromevents",
-      "community": 542
+      "community": 543
     },
     {
       "label": "mapJob()",
@@ -29777,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L65",
       "id": "telemetry_system_metrics_query_mapjob",
-      "community": 542
+      "community": 543
     },
     {
       "label": "querySystemMetrics()",
@@ -29785,7 +29785,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L81",
       "id": "telemetry_system_metrics_query_querysystemmetrics",
-      "community": 542
+      "community": 543
     },
     {
       "label": "telemetry-feedback-quality-query.ts",
@@ -29793,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_ts",
-      "community": 878
+      "community": 880
     },
     {
       "label": "queryFeedbackQuality()",
@@ -29801,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L6",
       "id": "telemetry_feedback_quality_query_queryfeedbackquality",
-      "community": 878
+      "community": 880
     },
     {
       "label": "telemetry-feedback-quality-query.spec.ts",
@@ -29809,7 +29809,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_spec_ts",
-      "community": 1243
+      "community": 1245
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -29817,7 +29817,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 879
+      "community": 881
     },
     {
       "label": "openTelemetryDb()",
@@ -29825,7 +29825,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 879
+      "community": 881
     },
     {
       "label": "telemetry-search-quality-query.ts",
@@ -29833,7 +29833,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_search_quality_query_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "avgCandidateCountForPeriod()",
@@ -29841,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L11",
       "id": "telemetry_search_quality_query_avgcandidatecountforperiod",
-      "community": 679
+      "community": 680
     },
     {
       "label": "querySearchQuality()",
@@ -29849,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L37",
       "id": "telemetry_search_quality_query_querysearchquality",
-      "community": 679
+      "community": 680
     },
     {
       "label": "telemetry-repository.ts",
@@ -29977,7 +29977,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_utils_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "periodCutoffIso()",
@@ -29985,7 +29985,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L3",
       "id": "telemetry_repository_utils_periodcutoffiso",
-      "community": 543
+      "community": 544
     },
     {
       "label": "rolling24hCutoffIso()",
@@ -29993,7 +29993,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L15",
       "id": "telemetry_repository_utils_rolling24hcutoffiso",
-      "community": 543
+      "community": 544
     },
     {
       "label": "percentile95Sorted()",
@@ -30001,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L22",
       "id": "telemetry_repository_utils_percentile95sorted",
-      "community": 543
+      "community": 544
     },
     {
       "label": "telemetry-memory-quality-query.ts",
@@ -30009,7 +30009,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_memory_quality_query_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "queryMemoryQuality()",
@@ -30017,7 +30017,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L8",
       "id": "telemetry_memory_quality_query_querymemoryquality",
-      "community": 680
+      "community": 681
     },
     {
       "label": "queryConsolidationQuality()",
@@ -30025,7 +30025,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L82",
       "id": "telemetry_memory_quality_query_queryconsolidationquality",
-      "community": 680
+      "community": 681
     },
     {
       "label": "get-telemetry-summary-tool.spec.ts",
@@ -30081,7 +30081,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -30089,7 +30089,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 544
+      "community": 545
     },
     {
       "label": ".constructor()",
@@ -30097,7 +30097,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 544
+      "community": 545
     },
     {
       "label": ".handle()",
@@ -30105,7 +30105,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 544
+      "community": 545
     },
     {
       "label": "audit-hash-chain-service.ts",
@@ -30233,7 +30233,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/audit-hash-chain-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_audit_hash_chain_service_spec_ts",
-      "community": 1244
+      "community": 1246
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -30241,7 +30241,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 1245
+      "community": 1247
     },
     {
       "label": "event-outbox-service.ts",
@@ -30255,7 +30255,7 @@
       "label": "isEventOutboxEnabled()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "id": "event_outbox_service_iseventoutboxenabled",
       "community": 203
     },
@@ -30263,7 +30263,7 @@
       "label": "parsePayload()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L43",
+      "source_location": "L44",
       "id": "event_outbox_service_parsepayload",
       "community": 203
     },
@@ -30271,7 +30271,7 @@
       "label": "toEvent()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L52",
+      "source_location": "L53",
       "id": "event_outbox_service_toevent",
       "community": 203
     },
@@ -30279,7 +30279,7 @@
       "label": "EventOutboxService",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "id": "event_outbox_service_eventoutboxservice",
       "community": 203
     },
@@ -30287,7 +30287,7 @@
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "id": "event_outbox_service_eventoutboxservice_constructor",
       "community": 203
     },
@@ -30295,7 +30295,7 @@
       "label": ".enqueue()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L71",
+      "source_location": "L72",
       "id": "event_outbox_service_eventoutboxservice_enqueue",
       "community": 203
     },
@@ -30303,7 +30303,7 @@
       "label": ".pending()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "id": "event_outbox_service_eventoutboxservice_pending",
       "community": 203
     },
@@ -30311,7 +30311,7 @@
       "label": ".publishPending()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L94",
+      "source_location": "L95",
       "id": "event_outbox_service_eventoutboxservice_publishpending",
       "community": 203
     },
@@ -30449,7 +30449,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_spec_ts",
-      "community": 1246
+      "community": 1248
     },
     {
       "label": "index.ts",
@@ -30457,7 +30457,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 1247
+      "community": 1249
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -30465,7 +30465,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 1248
+      "community": 1250
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -30473,7 +30473,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 1249
+      "community": 1251
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -30481,7 +30481,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 880
+      "community": 882
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -30489,7 +30489,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 880
+      "community": 882
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -30497,7 +30497,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "baseTags()",
@@ -30505,7 +30505,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 545
+      "community": 546
     },
     {
       "label": "pushUnique()",
@@ -30513,7 +30513,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 545
+      "community": 546
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -30521,7 +30521,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 545
+      "community": 546
     },
     {
       "label": "personal-agent-llm-error.ts",
@@ -30529,7 +30529,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "PersonalAgentLlmError",
@@ -30537,7 +30537,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L12",
       "id": "personal_agent_llm_error_personalagentllmerror",
-      "community": 546
+      "community": 547
     },
     {
       "label": ".constructor()",
@@ -30545,7 +30545,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L15",
       "id": "personal_agent_llm_error_personalagentllmerror_constructor",
-      "community": 546
+      "community": 547
     },
     {
       "label": "isPersonalAgentLlmError()",
@@ -30553,7 +30553,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L22",
       "id": "personal_agent_llm_error_ispersonalagentllmerror",
-      "community": 546
+      "community": 547
     },
     {
       "label": "personal-agent-llm-error.spec.ts",
@@ -30561,7 +30561,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 1250
+      "community": 1252
     },
     {
       "label": "llm-port.ts",
@@ -30569,7 +30569,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 1251
+      "community": 1253
     },
     {
       "label": "persistence-port.ts",
@@ -30577,7 +30577,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 1252
+      "community": 1254
     },
     {
       "label": "context-port.ts",
@@ -30585,7 +30585,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 1253
+      "community": 1255
     },
     {
       "label": "agent-types.ts",
@@ -30593,7 +30593,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 1254
+      "community": 1256
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -30601,7 +30601,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "readProviderToken()",
@@ -30609,7 +30609,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 681
+      "community": 682
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -30617,7 +30617,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 681
+      "community": 682
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -30625,7 +30625,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 1255
+      "community": 1257
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -30633,7 +30633,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 1256
+      "community": 1258
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -30681,7 +30681,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "OpenAiChatLlmAdapter",
@@ -30689,7 +30689,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "openai_chat_llm_adapter_openaichatllmadapter",
-      "community": 547
+      "community": 548
     },
     {
       "label": ".constructor()",
@@ -30697,7 +30697,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
-      "community": 547
+      "community": 548
     },
     {
       "label": ".complete()",
@@ -30705,7 +30705,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_complete",
-      "community": 547
+      "community": 548
     },
     {
       "label": "openai-chat-llm-adapter.spec.ts",
@@ -30713,7 +30713,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 1257
+      "community": 1259
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -30721,7 +30721,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "OllamaChatLlmAdapter",
@@ -30729,7 +30729,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter",
-      "community": 548
+      "community": 549
     },
     {
       "label": ".constructor()",
@@ -30737,7 +30737,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
-      "community": 548
+      "community": 549
     },
     {
       "label": ".complete()",
@@ -30745,7 +30745,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L27",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
-      "community": 548
+      "community": 549
     },
     {
       "label": "gemini-chat-llm-adapter.ts",
@@ -30753,7 +30753,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "GeminiChatLlmAdapter",
@@ -30761,7 +30761,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L10",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter",
-      "community": 549
+      "community": 550
     },
     {
       "label": ".constructor()",
@@ -30769,7 +30769,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L14",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
-      "community": 549
+      "community": 550
     },
     {
       "label": ".complete()",
@@ -30777,7 +30777,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L19",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
-      "community": 549
+      "community": 550
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -30865,7 +30865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 1258
+      "community": 1260
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -30873,7 +30873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 1259
+      "community": 1261
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -30881,7 +30881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 1260
+      "community": 1262
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -30889,7 +30889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 881
+      "community": 883
     },
     {
       "label": "baseCandidate()",
@@ -30897,7 +30897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 881
+      "community": 883
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -30945,7 +30945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 1261
+      "community": 1263
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -30953,7 +30953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 882
+      "community": 884
     },
     {
       "label": "makeDeps()",
@@ -30961,7 +30961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 882
+      "community": 884
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -31009,7 +31009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 883
+      "community": 885
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -31017,7 +31017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 883
+      "community": 885
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -31025,7 +31025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 884
+      "community": 886
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -31033,7 +31033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 884
+      "community": 886
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -31041,7 +31041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 1262
+      "community": 1264
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -31049,7 +31049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 1263
+      "community": 1265
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -31057,7 +31057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 885
+      "community": 887
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -31065,7 +31065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L9",
       "id": "feedback_repository_interface_sigmoidnormalizednet",
-      "community": 885
+      "community": 887
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -31073,7 +31073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 1264
+      "community": 1266
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -31081,7 +31081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 1265
+      "community": 1267
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -31089,7 +31089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 1266
+      "community": 1268
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -31097,7 +31097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 886
+      "community": 888
     },
     {
       "label": "createKgTripleTable()",
@@ -31105,7 +31105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 886
+      "community": 888
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -31113,7 +31113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 887
+      "community": 889
     },
     {
       "label": "createProcessAttributeTable()",
@@ -31121,7 +31121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 887
+      "community": 889
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -31129,7 +31129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 888
+      "community": 890
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -31137,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 888
+      "community": 890
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -31145,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 1267
+      "community": 1269
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -31153,7 +31153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 889
+      "community": 891
     },
     {
       "label": "createCoreMemoryTable()",
@@ -31161,7 +31161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 889
+      "community": 891
     },
     {
       "label": "recall-tool-host.ts",
@@ -31169,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 1268
+      "community": 1270
     },
     {
       "label": "remember-tool-memory-item.ts",
@@ -31177,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_memory_item_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "buildSimilarityWarning()",
@@ -31185,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L39",
       "id": "remember_tool_memory_item_buildsimilaritywarning",
-      "community": 550
+      "community": 551
     },
     {
       "label": "persistMemoryItem()",
@@ -31193,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L71",
       "id": "remember_tool_memory_item_persistmemoryitem",
-      "community": 550
+      "community": 551
     },
     {
       "label": "handleMemoryItem()",
@@ -31201,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L195",
       "id": "remember_tool_memory_item_handlememoryitem",
-      "community": 550
+      "community": 551
     },
     {
       "label": "recall-tool-definition.ts",
@@ -31209,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 1269
+      "community": 1271
     },
     {
       "label": "remember-tool-schema.ts",
@@ -31217,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_schema_ts",
-      "community": 1270
+      "community": 1272
     },
     {
       "label": "remember-tool-reflection.ts",
@@ -31265,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "RememberTool",
@@ -31273,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L27",
       "id": "remember_tool_remembertool",
-      "community": 551
+      "community": 552
     },
     {
       "label": ".constructor()",
@@ -31281,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L28",
       "id": "remember_tool_remembertool_constructor",
-      "community": 551
+      "community": 552
     },
     {
       "label": ".handle()",
@@ -31289,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L129",
       "id": "remember_tool_remembertool_handle",
-      "community": 551
+      "community": 552
     },
     {
       "label": "remember-tool-vault.ts",
@@ -31297,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_vault_ts",
-      "community": 890
+      "community": 892
     },
     {
       "label": "handleVaultMemory()",
@@ -31305,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L20",
       "id": "remember_tool_vault_handlevaultmemory",
-      "community": 890
+      "community": 892
     },
     {
       "label": "recall-tool-validation.ts",
@@ -31313,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "validateRecallQuery()",
@@ -31321,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 682
+      "community": 683
     },
     {
       "label": "validateRecallFilters()",
@@ -31329,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 682
+      "community": 683
     },
     {
       "label": "recall-tool-schema.ts",
@@ -31337,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 891
+      "community": 893
     },
     {
       "label": "normalizeProviderFilter()",
@@ -31345,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 891
+      "community": 893
     },
     {
       "label": "remember-tool-db-helpers.ts",
@@ -31353,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_db_helpers_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "findExistingProceduralMemory()",
@@ -31361,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L11",
       "id": "remember_tool_db_helpers_findexistingproceduralmemory",
-      "community": 552
+      "community": 553
     },
     {
       "label": "getExistingMemoriesForRelationExtraction()",
@@ -31369,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L78",
       "id": "remember_tool_db_helpers_getexistingmemoriesforrelationextraction",
-      "community": 552
+      "community": 553
     },
     {
       "label": "getMemoryById()",
@@ -31377,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L119",
       "id": "remember_tool_db_helpers_getmemorybyid",
-      "community": 552
+      "community": 553
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -31385,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -31393,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L30",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 553
+      "community": 554
     },
     {
       "label": ".constructor()",
@@ -31401,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L31",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 553
+      "community": 554
     },
     {
       "label": ".handle()",
@@ -31409,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L84",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 553
+      "community": 554
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -31417,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -31425,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".constructor()",
@@ -31433,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".handle()",
@@ -31441,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 554
+      "community": 555
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -31449,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "ProceduralRollbackTool",
@@ -31457,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".constructor()",
@@ -31465,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".handle()",
@@ -31473,7 +31473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 555
+      "community": 556
     },
     {
       "label": "feedback-tool.ts",
@@ -31537,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "CleanupMemoryTool",
@@ -31545,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 556
+      "community": 557
     },
     {
       "label": ".constructor()",
@@ -31553,7 +31553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 556
+      "community": 557
     },
     {
       "label": ".handle()",
@@ -31561,7 +31561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 556
+      "community": 557
     },
     {
       "label": "recall-tool-filters.ts",
@@ -31569,7 +31569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -31577,7 +31577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 683
+      "community": 684
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -31585,7 +31585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 683
+      "community": 684
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -31689,7 +31689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_host_ts",
-      "community": 1271
+      "community": 1273
     },
     {
       "label": "recall-tool-search-execution.ts",
@@ -31697,7 +31697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 892
+      "community": 894
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -31705,7 +31705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 892
+      "community": 894
     },
     {
       "label": "pin-tool.ts",
@@ -31881,7 +31881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_neighbors_fetch_ts",
-      "community": 893
+      "community": 895
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -31889,7 +31889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L16",
       "id": "recall_tool_neighbors_fetch_handleincludeneighbors",
-      "community": 893
+      "community": 895
     },
     {
       "label": "recall-tool-anchor-rotation.ts",
@@ -31897,7 +31897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_anchor_rotation_ts",
-      "community": 894
+      "community": 896
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -31905,7 +31905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L12",
       "id": "recall_tool_anchor_rotation_handleautosetanchor",
-      "community": 894
+      "community": 896
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -31913,7 +31913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "ProceduralDiffTool",
@@ -31921,7 +31921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".constructor()",
@@ -31929,7 +31929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".handle()",
@@ -31937,7 +31937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 557
+      "community": 558
     },
     {
       "label": "remember-tool-types.ts",
@@ -31945,7 +31945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_types_ts",
-      "community": 1272
+      "community": 1274
     },
     {
       "label": "recall-tool-direct.ts",
@@ -31953,7 +31953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_direct_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "recallCoreMemoryDirect()",
@@ -31961,7 +31961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L13",
       "id": "recall_tool_direct_recallcorememorydirect",
-      "community": 684
+      "community": 685
     },
     {
       "label": "recallVaultMemoryDirect()",
@@ -31969,7 +31969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L67",
       "id": "recall_tool_direct_recallvaultmemorydirect",
-      "community": 684
+      "community": 685
     },
     {
       "label": "unpin-tool.ts",
@@ -32161,7 +32161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -32169,7 +32169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 558
+      "community": 559
     },
     {
       "label": ".constructor()",
@@ -32177,7 +32177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 558
+      "community": 559
     },
     {
       "label": ".handle()",
@@ -32185,7 +32185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 558
+      "community": 559
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -32193,7 +32193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "RememberProcedureTool",
@@ -32201,7 +32201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".constructor()",
@@ -32209,7 +32209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".handle()",
@@ -32217,7 +32217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 559
+      "community": 560
     },
     {
       "label": "recall-tool-envelope.ts",
@@ -32225,7 +32225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "getMetaStatsForResults()",
@@ -32233,7 +32233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L35",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 685
+      "community": 686
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -32241,7 +32241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L79",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 685
+      "community": 686
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -32361,7 +32361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 895
+      "community": 897
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -32369,7 +32369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L12",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 895
+      "community": 897
     },
     {
       "label": "recall-tool.ts",
@@ -32441,7 +32441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 1273
+      "community": 1275
     },
     {
       "label": "forget-tool.ts",
@@ -32585,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_core_ts",
-      "community": 896
+      "community": 898
     },
     {
       "label": "handleCoreMemory()",
@@ -32593,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L19",
       "id": "remember_tool_core_handlecorememory",
-      "community": 896
+      "community": 898
     },
     {
       "label": "recall-tool-anchor-rotation.spec.ts",
@@ -32601,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_anchor_rotation_spec_ts",
-      "community": 897
+      "community": 899
     },
     {
       "label": "createAnchorTable()",
@@ -32609,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L10",
       "id": "recall_tool_anchor_rotation_spec_createanchortable",
-      "community": 897
+      "community": 899
     },
     {
       "label": "procedural-diff-tool.spec.ts",
@@ -32617,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 898
+      "community": 900
     },
     {
       "label": "createSchema()",
@@ -32625,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 898
+      "community": 900
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -32633,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 1274
+      "community": 1276
     },
     {
       "label": "remember-tool.spec.ts",
@@ -32641,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "initializeTestDatabase()",
@@ -32649,15 +32649,15 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 686
+      "community": 687
     },
     {
       "label": "createValidReflectionNote()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
-      "source_location": "L831",
+      "source_location": "L848",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 686
+      "community": 687
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -32665,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 1275
+      "community": 1277
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -32673,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 899
+      "community": 901
     },
     {
       "label": "createSchema()",
@@ -32681,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 899
+      "community": 901
     },
     {
       "label": "export-memories-tool.spec.ts",
@@ -32689,7 +32689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_export_memories_tool_spec_ts",
-      "community": 900
+      "community": 902
     },
     {
       "label": "initializeTestDatabase()",
@@ -32697,7 +32697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L6",
       "id": "export_memories_tool_spec_initializetestdatabase",
-      "community": 900
+      "community": 902
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -32705,7 +32705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "generateId()",
@@ -32713,7 +32713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 560
+      "community": 561
     },
     {
       "label": "initializeTestDatabase()",
@@ -32721,7 +32721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 560
+      "community": 561
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -32729,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 560
+      "community": 561
     },
     {
       "label": "forget-tool.spec.ts",
@@ -32737,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 1276
+      "community": 1278
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -32745,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 1277
+      "community": 1279
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -32753,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 901
+      "community": 903
     },
     {
       "label": "initializeTestDatabase()",
@@ -32761,7 +32761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 901
+      "community": 903
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -32769,7 +32769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 902
+      "community": 904
     },
     {
       "label": "parseData()",
@@ -32777,7 +32777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 902
+      "community": 904
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -32785,7 +32785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 1278
+      "community": 1280
     },
     {
       "label": "recall-tool.spec.ts",
@@ -32793,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "initializeTestDatabase()",
@@ -32801,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 687
+      "community": 688
     },
     {
       "label": "createValidReflectionNote()",
@@ -32809,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1508",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 687
+      "community": 688
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -32817,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1279
+      "community": 1281
     },
     {
       "label": "remember-tool-relation-load.spec.ts",
@@ -32825,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "initializeProductionLikeSchema()",
@@ -32833,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L15",
       "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
-      "community": 688
+      "community": 689
     },
     {
       "label": "createHost()",
@@ -32841,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L33",
       "id": "remember_tool_relation_load_spec_createhost",
-      "community": 688
+      "community": 689
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -32849,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1280
+      "community": 1282
     },
     {
       "label": "pin-tool.spec.ts",
@@ -32857,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1281
+      "community": 1283
     },
     {
       "label": "meta-memory-service.ts",
@@ -32985,7 +32985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "fieldDiff()",
@@ -32993,7 +32993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 561
+      "community": 562
     },
     {
       "label": "parseStepsJson()",
@@ -33001,7 +33001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 561
+      "community": 562
     },
     {
       "label": "computeProceduralDiff()",
@@ -33009,7 +33009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 561
+      "community": 562
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -33105,7 +33105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 903
+      "community": 905
     },
     {
       "label": "createBaseSchema()",
@@ -33113,7 +33113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L24",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 903
+      "community": 905
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -33193,7 +33193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 904
+      "community": 906
     },
     {
       "label": "baseRow()",
@@ -33201,7 +33201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 904
+      "community": 906
     },
     {
       "label": "procedural-versioning.ts",
@@ -33209,7 +33209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "getVersionChain()",
@@ -33217,7 +33217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 562
+      "community": 563
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -33225,7 +33225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 562
+      "community": 563
     },
     {
       "label": "getNextVersionNumber()",
@@ -33233,7 +33233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 562
+      "community": 563
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -33241,7 +33241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -33249,7 +33249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 689
+      "community": 690
     },
     {
       "label": ".runScan()",
@@ -33257,7 +33257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 689
+      "community": 690
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -33265,7 +33265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "generateMemoryId()",
@@ -33273,7 +33273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 690
+      "community": 691
     },
     {
       "label": "rollbackToVersion()",
@@ -33281,7 +33281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 690
+      "community": 691
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -33353,7 +33353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "selectionWindowLimit()",
@@ -33361,7 +33361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 691
+      "community": 692
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -33369,7 +33369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 691
+      "community": 692
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -33417,7 +33417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1282
+      "community": 1284
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -33425,7 +33425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 905
+      "community": 907
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -33433,7 +33433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 905
+      "community": 907
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -33441,7 +33441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 906
+      "community": 908
     },
     {
       "label": "openDb()",
@@ -33449,7 +33449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 906
+      "community": 908
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -34209,7 +34209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 907
+      "community": 909
     },
     {
       "label": "createBaseSchema()",
@@ -34217,7 +34217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 907
+      "community": 909
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -34481,7 +34481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1283
+      "community": 1285
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -34489,7 +34489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -34497,7 +34497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 692
+      "community": 693
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -34505,7 +34505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 692
+      "community": 693
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -34513,7 +34513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1284
+      "community": 1286
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -34521,7 +34521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1285
+      "community": 1287
     },
     {
       "label": "core-memory-service.ts",
@@ -34681,7 +34681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 908
+      "community": 910
     },
     {
       "label": "createBaseSchema()",
@@ -34689,7 +34689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 908
+      "community": 910
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -34697,7 +34697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 909
+      "community": 911
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -34705,7 +34705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 909
+      "community": 911
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -34785,7 +34785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1286
+      "community": 1288
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -34793,7 +34793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1287
+      "community": 1289
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -34801,7 +34801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 910
+      "community": 912
     },
     {
       "label": "createSchema()",
@@ -34809,7 +34809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 910
+      "community": 912
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -34817,7 +34817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1288
+      "community": 1290
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -34825,7 +34825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 911
+      "community": 913
     },
     {
       "label": "createSchema()",
@@ -34833,7 +34833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 911
+      "community": 913
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -34841,7 +34841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1289
+      "community": 1291
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -34849,7 +34849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 912
+      "community": 914
     },
     {
       "label": "createBaseSchema()",
@@ -34857,7 +34857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 912
+      "community": 914
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -34865,7 +34865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1290
+      "community": 1292
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -34873,7 +34873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 913
+      "community": 915
     },
     {
       "label": "createSchema()",
@@ -34881,7 +34881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 913
+      "community": 915
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -34889,7 +34889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1291
+      "community": 1293
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -34897,7 +34897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1292
+      "community": 1294
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -35017,7 +35017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1293
+      "community": 1295
     },
     {
       "label": "semantic-memory-crud.ts",
@@ -35353,7 +35353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_types_ts",
-      "community": 914
+      "community": 916
     },
     {
       "label": "generateSemanticMemoryId()",
@@ -35361,7 +35361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L14",
       "id": "semantic_memory_update_types_generatesemanticmemoryid",
-      "community": 914
+      "community": 916
     },
     {
       "label": "semantic-memory-update-service.ts",
@@ -35417,7 +35417,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1294
+      "community": 1296
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -35425,7 +35425,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 915
+      "community": 917
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -35433,7 +35433,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 915
+      "community": 917
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -35441,7 +35441,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1295
+      "community": 1297
     },
     {
       "label": "consolidation-repository.ts",
@@ -35529,87 +35529,95 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
-      "community": 139
+      "community": 122
     },
     {
       "label": "ConsolidationAlreadyRunningError",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L24",
+      "source_location": "L26",
       "id": "sleep_consolidation_service_consolidationalreadyrunningerror",
-      "community": 139
+      "community": 122
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L25",
+      "source_location": "L27",
       "id": "sleep_consolidation_service_consolidationalreadyrunningerror_constructor",
-      "community": 139
+      "community": 122
     },
     {
       "label": "newSemanticId()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L43",
+      "source_location": "L45",
       "id": "sleep_consolidation_service_newsemanticid",
-      "community": 139
+      "community": 122
     },
     {
       "label": "cosineSimilarity()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L50",
+      "source_location": "L52",
       "id": "sleep_consolidation_service_cosinesimilarity",
-      "community": 139
+      "community": 122
     },
     {
       "label": "getMergeSimilarityThreshold()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L68",
+      "source_location": "L70",
       "id": "sleep_consolidation_service_getmergesimilaritythreshold",
-      "community": 139
+      "community": 122
     },
     {
       "label": "mergeOriginSourceJson()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L74",
+      "source_location": "L76",
       "id": "sleep_consolidation_service_mergeoriginsourcejson",
-      "community": 139
+      "community": 122
     },
     {
       "label": "SleepConsolidationService",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L101",
+      "source_location": "L103",
       "id": "sleep_consolidation_service_sleepconsolidationservice",
-      "community": 139
+      "community": 122
     },
     {
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L112",
+      "source_location": "L114",
       "id": "sleep_consolidation_service_sleepconsolidationservice_constructor",
-      "community": 139
+      "community": 122
     },
     {
       "label": ".isRunning()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L127",
+      "source_location": "L129",
       "id": "sleep_consolidation_service_sleepconsolidationservice_isrunning",
-      "community": 139
+      "community": 122
+    },
+    {
+      "label": ".enqueueConsolidationCompleted()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
+      "source_location": "L137",
+      "id": "sleep_consolidation_service_sleepconsolidationservice_enqueueconsolidationcompleted",
+      "community": 122
     },
     {
       "label": ".run()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L131",
+      "source_location": "L163",
       "id": "sleep_consolidation_service_sleepconsolidationservice_run",
-      "community": 139
+      "community": 122
     },
     {
       "label": "clustering-service.ts",
@@ -35673,7 +35681,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 916
+      "community": 918
     },
     {
       "label": "row()",
@@ -35681,7 +35689,47 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 916
+      "community": 918
+    },
+    {
+      "label": "consolidation-outbox-worker.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_ts",
+      "community": 461
+    },
+    {
+      "label": "ConsolidationOutboxWorker",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L19",
+      "id": "consolidation_outbox_worker_consolidationoutboxworker",
+      "community": 461
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L22",
+      "id": "consolidation_outbox_worker_consolidationoutboxworker_constructor",
+      "community": 461
+    },
+    {
+      "label": ".publish()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L26",
+      "id": "consolidation_outbox_worker_consolidationoutboxworker_publish",
+      "community": 461
+    },
+    {
+      "label": ".handled()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L38",
+      "id": "consolidation_outbox_worker_consolidationoutboxworker_handled",
+      "community": 461
     },
     {
       "label": "summarization-service.ts",
@@ -35737,7 +35785,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "insertEpisodic()",
@@ -35745,7 +35793,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 461
+      "community": 462
     },
     {
       "label": "insertEmbedding()",
@@ -35753,7 +35801,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 461
+      "community": 462
     },
     {
       "label": "FailingRepo",
@@ -35761,7 +35809,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 461
+      "community": 462
     },
     {
       "label": ".insertSemanticMemory()",
@@ -35769,7 +35817,31 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 461
+      "community": 462
+    },
+    {
+      "label": "consolidation-outbox-worker.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
+      "community": 694
+    },
+    {
+      "label": "insertEpisodic()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
+      "source_location": "L10",
+      "id": "consolidation_outbox_worker_spec_insertepisodic",
+      "community": 694
+    },
+    {
+      "label": "insertEmbedding()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
+      "source_location": "L18",
+      "id": "consolidation_outbox_worker_spec_insertembedding",
+      "community": 694
     },
     {
       "label": "clustering-service.spec.ts",
@@ -35777,7 +35849,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 917
+      "community": 919
     },
     {
       "label": "ep()",
@@ -35785,7 +35857,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 917
+      "community": 919
     },
     {
       "label": "relation-graph.port.ts",
@@ -35793,7 +35865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1296
+      "community": 1298
     },
     {
       "label": "get-relations-tool.ts",
@@ -35857,7 +35929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 918
+      "community": 920
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -35865,7 +35937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 918
+      "community": 920
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -35873,7 +35945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "VisualizeRelationsTool",
@@ -35881,7 +35953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 563
+      "community": 564
     },
     {
       "label": ".constructor()",
@@ -35889,7 +35961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 563
+      "community": 564
     },
     {
       "label": ".handle()",
@@ -35897,7 +35969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 563
+      "community": 564
     },
     {
       "label": "remove-relation-tool.ts",
@@ -35905,7 +35977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "RemoveRelationTool",
@@ -35913,7 +35985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".constructor()",
@@ -35921,7 +35993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".handle()",
@@ -35929,7 +36001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 564
+      "community": 565
     },
     {
       "label": "extract-relations-tool.ts",
@@ -35937,7 +36009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "ExtractRelationsTool",
@@ -35945,7 +36017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".constructor()",
@@ -35953,7 +36025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".handle()",
@@ -35961,7 +36033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 565
+      "community": 566
     },
     {
       "label": "add-relation-tool.ts",
@@ -35969,7 +36041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "memoryItemHasOwnerIdColumn()",
@@ -35977,7 +36049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L16",
       "id": "add_relation_tool_memoryitemhasowneridcolumn",
-      "community": 462
+      "community": 463
     },
     {
       "label": "AddRelationTool",
@@ -35985,7 +36057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L28",
       "id": "add_relation_tool_addrelationtool",
-      "community": 462
+      "community": 463
     },
     {
       "label": ".constructor()",
@@ -35993,7 +36065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L29",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 462
+      "community": 463
     },
     {
       "label": ".handle()",
@@ -36001,7 +36073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L67",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 462
+      "community": 463
     },
     {
       "label": "extract-triples-tool.ts",
@@ -36065,7 +36137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "createBaseSchema()",
@@ -36073,7 +36145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 693
+      "community": 695
     },
     {
       "label": "createTestMemory()",
@@ -36081,7 +36153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L53",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 693
+      "community": 695
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -36089,7 +36161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "createBaseSchema()",
@@ -36097,7 +36169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 694
+      "community": 696
     },
     {
       "label": "createTestMemory()",
@@ -36105,7 +36177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 694
+      "community": 696
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -36113,7 +36185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -36121,7 +36193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 695
+      "community": 697
     },
     {
       "label": "createTestMemory()",
@@ -36129,7 +36201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 695
+      "community": 697
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -36137,7 +36209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1297
+      "community": 1299
     },
     {
       "label": "relation-tools-registry.spec.ts",
@@ -36145,7 +36217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/relation-tools-registry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_relation_tools_registry_spec_ts",
-      "community": 1298
+      "community": 1300
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -36153,7 +36225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "createBaseSchema()",
@@ -36161,7 +36233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 696
+      "community": 698
     },
     {
       "label": "createTestMemory()",
@@ -36169,7 +36241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L53",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 696
+      "community": 698
     },
     {
       "label": "relation-retry-manager.ts",
@@ -36177,7 +36249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "RelationRetryManager",
@@ -36185,7 +36257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 566
+      "community": 567
     },
     {
       "label": ".constructor()",
@@ -36193,7 +36265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 566
+      "community": 567
     },
     {
       "label": ".retry()",
@@ -36201,7 +36273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 566
+      "community": 567
     },
     {
       "label": "relation-errors.ts",
@@ -36409,7 +36481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_query_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "RelationGraphQuery",
@@ -36417,7 +36489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L16",
       "id": "relation_graph_query_relationgraphquery",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".constructor()",
@@ -36425,7 +36497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L17",
       "id": "relation_graph_query_relationgraphquery_constructor",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".getRelations()",
@@ -36433,7 +36505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L25",
       "id": "relation_graph_query_relationgraphquery_getrelations",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".getRelationsBatch()",
@@ -36441,7 +36513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L99",
       "id": "relation_graph_query_relationgraphquery_getrelationsbatch",
-      "community": 463
+      "community": 464
     },
     {
       "label": "relation-graph-row-utils.ts",
@@ -36449,7 +36521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_row_utils_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "mapRelationRowToMemoryRelation()",
@@ -36457,7 +36529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L13",
       "id": "relation_graph_row_utils_maprelationrowtomemoryrelation",
-      "community": 567
+      "community": 568
     },
     {
       "label": "filterRelationRows()",
@@ -36465,7 +36537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L29",
       "id": "relation_graph_row_utils_filterrelationrows",
-      "community": 567
+      "community": 568
     },
     {
       "label": "filterRelationRowsWithWarning()",
@@ -36473,7 +36545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L36",
       "id": "relation_graph_row_utils_filterrelationrowswithwarning",
-      "community": 567
+      "community": 568
     },
     {
       "label": "relation-graph-cycle-detector.ts",
@@ -36481,7 +36553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_cycle_detector_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "RelationGraphCycleDetector",
@@ -36489,7 +36561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L11",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".constructor()",
@@ -36497,7 +36569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L12",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_constructor",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".detectCycleInternal()",
@@ -36505,7 +36577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L17",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycleinternal",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".detectCycle()",
@@ -36513,7 +36585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L89",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycle",
-      "community": 464
+      "community": 465
     },
     {
       "label": "relation-graph.ts",
@@ -36785,7 +36857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_traversal_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "RelationGraphTraversal",
@@ -36793,7 +36865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L24",
       "id": "relation_graph_traversal_relationgraphtraversal",
-      "community": 568
+      "community": 569
     },
     {
       "label": ".constructor()",
@@ -36801,7 +36873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L25",
       "id": "relation_graph_traversal_relationgraphtraversal_constructor",
-      "community": 568
+      "community": 569
     },
     {
       "label": ".getRelatedMemories()",
@@ -36809,7 +36881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L30",
       "id": "relation_graph_traversal_relationgraphtraversal_getrelatedmemories",
-      "community": 568
+      "community": 569
     },
     {
       "label": "llm-based-relation-extractor.ts",
@@ -37185,7 +37257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "loadTestDataset()",
@@ -37193,7 +37265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 569
+      "community": 570
     },
     {
       "label": "createBaseSchema()",
@@ -37201,7 +37273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 569
+      "community": 570
     },
     {
       "label": "createTestMemory()",
@@ -37209,7 +37281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 569
+      "community": 570
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -37217,7 +37289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1299
+      "community": 1301
     },
     {
       "label": "relation-graph.spec.ts",
@@ -37225,7 +37297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "createBaseSchema()",
@@ -37233,7 +37305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 697
+      "community": 699
     },
     {
       "label": "createTestMemory()",
@@ -37241,7 +37313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 697
+      "community": 699
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -37249,7 +37321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 919
+      "community": 921
     },
     {
       "label": "createTestMemory()",
@@ -37257,7 +37329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L65",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 919
+      "community": 921
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -37265,7 +37337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createBaseSchema()",
@@ -37273,7 +37345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createTestMemory()",
@@ -37281,7 +37353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createBulkMemories()",
@@ -37289,7 +37361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 570
+      "community": 571
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -37297,7 +37369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 920
+      "community": 922
     },
     {
       "label": "createTestMemory()",
@@ -37305,7 +37377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 920
+      "community": 922
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -37369,7 +37441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1300
+      "community": 1302
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -37377,7 +37449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1301
+      "community": 1303
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -37385,7 +37457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "getMockMementoConfig()",
@@ -37393,7 +37465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 698
+      "community": 700
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -37401,7 +37473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 698
+      "community": 700
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -37409,7 +37481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1302
+      "community": 1304
     },
     {
       "label": "provider-openai.spec.ts",
@@ -37417,7 +37489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1303
+      "community": 1305
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -37425,7 +37497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1304
+      "community": 1306
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -37433,7 +37505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1305
+      "community": 1307
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -37441,7 +37513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -37449,7 +37521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".constructor()",
@@ -37457,7 +37529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".consume()",
@@ -37465,7 +37537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".refill()",
@@ -37473,7 +37545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 465
+      "community": 466
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -37481,7 +37553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -37489,7 +37561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 571
+      "community": 572
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -37497,7 +37569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -37505,7 +37577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 571
+      "community": 572
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -37753,7 +37825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 921
+      "community": 923
     },
     {
       "label": "extract()",
@@ -37761,7 +37833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 921
+      "community": 923
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -37769,7 +37841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "tripleDedupeKey()",
@@ -37777,7 +37849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 699
+      "community": 701
     },
     {
       "label": "mergeTripleLists()",
@@ -37785,7 +37857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 699
+      "community": 701
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -37793,7 +37865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1306
+      "community": 1308
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -38001,7 +38073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1307
+      "community": 1309
     },
     {
       "label": "triple-extraction-llm-pipeline.spec.ts",
@@ -38009,7 +38081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_spec_ts",
-      "community": 1308
+      "community": 1310
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -38017,7 +38089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1309
+      "community": 1311
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -38025,7 +38097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1310
+      "community": 1312
     },
     {
       "label": "triple-extractor.ts",
@@ -38169,7 +38241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "TripleNormalizer",
@@ -38177,7 +38249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 572
+      "community": 573
     },
     {
       "label": ".constructor()",
@@ -38185,7 +38257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 572
+      "community": 573
     },
     {
       "label": ".normalize()",
@@ -38193,7 +38265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 572
+      "community": 573
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -38201,7 +38273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1311
+      "community": 1313
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -38209,7 +38281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -38217,7 +38289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 573
+      "community": 574
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -38225,7 +38297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 573
+      "community": 574
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -38233,7 +38305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 573
+      "community": 574
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -38241,7 +38313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1312
+      "community": 1314
     },
     {
       "label": "triple-parser.ts",
@@ -38249,7 +38321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "TripleParser",
@@ -38257,7 +38329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".parse()",
@@ -38265,7 +38337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".extractJSON()",
@@ -38273,7 +38345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".isValidTriple()",
@@ -38281,7 +38353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 466
+      "community": 467
     },
     {
       "label": "triple-text-chunker.ts",
@@ -38289,7 +38361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 922
+      "community": 924
     },
     {
       "label": "splitTextIntoChunks()",
@@ -38297,7 +38369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 922
+      "community": 924
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -38305,7 +38377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 923
+      "community": 925
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -38313,7 +38385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 923
+      "community": 925
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -38401,7 +38473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1313
+      "community": 1315
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -38409,7 +38481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1314
+      "community": 1316
     },
     {
       "label": "interfaces.spec.ts",
@@ -38417,7 +38489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1315
+      "community": 1317
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -38425,7 +38497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1316
+      "community": 1318
     },
     {
       "label": "triple-parser.spec.ts",
@@ -38433,7 +38505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1317
+      "community": 1319
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -38441,7 +38513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 924
+      "community": 926
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -38449,7 +38521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 924
+      "community": 926
     },
     {
       "label": "extract-relations-openai.ts",
@@ -38457,7 +38529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 925
+      "community": 927
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -38465,7 +38537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 925
+      "community": 927
     },
     {
       "label": "types.ts",
@@ -38473,7 +38545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1318
+      "community": 1320
     },
     {
       "label": "ollama-chat-support.ts",
@@ -38481,7 +38553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "checkOllamaModel()",
@@ -38489,7 +38561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 574
+      "community": 575
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -38497,7 +38569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 574
+      "community": 575
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -38505,7 +38577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 574
+      "community": 575
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -38513,7 +38585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 926
+      "community": 928
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -38521,7 +38593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 926
+      "community": 928
     },
     {
       "label": "provider-selection.ts",
@@ -38529,7 +38601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -38537,7 +38609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 700
+      "community": 702
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -38545,7 +38617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 700
+      "community": 702
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -38553,7 +38625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 927
+      "community": 929
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -38561,7 +38633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 927
+      "community": 929
     },
     {
       "label": "llm-response-parse.ts",
@@ -38569,7 +38641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -38577,7 +38649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 467
+      "community": 468
     },
     {
       "label": "trimToValidJsonObject()",
@@ -38585,7 +38657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 467
+      "community": 468
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -38593,7 +38665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 467
+      "community": 468
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -38601,7 +38673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 467
+      "community": 468
     },
     {
       "label": "types.ts",
@@ -38609,7 +38681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_types_ts",
-      "community": 1319
+      "community": 1321
     },
     {
       "label": "analysis-rules.ts",
@@ -38617,7 +38689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_analysis_rules_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "calculateConfusionMatrix()",
@@ -38625,7 +38697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L12",
       "id": "analysis_rules_calculateconfusionmatrix",
-      "community": 575
+      "community": 576
     },
     {
       "label": "analyzeRelationType()",
@@ -38633,7 +38705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L56",
       "id": "analysis_rules_analyzerelationtype",
-      "community": 575
+      "community": 576
     },
     {
       "label": "analyzeAllRelationTypes()",
@@ -38641,7 +38713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L127",
       "id": "analysis_rules_analyzeallrelationtypes",
-      "community": 575
+      "community": 576
     },
     {
       "label": "metric-rules.ts",
@@ -38697,7 +38769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_quality_metrics_rules_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "emptyTypeMetric()",
@@ -38705,7 +38777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L20",
       "id": "quality_metrics_rules_emptytypemetric",
-      "community": 468
+      "community": 469
     },
     {
       "label": "calculateQualityMetrics()",
@@ -38713,7 +38785,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L31",
       "id": "quality_metrics_rules_calculatequalitymetrics",
-      "community": 468
+      "community": 469
     },
     {
       "label": "validateThresholds()",
@@ -38721,7 +38793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L79",
       "id": "quality_metrics_rules_validatethresholds",
-      "community": 468
+      "community": 469
     },
     {
       "label": "calculateQualityMetricsWithAnalysis()",
@@ -38729,7 +38801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L122",
       "id": "quality_metrics_rules_calculatequalitymetricswithanalysis",
-      "community": 468
+      "community": 469
     },
     {
       "label": "matching-rules.ts",
@@ -38737,7 +38809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_matching_rules_ts",
-      "community": 928
+      "community": 930
     },
     {
       "label": "matchRelations()",
@@ -38745,7 +38817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L7",
       "id": "matching_rules_matchrelations",
-      "community": 928
+      "community": 930
     },
     {
       "label": "types.ts",
@@ -38753,7 +38825,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1320
+      "community": 1322
     },
     {
       "label": "agent-integration-repository.ts",
@@ -38761,7 +38833,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1321
+      "community": 1323
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -38769,7 +38841,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "candidate()",
@@ -38777,7 +38849,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 701
+      "community": 703
     },
     {
       "label": "source()",
@@ -38785,7 +38857,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 701
+      "community": 703
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -38793,7 +38865,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1322
+      "community": 1324
     },
     {
       "label": "agent-integration-error.ts",
@@ -38801,7 +38873,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "AgentIntegrationError",
@@ -38809,7 +38881,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 702
+      "community": 704
     },
     {
       "label": ".constructor()",
@@ -38817,7 +38889,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 702
+      "community": 704
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -38825,7 +38897,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1323
+      "community": 1325
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -38833,7 +38905,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "createSession()",
@@ -38841,7 +38913,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 703
+      "community": 705
     },
     {
       "label": "addObservation()",
@@ -38849,7 +38921,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 703
+      "community": 705
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -39313,7 +39385,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_provenance_graph_ts",
-      "community": 929
+      "community": 931
     },
     {
       "label": "buildProvenanceTrace()",
@@ -39321,7 +39393,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L10",
       "id": "agent_provenance_graph_buildprovenancetrace",
-      "community": 929
+      "community": 931
     },
     {
       "label": "agent-context-injection-service.spec.ts",
@@ -39329,7 +39401,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1324
+      "community": 1326
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -39417,7 +39489,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "addObservation()",
@@ -39425,7 +39497,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 704
+      "community": 706
     },
     {
       "label": "finishAndSummarize()",
@@ -39433,7 +39505,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 704
+      "community": 706
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -39441,7 +39513,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_capture_transaction_ts",
-      "community": 930
+      "community": 932
     },
     {
       "label": "executeAgentCaptureTransaction()",
@@ -39449,7 +39521,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L21",
       "id": "agent_capture_transaction_executeagentcapturetransaction",
-      "community": 930
+      "community": 932
     },
     {
       "label": "agent-lifecycle-service.ts",
@@ -39825,7 +39897,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createMockService()",
@@ -39833,7 +39905,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 576
+      "community": 577
     },
     {
       "label": "resolver()",
@@ -39841,7 +39913,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 576
+      "community": 577
     },
     {
       "label": "priority()",
@@ -39849,7 +39921,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 576
+      "community": 577
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -39857,7 +39929,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1325
+      "community": 1327
     },
     {
       "label": "minilm-embedding-service.ts",
@@ -40873,7 +40945,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1326
+      "community": 1328
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -40881,7 +40953,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1327
+      "community": 1329
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -40889,7 +40961,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "createSchema()",
@@ -40897,7 +40969,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 705
+      "community": 707
     },
     {
       "label": "seedMemoryItem()",
@@ -40905,7 +40977,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 705
+      "community": 707
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -40913,7 +40985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1328
+      "community": 1330
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -40921,7 +40993,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1329
+      "community": 1331
     },
     {
       "label": "embedding-reindex-service.spec.ts",
@@ -40929,7 +41001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-reindex-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_reindex_service_spec_ts",
-      "community": 1330
+      "community": 1332
     },
     {
       "label": "types.ts",
@@ -40937,7 +41009,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_types_ts",
-      "community": 1331
+      "community": 1333
     },
     {
       "label": "migration-execution.ts",
@@ -40945,7 +41017,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_execution_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "safeParseEmbedding()",
@@ -40953,7 +41025,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L24",
       "id": "migration_execution_safeparseembedding",
-      "community": 469
+      "community": 470
     },
     {
       "label": "processMigrationRow()",
@@ -40961,7 +41033,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L38",
       "id": "migration_execution_processmigrationrow",
-      "community": 469
+      "community": 470
     },
     {
       "label": "runMigrationBatchLoop()",
@@ -40969,7 +41041,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L143",
       "id": "migration_execution_runmigrationbatchloop",
-      "community": 469
+      "community": 470
     },
     {
       "label": "finalizeMigrationExecution()",
@@ -40977,7 +41049,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L169",
       "id": "migration_execution_finalizemigrationexecution",
-      "community": 469
+      "community": 470
     },
     {
       "label": "migration-progress.ts",
@@ -41049,7 +41121,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_rollback_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "rollback()",
@@ -41057,7 +41129,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L6",
       "id": "migration_rollback_rollback",
-      "community": 577
+      "community": 578
     },
     {
       "label": "applyRollbackDelete()",
@@ -41065,7 +41137,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L53",
       "id": "migration_rollback_applyrollbackdelete",
-      "community": 577
+      "community": 578
     },
     {
       "label": "applyRollbackRestore()",
@@ -41073,7 +41145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L57",
       "id": "migration_rollback_applyrollbackrestore",
-      "community": 577
+      "community": 578
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -41081,7 +41153,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -41089,7 +41161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 578
+      "community": 579
     },
     {
       "label": ".constructor()",
@@ -41097,7 +41169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 578
+      "community": 579
     },
     {
       "label": ".handle()",
@@ -41105,7 +41177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 578
+      "community": 579
     },
     {
       "label": "performance-alerts.ts",
@@ -41161,7 +41233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "PerformanceStatsTool",
@@ -41169,7 +41241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 579
+      "community": 580
     },
     {
       "label": ".constructor()",
@@ -41177,7 +41249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 579
+      "community": 580
     },
     {
       "label": ".handle()",
@@ -41185,7 +41257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 579
+      "community": 580
     },
     {
       "label": "resolve-error.ts",
@@ -41193,7 +41265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 931
+      "community": 933
     },
     {
       "label": "executeResolveError()",
@@ -41201,7 +41273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 931
+      "community": 933
     },
     {
       "label": "error-stats.ts",
@@ -41209,7 +41281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 932
+      "community": 934
     },
     {
       "label": "executeErrorStats()",
@@ -41217,7 +41289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 932
+      "community": 934
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -41225,7 +41297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1332
+      "community": 1334
     },
     {
       "label": "resolve-error.spec.ts",
@@ -41233,7 +41305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1333
+      "community": 1335
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -41241,7 +41313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 933
+      "community": 935
     },
     {
       "label": "createBaseSchema()",
@@ -41249,7 +41321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 933
+      "community": 935
     },
     {
       "label": "error-stats.spec.ts",
@@ -41257,7 +41329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1334
+      "community": 1336
     },
     {
       "label": "performance-monitor-types.ts",
@@ -41265,7 +41337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_monitor_types_ts",
-      "community": 1335
+      "community": 1337
     },
     {
       "label": "performance-monitor.ts",
@@ -41745,7 +41817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_database_metrics_reader_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "DatabaseMetricsReader",
@@ -41753,7 +41825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L15",
       "id": "database_metrics_reader_databasemetricsreader",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".setDatabase()",
@@ -41761,7 +41833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L18",
       "id": "database_metrics_reader_databasemetricsreader_setdatabase",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".getDatabaseMetrics()",
@@ -41769,7 +41841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L22",
       "id": "database_metrics_reader_databasemetricsreader_getdatabasemetrics",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".optimizeDatabase()",
@@ -41777,7 +41849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L70",
       "id": "database_metrics_reader_databasemetricsreader_optimizedatabase",
-      "community": 470
+      "community": 471
     },
     {
       "label": "performance-alert-service.ts",
@@ -42185,7 +42257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_cpu_usage_tracker_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "CpuUsageTracker",
@@ -42193,7 +42265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L14",
       "id": "cpu_usage_tracker_cpuusagetracker",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".seed()",
@@ -42201,7 +42273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L18",
       "id": "cpu_usage_tracker_cpuusagetracker_seed",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".getLatestSnapshot()",
@@ -42209,7 +42281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L28",
       "id": "cpu_usage_tracker_cpuusagetracker_getlatestsnapshot",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".calculateUsage()",
@@ -42217,7 +42289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L40",
       "id": "cpu_usage_tracker_cpuusagetracker_calculateusage",
-      "community": 471
+      "community": 472
     },
     {
       "label": "runtime-diagnostics-logger.ts",
@@ -42393,7 +42465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_memory_pressure_utils_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "getMemoryPressureDenominatorBytes()",
@@ -42401,7 +42473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L12",
       "id": "memory_pressure_utils_getmemorypressuredenominatorbytes",
-      "community": 580
+      "community": 581
     },
     {
       "label": "memoryRatioToPercent()",
@@ -42409,7 +42481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L27",
       "id": "memory_pressure_utils_memoryratiotopercent",
-      "community": 580
+      "community": 581
     },
     {
       "label": "formatBytes()",
@@ -42417,7 +42489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L38",
       "id": "memory_pressure_utils_formatbytes",
-      "community": 580
+      "community": 581
     },
     {
       "label": "performance-analytics.ts",
@@ -42425,7 +42497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_analytics_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "analyzeTrend()",
@@ -42433,7 +42505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L54",
       "id": "performance_analytics_analyzetrend",
-      "community": 472
+      "community": 473
     },
     {
       "label": "generateRecommendations()",
@@ -42441,7 +42513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L72",
       "id": "performance_analytics_generaterecommendations",
-      "community": 472
+      "community": 473
     },
     {
       "label": "getPerformanceSummary()",
@@ -42449,7 +42521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L101",
       "id": "performance_analytics_getperformancesummary",
-      "community": 472
+      "community": 473
     },
     {
       "label": "getMetricsAnalytics()",
@@ -42457,7 +42529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L130",
       "id": "performance_analytics_getmetricsanalytics",
-      "community": 472
+      "community": 473
     },
     {
       "label": "failure-detector.spec.ts",
@@ -42465,7 +42537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1336
+      "community": 1338
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -42473,7 +42545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1337
+      "community": 1339
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -42481,7 +42553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1338
+      "community": 1340
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -42489,7 +42561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1339
+      "community": 1341
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -42497,7 +42569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "toBytes()",
@@ -42505,7 +42577,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L7",
       "id": "performance_monitor_spec_tobytes",
-      "community": 473
+      "community": 474
     },
     {
       "label": "createMetrics()",
@@ -42513,7 +42585,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L9",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 473
+      "community": 474
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -42521,7 +42593,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L238",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 473
+      "community": 474
     },
     {
       "label": "makeMonitor()",
@@ -42529,7 +42601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L245",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 473
+      "community": 474
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -42537,7 +42609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 934
+      "community": 936
     },
     {
       "label": "restoreEnvValue()",
@@ -42545,7 +42617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 934
+      "community": 936
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -42553,7 +42625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -42561,7 +42633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createQualityMetricsTable()",
@@ -42569,7 +42641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 581
+      "community": 582
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42577,7 +42649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 581
+      "community": 582
     },
     {
       "label": "relation-metrics-collector.ts",
@@ -42585,7 +42657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_relation_metrics_collector_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "isRelationType()",
@@ -42593,7 +42665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L9",
       "id": "relation_metrics_collector_isrelationtype",
-      "community": 474
+      "community": 475
     },
     {
       "label": "RelationMetricsCollector",
@@ -42601,7 +42673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L13",
       "id": "relation_metrics_collector_relationmetricscollector",
-      "community": 474
+      "community": 475
     },
     {
       "label": ".constructor()",
@@ -42609,7 +42681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L14",
       "id": "relation_metrics_collector_relationmetricscollector_constructor",
-      "community": 474
+      "community": 475
     },
     {
       "label": ".collect()",
@@ -42617,7 +42689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L16",
       "id": "relation_metrics_collector_relationmetricscollector_collect",
-      "community": 474
+      "community": 475
     },
     {
       "label": "quality-recorder.ts",
@@ -42689,7 +42761,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 935
+      "community": 937
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42697,7 +42769,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 935
+      "community": 937
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -42777,7 +42849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 936
+      "community": 938
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42785,7 +42857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 936
+      "community": 938
     },
     {
       "label": "category-quality-aggregator.ts",
@@ -42793,7 +42865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_category_quality_aggregator_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "CategoryQualityAggregator",
@@ -42801,7 +42873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L23",
       "id": "category_quality_aggregator_categoryqualityaggregator",
-      "community": 582
+      "community": 583
     },
     {
       "label": ".constructor()",
@@ -42809,7 +42881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L24",
       "id": "category_quality_aggregator_categoryqualityaggregator_constructor",
-      "community": 582
+      "community": 583
     },
     {
       "label": ".collect()",
@@ -42817,7 +42889,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L26",
       "id": "category_quality_aggregator_categoryqualityaggregator_collect",
-      "community": 582
+      "community": 583
     },
     {
       "label": "consolidation-metrics-collector.ts",
@@ -42825,7 +42897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_consolidation_metrics_collector_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "ConsolidationMetricsCollector",
@@ -42833,7 +42905,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L14",
       "id": "consolidation_metrics_collector_consolidationmetricscollector",
-      "community": 583
+      "community": 584
     },
     {
       "label": ".constructor()",
@@ -42841,7 +42913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L15",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_constructor",
-      "community": 583
+      "community": 584
     },
     {
       "label": ".collect()",
@@ -42849,7 +42921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L17",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_collect",
-      "community": 583
+      "community": 584
     },
     {
       "label": "quality-report-renderers.ts",
@@ -42969,7 +43041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -42977,7 +43049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 584
+      "community": 585
     },
     {
       "label": "createQualityMetricsTable()",
@@ -42985,7 +43057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 584
+      "community": 585
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42993,7 +43065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 584
+      "community": 585
     },
     {
       "label": "storage-metrics-collector.ts",
@@ -43001,7 +43073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_storage_metrics_collector_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "StorageMetricsCollector",
@@ -43009,7 +43081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L5",
       "id": "storage_metrics_collector_storagemetricscollector",
-      "community": 585
+      "community": 586
     },
     {
       "label": ".constructor()",
@@ -43017,7 +43089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L6",
       "id": "storage_metrics_collector_storagemetricscollector_constructor",
-      "community": 585
+      "community": 586
     },
     {
       "label": ".collect()",
@@ -43025,7 +43097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L8",
       "id": "storage_metrics_collector_storagemetricscollector_collect",
-      "community": 585
+      "community": 586
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -43033,7 +43105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1340
+      "community": 1342
     },
     {
       "label": "quality-assurance-service.ts",
@@ -43233,7 +43305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_search_metrics_collector_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "calculateMRR()",
@@ -43241,7 +43313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L31",
       "id": "search_metrics_collector_calculatemrr",
-      "community": 475
+      "community": 476
     },
     {
       "label": "SearchMetricsCollector",
@@ -43249,7 +43321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L64",
       "id": "search_metrics_collector_searchmetricscollector",
-      "community": 475
+      "community": 476
     },
     {
       "label": ".constructor()",
@@ -43257,7 +43329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L65",
       "id": "search_metrics_collector_searchmetricscollector_constructor",
-      "community": 475
+      "community": 476
     },
     {
       "label": ".collect()",
@@ -43265,7 +43337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L67",
       "id": "search_metrics_collector_searchmetricscollector_collect",
-      "community": 475
+      "community": 476
     },
     {
       "label": "quality-evaluator.ts",
@@ -43345,7 +43417,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_types_ts",
-      "community": 1341
+      "community": 1343
     },
     {
       "label": "quality-recorder.spec.ts",
@@ -43353,7 +43425,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -43361,7 +43433,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 586
+      "community": 587
     },
     {
       "label": "createQualityMetricsTable()",
@@ -43369,7 +43441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 586
+      "community": 587
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43377,7 +43449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 586
+      "community": 587
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -43569,7 +43641,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1342
+      "community": 1344
     },
     {
       "label": "base-tool.ts",
@@ -43865,7 +43937,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 937
+      "community": 939
     },
     {
       "label": "testBootstrapIntegration()",
@@ -43873,7 +43945,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 937
+      "community": 939
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -43881,7 +43953,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 938
+      "community": 940
     },
     {
       "label": "measureRecall()",
@@ -43889,7 +43961,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 938
+      "community": 940
     },
     {
       "label": "test-embedding.ts",
@@ -43897,7 +43969,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 939
+      "community": 941
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -43905,7 +43977,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 939
+      "community": 941
     },
     {
       "label": "test-tool-consistency.ts",
@@ -43913,7 +43985,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "compareToolResults()",
@@ -43921,7 +43993,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 706
+      "community": 708
     },
     {
       "label": "testToolConsistency()",
@@ -43929,7 +44001,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 706
+      "community": 708
     },
     {
       "label": "test-quality-assurance.ts",
@@ -43937,7 +44009,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "createQualityTables()",
@@ -43945,7 +44017,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 707
+      "community": 709
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -43953,7 +44025,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 707
+      "community": 709
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -43961,7 +44033,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "PerformanceBenchmark",
@@ -43969,7 +44041,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".measureOperation()",
@@ -43977,7 +44049,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".getResults()",
@@ -43985,7 +44057,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".getSummary()",
@@ -43993,7 +44065,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 476
+      "community": 477
     },
     {
       "label": "test-search.ts",
@@ -44001,7 +44073,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 940
+      "community": 942
     },
     {
       "label": "testSearchFunctionality()",
@@ -44009,7 +44081,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 940
+      "community": 942
     },
     {
       "label": "test-forgetting.ts",
@@ -44017,7 +44089,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 941
+      "community": 943
     },
     {
       "label": "testForgettingFunctionality()",
@@ -44025,7 +44097,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 941
+      "community": 943
     },
     {
       "label": "mock-database.spec.ts",
@@ -44033,7 +44105,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1343
+      "community": 1345
     },
     {
       "label": "test-m1-completion.ts",
@@ -44041,7 +44113,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 942
+      "community": 944
     },
     {
       "label": "testM1Completion()",
@@ -44049,7 +44121,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 942
+      "community": 944
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -44057,7 +44129,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 943
+      "community": 945
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -44065,7 +44137,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 943
+      "community": 945
     },
     {
       "label": "vitest.setup.ts",
@@ -44073,7 +44145,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1344
+      "community": 1346
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -44081,7 +44153,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 944
+      "community": 946
     },
     {
       "label": "parseItems()",
@@ -44089,7 +44161,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 944
+      "community": 946
     },
     {
       "label": "test-memory-resource.ts",
@@ -44097,7 +44169,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "setupResourceHandlers()",
@@ -44105,7 +44177,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 708
+      "community": 710
     },
     {
       "label": "createTestMemories()",
@@ -44113,7 +44185,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 708
+      "community": 710
     },
     {
       "label": "test-regression.ts",
@@ -44121,7 +44193,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 945
+      "community": 947
     },
     {
       "label": "testRegression()",
@@ -44129,7 +44201,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 945
+      "community": 947
     },
     {
       "label": "test-anchor-system.ts",
@@ -44193,7 +44265,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1345
+      "community": 1347
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -44265,7 +44337,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 946
+      "community": 948
     },
     {
       "label": "testSingleProviderRegression()",
@@ -44273,7 +44345,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 946
+      "community": 948
     },
     {
       "label": "visualize-recency.ts",
@@ -44337,7 +44409,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1346
+      "community": 1348
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -44401,7 +44473,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 947
+      "community": 949
     },
     {
       "label": "constructor()",
@@ -44409,7 +44481,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 947
+      "community": 949
     },
     {
       "label": "mock-database.ts",
@@ -44641,7 +44713,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1347
+      "community": 1349
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -44649,7 +44721,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "telemetryDb()",
@@ -44657,7 +44729,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 587
+      "community": 588
     },
     {
       "label": "percentile95()",
@@ -44665,7 +44737,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 587
+      "community": 588
     },
     {
       "label": "run()",
@@ -44673,7 +44745,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 587
+      "community": 588
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -44681,7 +44753,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 948
+      "community": 950
     },
     {
       "label": "createTestMemories()",
@@ -44689,7 +44761,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L289",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 948
+      "community": 950
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -44697,7 +44769,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 949
+      "community": 951
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -44705,7 +44777,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 949
+      "community": 951
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -44713,7 +44785,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1348
+      "community": 1350
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -44721,7 +44793,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 950
+      "community": 952
     },
     {
       "label": "seedCluster()",
@@ -44729,7 +44801,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 950
+      "community": 952
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -44737,7 +44809,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "readSource()",
@@ -44745,7 +44817,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 709
+      "community": 711
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -44753,7 +44825,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 709
+      "community": 711
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -44761,7 +44833,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -44769,7 +44841,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 588
+      "community": 589
     },
     {
       "label": "normalizeTags()",
@@ -44777,7 +44849,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 588
+      "community": 589
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -44785,7 +44857,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 588
+      "community": 589
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -44793,7 +44865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 951
+      "community": 953
     },
     {
       "label": "writeFixtureDir()",
@@ -44801,7 +44873,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 951
+      "community": 953
     },
     {
       "label": "search-quality-metrics.ts",
@@ -44897,7 +44969,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1349
+      "community": 1351
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -44961,7 +45033,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "mulberry32()",
@@ -44969,7 +45041,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L22",
       "id": "benchmark_search_database_mulberry32",
-      "community": 477
+      "community": 478
     },
     {
       "label": "normalizeMemoryType()",
@@ -44977,7 +45049,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L33",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 477
+      "community": 478
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -44985,7 +45057,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L50",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 477
+      "community": 478
     },
     {
       "label": "seedOneCorpusRow()",
@@ -44993,7 +45065,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L134",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 477
+      "community": 478
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -45001,7 +45073,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1350
+      "community": 1352
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -45009,7 +45081,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1351
+      "community": 1353
     },
     {
       "label": "test-database.ts",
@@ -45041,7 +45113,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 952
+      "community": 954
     },
     {
       "label": "mergeCandidateIds()",
@@ -45049,7 +45121,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 952
+      "community": 954
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -45057,7 +45129,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -45065,7 +45137,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 710
+      "community": 712
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -45073,7 +45145,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 710
+      "community": 712
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -45081,7 +45153,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1352
+      "community": 1354
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -45089,7 +45161,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1353
+      "community": 1355
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -45289,7 +45361,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1354
+      "community": 1356
     },
     {
       "label": "query-counter.ts",
@@ -45297,7 +45369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "extractQueryType()",
@@ -45305,7 +45377,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 589
+      "community": 590
     },
     {
       "label": "isExcluded()",
@@ -45313,7 +45385,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 589
+      "community": 590
     },
     {
       "label": "createQueryCounter()",
@@ -45321,7 +45393,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 589
+      "community": 590
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -45329,7 +45401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_ts",
-      "community": 1355
+      "community": 1357
     },
     {
       "label": "top-k-retention.ts",
@@ -45337,7 +45409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_top_k_retention_ts",
-      "community": 953
+      "community": 955
     },
     {
       "label": "calculateTopKRetention()",
@@ -45345,7 +45417,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L29",
       "id": "top_k_retention_calculatetopkretention",
-      "community": 953
+      "community": 955
     },
     {
       "label": "types.ts",
@@ -45353,7 +45425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_types_ts",
-      "community": 1356
+      "community": 1358
     },
     {
       "label": "kendall-tau.ts",
@@ -45409,7 +45481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spearman_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "calculateSpearmanRho()",
@@ -45417,7 +45489,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L27",
       "id": "spearman_calculatespearmanrho",
-      "community": 711
+      "community": 713
     },
     {
       "label": "calculateRanks()",
@@ -45425,7 +45497,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L81",
       "id": "spearman_calculateranks",
-      "community": 711
+      "community": 713
     },
     {
       "label": "report-comparison.ts",
@@ -45729,7 +45801,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 954
+      "community": 956
     },
     {
       "label": "copyDir()",
@@ -45737,7 +45809,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 954
+      "community": 956
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -45745,7 +45817,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 955
+      "community": 957
     },
     {
       "label": "readRootPackageJson()",
@@ -45753,7 +45825,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 955
+      "community": 957
     },
     {
       "label": "memory-export-import.spec.ts",
@@ -45761,7 +45833,7 @@
       "source_file": "tests/memory-export-import.spec.ts",
       "source_location": "L1",
       "id": "tests_memory_export_import_spec_ts",
-      "community": 1357
+      "community": 1359
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -45769,7 +45841,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 956
+      "community": 958
     },
     {
       "label": "readJson()",
@@ -45777,7 +45849,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 956
+      "community": 958
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -45785,7 +45857,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 957
+      "community": 959
     },
     {
       "label": "readWorkflow()",
@@ -45793,7 +45865,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 957
+      "community": 959
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -45865,7 +45937,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "readStaticFile()",
@@ -45873,7 +45945,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 712
+      "community": 714
     },
     {
       "label": "getFunctionMetrics()",
@@ -45881,7 +45953,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L9",
       "id": "static_design_contracts_spec_getfunctionmetrics",
-      "community": 712
+      "community": 714
     },
     {
       "label": "anchor-map.e2e.ts",
@@ -45889,7 +45961,7 @@
       "source_file": "tests/e2e/dashboard/anchor-map.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_anchor_map_e2e_ts",
-      "community": 1358
+      "community": 1360
     },
     {
       "label": "agent-sessions.e2e.ts",
@@ -45897,7 +45969,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_e2e_ts",
-      "community": 1359
+      "community": 1361
     },
     {
       "label": "agent-sessions.fixtures.ts",
@@ -45961,7 +46033,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 958
+      "community": 960
     },
     {
       "label": "extractFencedBlocks()",
@@ -45969,7 +46041,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 958
+      "community": 960
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -46041,7 +46113,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "parseArgs()",
@@ -46049,7 +46121,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 590
+      "community": 591
     },
     {
       "label": "printHelp()",
@@ -46057,7 +46129,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 590
+      "community": 591
     },
     {
       "label": "main()",
@@ -46065,7 +46137,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 590
+      "community": 591
     },
     {
       "label": "check-magic-numbers.ts",
@@ -46153,7 +46225,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 959
+      "community": 961
     },
     {
       "label": "shouldInclude()",
@@ -46161,7 +46233,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 959
+      "community": 961
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -46169,7 +46241,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 713
+      "community": 715
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -46177,7 +46249,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 713
+      "community": 715
     },
     {
       "label": "readTarString()",
@@ -46185,7 +46257,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 713
+      "community": 715
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -46249,7 +46321,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 960
+      "community": 962
     },
     {
       "label": "fixMigration()",
@@ -46257,7 +46329,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 960
+      "community": 962
     },
     {
       "label": "sync-root-server-dist.js",
@@ -46265,7 +46337,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1360
+      "community": 1362
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -46481,7 +46553,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "parseArgs()",
@@ -46489,7 +46561,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 591
+      "community": 592
     },
     {
       "label": "printHelp()",
@@ -46497,7 +46569,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 591
+      "community": 592
     },
     {
       "label": "main()",
@@ -46505,7 +46577,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 591
+      "community": 592
     },
     {
       "label": "check-path-traversal.ts",
@@ -46705,7 +46777,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "buildLongMemEvalDatasetUrl()",
@@ -46713,7 +46785,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L19",
       "id": "acquire_longmemeval_buildlongmemevaldataseturl",
-      "community": 592
+      "community": 593
     },
     {
       "label": "acquireLongMemEval()",
@@ -46721,7 +46793,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L29",
       "id": "acquire_longmemeval_acquirelongmemeval",
-      "community": 592
+      "community": 593
     },
     {
       "label": "main()",
@@ -46729,7 +46801,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L65",
       "id": "acquire_longmemeval_main",
-      "community": 592
+      "community": 593
     },
     {
       "label": "agent-memory-benchmark.ts",
@@ -47017,7 +47089,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "parseArgs()",
@@ -47025,7 +47097,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 478
+      "community": 479
     },
     {
       "label": "printHelp()",
@@ -47033,7 +47105,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 478
+      "community": 479
     },
     {
       "label": "printThresholds()",
@@ -47041,7 +47113,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 478
+      "community": 479
     },
     {
       "label": "main()",
@@ -47049,7 +47121,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 478
+      "community": 479
     },
     {
       "label": "simple-update.js",
@@ -47057,7 +47129,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 961
+      "community": 963
     },
     {
       "label": "updateEmbeddings()",
@@ -47065,7 +47137,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 961
+      "community": 963
     },
     {
       "label": "memory-export.ts",
@@ -47073,7 +47145,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L1",
       "id": "scripts_memory_export_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "parseArgs()",
@@ -47081,7 +47153,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L20",
       "id": "memory_export_parseargs",
-      "community": 593
+      "community": 594
     },
     {
       "label": "printHelp()",
@@ -47089,7 +47161,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L47",
       "id": "memory_export_printhelp",
-      "community": 593
+      "community": 594
     },
     {
       "label": "main()",
@@ -47097,7 +47169,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L65",
       "id": "memory_export_main",
-      "community": 593
+      "community": 594
     },
     {
       "label": "agent-smoke-matrix.spec.ts",
@@ -47105,7 +47177,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "temporaryRoot()",
@@ -47113,7 +47185,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 714
+      "community": 716
     },
     {
       "label": "dependencies()",
@@ -47121,7 +47193,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 714
+      "community": 716
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -47217,7 +47289,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L1",
       "id": "scripts_reindex_embeddings_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "option()",
@@ -47225,7 +47297,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L3",
       "id": "reindex_embeddings_option",
-      "community": 715
+      "community": 717
     },
     {
       "label": "main()",
@@ -47233,7 +47305,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L8",
       "id": "reindex_embeddings_main",
-      "community": 715
+      "community": 717
     },
     {
       "label": "check-pii-masking.ts",
@@ -47313,7 +47385,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 962
+      "community": 964
     },
     {
       "label": "analyzeEmbeddings()",
@@ -47321,7 +47393,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 962
+      "community": 964
     },
     {
       "label": "test-docker.js",
@@ -47329,7 +47401,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 716
+      "community": 718
     },
     {
       "label": "fetchJson()",
@@ -47337,7 +47409,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L7",
       "id": "test_docker_fetchjson",
-      "community": 716
+      "community": 718
     },
     {
       "label": "testDockerServer()",
@@ -47345,7 +47417,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L23",
       "id": "test_docker_testdockerserver",
-      "community": 716
+      "community": 718
     },
     {
       "label": "pack-with-restore.js",
@@ -47353,7 +47425,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1361
+      "community": 1363
     },
     {
       "label": "run-migration.js",
@@ -47361,7 +47433,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 963
+      "community": 965
     },
     {
       "label": "runMigration()",
@@ -47369,7 +47441,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 963
+      "community": 965
     },
     {
       "label": "safe-migration.js",
@@ -47377,7 +47449,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 964
+      "community": 966
     },
     {
       "label": "safeMigration()",
@@ -47385,7 +47457,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 964
+      "community": 966
     },
     {
       "label": "generate-ground-truth.ts",
@@ -47449,7 +47521,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 965
+      "community": 967
     },
     {
       "label": "saveWorkMemory()",
@@ -47457,7 +47529,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 965
+      "community": 967
     },
     {
       "label": "check-file-sizes.ts",
@@ -47697,7 +47769,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1362
+      "community": 1364
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -47705,7 +47777,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 966
+      "community": 968
     },
     {
       "label": "main()",
@@ -47713,7 +47785,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 966
+      "community": 968
     },
     {
       "label": "agent-integration-release-gate.spec.ts",
@@ -47721,7 +47793,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_integration_release_gate_spec_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "createDatabase()",
@@ -47729,7 +47801,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L8",
       "id": "agent_integration_release_gate_spec_createdatabase",
-      "community": 594
+      "community": 595
     },
     {
       "label": "passingEvidence()",
@@ -47737,7 +47809,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L49",
       "id": "agent_integration_release_gate_spec_passingevidence",
-      "community": 594
+      "community": 595
     },
     {
       "label": "seedPassingDatabase()",
@@ -47745,7 +47817,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L64",
       "id": "agent_integration_release_gate_spec_seedpassingdatabase",
-      "community": 594
+      "community": 595
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -47753,7 +47825,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "parseArgs()",
@@ -47761,7 +47833,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 595
+      "community": 596
     },
     {
       "label": "printHelp()",
@@ -47769,7 +47841,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 595
+      "community": 596
     },
     {
       "label": "main()",
@@ -47777,7 +47849,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 595
+      "community": 596
     },
     {
       "label": "check-debt-markers.ts",
@@ -47833,7 +47905,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1363
+      "community": 1365
     },
     {
       "label": "forgetting-events-query.ts",
@@ -47841,7 +47913,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L1",
       "id": "scripts_forgetting_events_query_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "parseArgs()",
@@ -47849,7 +47921,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L20",
       "id": "forgetting_events_query_parseargs",
-      "community": 596
+      "community": 597
     },
     {
       "label": "printHelp()",
@@ -47857,7 +47929,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L49",
       "id": "forgetting_events_query_printhelp",
-      "community": 596
+      "community": 597
     },
     {
       "label": "main()",
@@ -47865,7 +47937,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L65",
       "id": "forgetting_events_query_main",
-      "community": 596
+      "community": 597
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -47873,7 +47945,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1364
+      "community": 1366
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -47881,7 +47953,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "getTriggerInfo()",
@@ -47889,7 +47961,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 479
+      "community": 480
     },
     {
       "label": "fixTriggers()",
@@ -47897,7 +47969,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 479
+      "community": 480
     },
     {
       "label": "checkMigrationVersion()",
@@ -47905,7 +47977,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 479
+      "community": 480
     },
     {
       "label": "main()",
@@ -47913,7 +47985,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 479
+      "community": 480
     },
     {
       "label": "simple-migrate.js",
@@ -47921,7 +47993,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 967
+      "community": 969
     },
     {
       "label": "analyzeEmbeddings()",
@@ -47929,7 +48001,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 967
+      "community": 969
     },
     {
       "label": "memory-import.ts",
@@ -47937,7 +48009,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L1",
       "id": "scripts_memory_import_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "parseArgs()",
@@ -47945,7 +48017,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L27",
       "id": "memory_import_parseargs",
-      "community": 597
+      "community": 598
     },
     {
       "label": "printHelp()",
@@ -47953,7 +48025,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L60",
       "id": "memory_import_printhelp",
-      "community": 597
+      "community": 598
     },
     {
       "label": "main()",
@@ -47961,7 +48033,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L79",
       "id": "memory_import_main",
-      "community": 597
+      "community": 598
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -47969,7 +48041,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 968
+      "community": 970
     },
     {
       "label": "fixVectorDimensions()",
@@ -47977,7 +48049,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 968
+      "community": 970
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -47985,7 +48057,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "formatCategoryReportLine()",
@@ -47993,7 +48065,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 598
+      "community": 599
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -48001,7 +48073,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 598
+      "community": 599
     },
     {
       "label": "main()",
@@ -48009,7 +48081,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 598
+      "community": 599
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -48017,7 +48089,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "loadVecExtension()",
@@ -48025,7 +48097,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 717
+      "community": 719
     },
     {
       "label": "fixTfidfDimensions()",
@@ -48033,7 +48105,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 717
+      "community": 719
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -48041,7 +48113,7 @@
       "source_file": "scripts/longmemeval-validation.spec.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_spec_ts",
-      "community": 1365
+      "community": 1367
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -48049,7 +48121,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 969
+      "community": 971
     },
     {
       "label": "runUpdateMigration()",
@@ -48057,7 +48129,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 969
+      "community": 971
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -48065,7 +48137,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "reappearanceRate()",
@@ -48073,7 +48145,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 718
+      "community": 720
     },
     {
       "label": "main()",
@@ -48081,7 +48153,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 718
+      "community": 720
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -48089,7 +48161,7 @@
       "source_file": "scripts/acquire-longmemeval.spec.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_spec_ts",
-      "community": 1366
+      "community": 1368
     },
     {
       "label": "regenerate-embeddings.js",
@@ -48097,7 +48169,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 970
+      "community": 972
     },
     {
       "label": "regenerateEmbeddings()",
@@ -48105,7 +48177,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 970
+      "community": 972
     },
     {
       "label": "generate-relation-report.ts",
@@ -48257,7 +48329,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 971
+      "community": 973
     },
     {
       "label": "sampleReport()",
@@ -48265,7 +48337,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 971
+      "community": 973
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -48273,7 +48345,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1367
+      "community": 1369
     },
     {
       "label": "debug-embeddings.js",
@@ -48281,7 +48353,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 972
+      "community": 974
     },
     {
       "label": "debugEmbeddings()",
@@ -48289,7 +48361,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 972
+      "community": 974
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -48297,7 +48369,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1368
+      "community": 1370
     },
     {
       "label": "longmemeval-validation.ts",
@@ -48305,7 +48377,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_ts",
-      "community": 122
+      "community": 123
     },
     {
       "label": "aggregateJudgeResults()",
@@ -48313,7 +48385,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L41",
       "id": "longmemeval_validation_aggregatejudgeresults",
-      "community": 122
+      "community": 123
     },
     {
       "label": "runLongMemEvalValidation()",
@@ -48321,7 +48393,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L73",
       "id": "longmemeval_validation_runlongmemevalvalidation",
-      "community": 122
+      "community": 123
     },
     {
       "label": "assertJudgeResults()",
@@ -48329,7 +48401,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L152",
       "id": "longmemeval_validation_assertjudgeresults",
-      "community": 122
+      "community": 123
     },
     {
       "label": "createManifest()",
@@ -48337,7 +48409,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L186",
       "id": "longmemeval_validation_createmanifest",
-      "community": 122
+      "community": 123
     },
     {
       "label": "graphRrfStatus()",
@@ -48345,7 +48417,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L216",
       "id": "longmemeval_validation_graphrrfstatus",
-      "community": 122
+      "community": 123
     },
     {
       "label": "writeArtifacts()",
@@ -48353,7 +48425,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L223",
       "id": "longmemeval_validation_writeartifacts",
-      "community": 122
+      "community": 123
     },
     {
       "label": "readJsonLines()",
@@ -48361,7 +48433,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L255",
       "id": "longmemeval_validation_readjsonlines",
-      "community": 122
+      "community": 123
     },
     {
       "label": "writeJson()",
@@ -48369,7 +48441,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L263",
       "id": "longmemeval_validation_writejson",
-      "community": 122
+      "community": 123
     },
     {
       "label": "sha256()",
@@ -48377,7 +48449,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L267",
       "id": "longmemeval_validation_sha256",
-      "community": 122
+      "community": 123
     },
     {
       "label": "parseCli()",
@@ -48385,7 +48457,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L271",
       "id": "longmemeval_validation_parsecli",
-      "community": 122
+      "community": 123
     },
     {
       "label": "main()",
@@ -48393,7 +48465,7 @@
       "source_file": "scripts/longmemeval-validation.ts",
       "source_location": "L292",
       "id": "longmemeval_validation_main",
-      "community": 122
+      "community": 123
     },
     {
       "label": "tune-weights.ts",
@@ -48457,7 +48529,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 599
+      "community": 600
     },
     {
       "label": "log()",
@@ -48465,7 +48537,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 599
+      "community": 600
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -48473,7 +48545,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 599
+      "community": 600
     },
     {
       "label": "main()",
@@ -48481,7 +48553,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 599
+      "community": 600
     },
     {
       "label": "agent-smoke-matrix.ts",
@@ -48665,7 +48737,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L1",
       "id": "scripts_tune_report_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "parseReportArgs()",
@@ -48673,7 +48745,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L10",
       "id": "tune_report_parsereportargs",
-      "community": 600
+      "community": 601
     },
     {
       "label": "findLatestRunDir()",
@@ -48681,7 +48753,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L20",
       "id": "tune_report_findlatestrundir",
-      "community": 600
+      "community": 601
     },
     {
       "label": "main()",
@@ -48689,7 +48761,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L61",
       "id": "tune_report_main",
-      "community": 600
+      "community": 601
     },
     {
       "label": "mcp-http-client.js",
@@ -48929,7 +49001,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 973
+      "community": 975
     },
     {
       "label": "backupEmbeddings()",
@@ -48937,7 +49009,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 973
+      "community": 975
     },
     {
       "label": "count-any-types.ts",
@@ -49153,7 +49225,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 974
+      "community": 976
     },
     {
       "label": "makeRng()",
@@ -49161,7 +49233,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 974
+      "community": 976
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -49169,7 +49241,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1369
+      "community": 1371
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -49177,7 +49249,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1370
+      "community": 1372
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -49185,7 +49257,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1371
+      "community": 1373
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -49193,7 +49265,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 975
+      "community": 977
     },
     {
       "label": "jsonEmbedding()",
@@ -49201,7 +49273,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 975
+      "community": 977
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -49209,7 +49281,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1372
+      "community": 1374
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -49217,7 +49289,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1373
+      "community": 1375
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -49225,7 +49297,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1374
+      "community": 1376
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -49233,7 +49305,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 976
+      "community": 978
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -49241,7 +49313,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 976
+      "community": 978
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -49249,7 +49321,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1375
+      "community": 1377
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -49257,7 +49329,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 977
+      "community": 979
     },
     {
       "label": "jsonEmbedding()",
@@ -49265,7 +49337,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 977
+      "community": 979
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -49273,7 +49345,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 978
+      "community": 980
     },
     {
       "label": "main()",
@@ -49281,7 +49353,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 978
+      "community": 980
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -49289,7 +49361,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 979
+      "community": 981
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -49297,7 +49369,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 979
+      "community": 981
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -49305,7 +49377,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "createBackup()",
@@ -49313,7 +49385,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 719
+      "community": 721
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -49321,7 +49393,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 719
+      "community": 721
     },
     {
       "label": "restore-legacy.ps1",
@@ -49329,7 +49401,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1376
+      "community": 1378
     },
     {
       "label": "check-retry-usage.ts",
@@ -49449,7 +49521,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 980
+      "community": 982
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -49457,7 +49529,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 980
+      "community": 982
     },
     {
       "label": "check-no-console-violations.ts",
@@ -49553,7 +49625,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 981
+      "community": 983
     },
     {
       "label": "fixVecTableDimensions()",
@@ -49561,7 +49633,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 981
+      "community": 983
     },
     {
       "label": "sources.ts",
@@ -49649,7 +49721,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1377
+      "community": 1379
     },
     {
       "label": "issue-body.ts",
@@ -49657,7 +49729,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "startMarker()",
@@ -49665,7 +49737,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 601
+      "community": 602
     },
     {
       "label": "renderManagedIssueBody()",
@@ -49673,7 +49745,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 601
+      "community": 602
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -49681,7 +49753,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 601
+      "community": 602
     },
     {
       "label": "fingerprint.ts",
@@ -49689,7 +49761,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 720
+      "community": 722
     },
     {
       "label": "normalizeMessage()",
@@ -49697,7 +49769,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 720
+      "community": 722
     },
     {
       "label": "createFingerprint()",
@@ -49705,7 +49777,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 720
+      "community": 722
     },
     {
       "label": "sanitizer.ts",
@@ -49713,7 +49785,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "limitUtf8Bytes()",
@@ -49721,7 +49793,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 721
+      "community": 723
     },
     {
       "label": "sanitizeExcerpt()",
@@ -49729,7 +49801,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 721
+      "community": 723
     },
     {
       "label": "parsers.ts",
@@ -49737,7 +49809,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "inferLevel()",
@@ -49745,7 +49817,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 602
+      "community": 603
     },
     {
       "label": "parseAppLogLine()",
@@ -49753,7 +49825,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 602
+      "community": 603
     },
     {
       "label": "parseJsonlRecord()",
@@ -49761,7 +49833,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 602
+      "community": 603
     },
     {
       "label": "index.ts",
@@ -49769,7 +49841,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -49777,7 +49849,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 603
+      "community": 604
     },
     {
       "label": "createMonitorRuntime()",
@@ -49785,7 +49857,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 603
+      "community": 604
     },
     {
       "label": "runForever()",
@@ -49793,7 +49865,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 603
+      "community": 604
     },
     {
       "label": "promotion.ts",
@@ -49801,7 +49873,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 982
+      "community": 984
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -49809,7 +49881,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 982
+      "community": 984
     },
     {
       "label": "state-store.ts",
@@ -50089,7 +50161,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1378
+      "community": 1380
     },
     {
       "label": "issue-body.spec.ts",
@@ -50097,7 +50169,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1379
+      "community": 1381
     },
     {
       "label": "github-client.spec.ts",
@@ -50105,7 +50177,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1380
+      "community": 1382
     },
     {
       "label": "config.spec.ts",
@@ -50113,7 +50185,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1381
+      "community": 1383
     },
     {
       "label": "detectors.spec.ts",
@@ -50121,7 +50193,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1382
+      "community": 1384
     },
     {
       "label": "sources.spec.ts",
@@ -50129,7 +50201,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1383
+      "community": 1385
     },
     {
       "label": "parsers.spec.ts",
@@ -50137,7 +50209,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1384
+      "community": 1386
     },
     {
       "label": "monitor.spec.ts",
@@ -50145,7 +50217,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 983
+      "community": 985
     },
     {
       "label": "config()",
@@ -50153,7 +50225,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 983
+      "community": 985
     },
     {
       "label": "fingerprint.spec.ts",
@@ -50161,7 +50233,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1385
+      "community": 1387
     },
     {
       "label": "state-store.spec.ts",
@@ -50169,7 +50241,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1386
+      "community": 1388
     },
     {
       "label": "sanitizer.spec.ts",
@@ -50177,7 +50249,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1387
+      "community": 1389
     },
     {
       "label": "entrypoint.spec.ts",
@@ -50185,7 +50257,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1388
+      "community": 1390
     },
     {
       "label": "index.ts",
@@ -50193,7 +50265,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "main()",
@@ -50201,7 +50273,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 604
+      "community": 605
     },
     {
       "label": "index.ts",
@@ -50209,7 +50281,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "runExample()",
@@ -50217,7 +50289,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 604
+      "community": 605
     },
     {
       "label": "index.spec.ts",
@@ -50225,7 +50297,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1389
+      "community": 1391
     },
     {
       "label": "review-candidates-panel-poll-fetch.js",
@@ -50233,7 +50305,7 @@
       "source_file": "static/js/review-candidates-panel-poll-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_fetch_js",
-      "community": 1390
+      "community": 1392
     },
     {
       "label": "memento-admin-fetch.js",
@@ -50297,7 +50369,7 @@
       "source_file": "static/js/embedding-map-state.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_state_js",
-      "community": 1391
+      "community": 1393
     },
     {
       "label": "memory-evolution-demo-shell-render.js",
@@ -50305,7 +50377,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1392
+      "community": 1394
     },
     {
       "label": "dashboard-auth.js",
@@ -50313,7 +50385,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_js",
-      "community": 1393
+      "community": 1395
     },
     {
       "label": "anchor-map.js",
@@ -50321,7 +50393,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_js",
-      "community": 605
+      "community": 606
     },
     {
       "label": "initializeMap()",
@@ -50329,7 +50401,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L14",
       "id": "anchor_map_initializemap",
-      "community": 605
+      "community": 606
     },
     {
       "label": "onSearchResultClick()",
@@ -50337,7 +50409,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L52",
       "id": "anchor_map_onsearchresultclick",
-      "community": 605
+      "community": 606
     },
     {
       "label": "setupEventListeners()",
@@ -50345,7 +50417,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L68",
       "id": "anchor_map_setupeventlisteners",
-      "community": 605
+      "community": 606
     },
     {
       "label": "dashboard-auth-error.js",
@@ -50353,7 +50425,7 @@
       "source_file": "static/js/dashboard-auth-error.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_error_js",
-      "community": 1394
+      "community": 1396
     },
     {
       "label": "embedding-map-fetch.js",
@@ -50361,7 +50433,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_js",
-      "community": 722
+      "community": 724
     },
     {
       "label": "buildEmbeddingMapQuery()",
@@ -50369,7 +50441,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L12",
       "id": "embedding_map_fetch_buildembeddingmapquery",
-      "community": 722
+      "community": 724
     },
     {
       "label": "handleEmbeddingMapResponse()",
@@ -50377,7 +50449,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_handleembeddingmapresponse",
-      "community": 722
+      "community": 724
     },
     {
       "label": "review-candidates-panel-poll.js",
@@ -50385,7 +50457,7 @@
       "source_file": "static/js/review-candidates-panel-poll.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_js",
-      "community": 1395
+      "community": 1397
     },
     {
       "label": "review-candidates-panel-poll-notify-os.js",
@@ -50393,7 +50465,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_notify_os_js",
-      "community": 984
+      "community": 986
     },
     {
       "label": "tryOsNotifyReviewQueueGrowth()",
@@ -50401,7 +50473,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_notify_os_tryosnotifyreviewqueuegrowth",
-      "community": 984
+      "community": 986
     },
     {
       "label": "graph-detail.js",
@@ -50409,7 +50481,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L1",
       "id": "static_js_graph_detail_js",
-      "community": 606
+      "community": 607
     },
     {
       "label": "getTypeBadgeClass()",
@@ -50417,7 +50489,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L12",
       "id": "graph_detail_gettypebadgeclass",
-      "community": 606
+      "community": 607
     },
     {
       "label": "buildTagsHtml()",
@@ -50425,7 +50497,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L19",
       "id": "graph_detail_buildtagshtml",
-      "community": 606
+      "community": 607
     },
     {
       "label": "buildDetailRows()",
@@ -50433,7 +50505,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L26",
       "id": "graph_detail_builddetailrows",
-      "community": 606
+      "community": 607
     },
     {
       "label": "review-candidates-panel-render-actions.js",
@@ -50441,7 +50513,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_actions_js",
-      "community": 607
+      "community": 608
     },
     {
       "label": "showActionToast()",
@@ -50449,7 +50521,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L16",
       "id": "review_candidates_panel_render_actions_showactiontoast",
-      "community": 607
+      "community": 608
     },
     {
       "label": "showError()",
@@ -50457,7 +50529,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L33",
       "id": "review_candidates_panel_render_actions_showerror",
-      "community": 607
+      "community": 608
     },
     {
       "label": "postCandidateAction()",
@@ -50465,7 +50537,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L41",
       "id": "review_candidates_panel_render_actions_postcandidateaction",
-      "community": 607
+      "community": 608
     },
     {
       "label": "dashboard-auth-render-message.js",
@@ -50473,7 +50545,7 @@
       "source_file": "static/js/dashboard-auth-render-message.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_message_js",
-      "community": 1396
+      "community": 1398
     },
     {
       "label": "review-candidates-panel.js",
@@ -50481,7 +50553,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 985
+      "community": 987
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -50489,7 +50561,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 985
+      "community": 987
     },
     {
       "label": "review-candidates-panel-health-fetch.js",
@@ -50497,7 +50569,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_fetch_js",
-      "community": 723
+      "community": 725
     },
     {
       "label": "loadBatchRunHistory()",
@@ -50505,7 +50577,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L15",
       "id": "review_candidates_panel_health_fetch_loadbatchrunhistory",
-      "community": 723
+      "community": 725
     },
     {
       "label": "loadHealthMetrics()",
@@ -50513,7 +50585,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L61",
       "id": "review_candidates_panel_health_fetch_loadhealthmetrics",
-      "community": 723
+      "community": 725
     },
     {
       "label": "graph.js",
@@ -50521,7 +50593,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L1",
       "id": "static_js_graph_js",
-      "community": 1397
+      "community": 1399
     },
     {
       "label": "dashboard-tabs-init.js",
@@ -50601,7 +50673,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_state_js",
-      "community": 480
+      "community": 481
     },
     {
       "label": "createSessionGate()",
@@ -50609,7 +50681,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L16",
       "id": "dashboard_auth_state_createsessiongate",
-      "community": 480
+      "community": 481
     },
     {
       "label": "ensureSessionGate()",
@@ -50617,7 +50689,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L22",
       "id": "dashboard_auth_state_ensuresessiongate",
-      "community": 480
+      "community": 481
     },
     {
       "label": "unlockSessionGate()",
@@ -50625,7 +50697,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L25",
       "id": "dashboard_auth_state_unlocksessiongate",
-      "community": 480
+      "community": 481
     },
     {
       "label": "resetSessionGate()",
@@ -50633,7 +50705,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L31",
       "id": "dashboard_auth_state_resetsessiongate",
-      "community": 480
+      "community": 481
     },
     {
       "label": "embedding-map-chart-setup.js",
@@ -50641,7 +50713,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_setup_js",
-      "community": 608
+      "community": 609
     },
     {
       "label": "readContainerSize()",
@@ -50649,7 +50721,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L12",
       "id": "embedding_map_chart_setup_readcontainersize",
-      "community": 608
+      "community": 609
     },
     {
       "label": "appendPlotLayers()",
@@ -50657,7 +50729,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L24",
       "id": "embedding_map_chart_setup_appendplotlayers",
-      "community": 608
+      "community": 609
     },
     {
       "label": "appendBackgroundClickHandler()",
@@ -50665,7 +50737,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L32",
       "id": "embedding_map_chart_setup_appendbackgroundclickhandler",
-      "community": 608
+      "community": 609
     },
     {
       "label": "memory-evolution-demo-shell-render-timeline.js",
@@ -50673,7 +50745,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_timeline_js",
-      "community": 481
+      "community": 482
     },
     {
       "label": "buildComparisonHintMarkup()",
@@ -50681,7 +50753,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_timeline_buildcomparisonhintmarkup",
-      "community": 481
+      "community": 482
     },
     {
       "label": "updateComparisonHint()",
@@ -50689,7 +50761,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L36",
       "id": "memory_evolution_demo_shell_render_timeline_updatecomparisonhint",
-      "community": 481
+      "community": 482
     },
     {
       "label": "syncSegmentSelection()",
@@ -50697,7 +50769,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L51",
       "id": "memory_evolution_demo_shell_render_timeline_syncsegmentselection",
-      "community": 481
+      "community": 482
     },
     {
       "label": "renderPointSegment()",
@@ -50705,7 +50777,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L66",
       "id": "memory_evolution_demo_shell_render_timeline_renderpointsegment",
-      "community": 481
+      "community": 482
     },
     {
       "label": "embedding-map-fetch-status.js",
@@ -50713,7 +50785,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_status_js",
-      "community": 609
+      "community": 610
     },
     {
       "label": "setLoading()",
@@ -50721,7 +50793,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_status_setloading",
-      "community": 609
+      "community": 610
     },
     {
       "label": "setError()",
@@ -50729,7 +50801,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L30",
       "id": "embedding_map_fetch_status_seterror",
-      "community": 609
+      "community": 610
     },
     {
       "label": "updateCacheInfo()",
@@ -50737,7 +50809,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L58",
       "id": "embedding_map_fetch_status_updatecacheinfo",
-      "community": 609
+      "community": 610
     },
     {
       "label": "agent-sessions-panel-data.js",
@@ -50793,7 +50865,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_category_js",
-      "community": 986
+      "community": 988
     },
     {
       "label": "eventCategory()",
@@ -50801,7 +50873,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_render_timeline_category_eventcategory",
-      "community": 986
+      "community": 988
     },
     {
       "label": "graph-shared.js",
@@ -50809,7 +50881,7 @@
       "source_file": "static/js/graph-shared.js",
       "source_location": "L1",
       "id": "static_js_graph_shared_js",
-      "community": 1398
+      "community": 1400
     },
     {
       "label": "dashboard-auth-render-form.js",
@@ -50817,7 +50889,7 @@
       "source_file": "static/js/dashboard-auth-render-form.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_form_js",
-      "community": 1399
+      "community": 1401
     },
     {
       "label": "memory-evolution-demo-shell-shared.js",
@@ -51105,7 +51177,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_config_js",
-      "community": 482
+      "community": 483
     },
     {
       "label": "getReviewQueueBoot()",
@@ -51113,7 +51185,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L12",
       "id": "review_candidates_panel_poll_config_getreviewqueueboot",
-      "community": 482
+      "community": 483
     },
     {
       "label": "clearPollTimer()",
@@ -51121,7 +51193,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L23",
       "id": "review_candidates_panel_poll_config_clearpolltimer",
-      "community": 482
+      "community": 483
     },
     {
       "label": "schedulePollAfterMs()",
@@ -51129,7 +51201,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L30",
       "id": "review_candidates_panel_poll_config_schedulepollafterms",
-      "community": 482
+      "community": 483
     },
     {
       "label": "schedulePollAfterMsUnlessSse()",
@@ -51137,7 +51209,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L41",
       "id": "review_candidates_panel_poll_config_schedulepollaftermsunlesssse",
-      "community": 482
+      "community": 483
     },
     {
       "label": "agent-sessions-panel-shared.js",
@@ -51145,7 +51217,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1400
+      "community": 1402
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -51153,7 +51225,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_js",
-      "community": 1401
+      "community": 1403
     },
     {
       "label": "embedding-map-tooltip.js",
@@ -51161,7 +51233,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_tooltip_js",
-      "community": 610
+      "community": 611
     },
     {
       "label": "ensureTooltip()",
@@ -51169,7 +51241,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L12",
       "id": "embedding_map_tooltip_ensuretooltip",
-      "community": 610
+      "community": 611
     },
     {
       "label": "showTooltip()",
@@ -51177,7 +51249,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L23",
       "id": "embedding_map_tooltip_showtooltip",
-      "community": 610
+      "community": 611
     },
     {
       "label": "hideTooltip()",
@@ -51185,7 +51257,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L40",
       "id": "embedding_map_tooltip_hidetooltip",
-      "community": 610
+      "community": 611
     },
     {
       "label": "review-candidates-panel-render-preview.js",
@@ -51265,7 +51337,7 @@
       "source_file": "static/js/anchor-map-shared.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_shared_js",
-      "community": 1402
+      "community": 1404
     },
     {
       "label": "dashboard-auth-render-status.js",
@@ -51273,7 +51345,7 @@
       "source_file": "static/js/dashboard-auth-render-status.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_status_js",
-      "community": 1403
+      "community": 1405
     },
     {
       "label": "review-candidates-panel-poll-toast.js",
@@ -51281,7 +51353,7 @@
       "source_file": "static/js/review-candidates-panel-poll-toast.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_toast_js",
-      "community": 1404
+      "community": 1406
     },
     {
       "label": "embedding-map-chart-scatter.js",
@@ -51393,7 +51465,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_js",
-      "community": 611
+      "community": 612
     },
     {
       "label": "on()",
@@ -51401,7 +51473,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_on",
-      "community": 611
+      "community": 612
     },
     {
       "label": "wirePanel()",
@@ -51409,7 +51481,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L19",
       "id": "agent_sessions_panel_wirepanel",
-      "community": 611
+      "community": 612
     },
     {
       "label": "initAgentSessionsPanel()",
@@ -51417,7 +51489,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L71",
       "id": "agent_sessions_panel_initagentsessionspanel",
-      "community": 611
+      "community": 612
     },
     {
       "label": "agent-sessions-panel-render-injections.js",
@@ -51425,7 +51497,7 @@
       "source_file": "static/js/agent-sessions-panel-render-injections.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_injections_js",
-      "community": 1405
+      "community": 1407
     },
     {
       "label": "anchor-map-render.js",
@@ -51569,7 +51641,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_consolidation_js",
-      "community": 483
+      "community": 484
     },
     {
       "label": "renderEpisodicSources()",
@@ -51577,7 +51649,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_consolidation_renderepisodicsources",
-      "community": 483
+      "community": 484
     },
     {
       "label": "renderSemanticResult()",
@@ -51585,7 +51657,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersemanticresult",
-      "community": 483
+      "community": 484
     },
     {
       "label": "renderSearchComparison()",
@@ -51593,7 +51665,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L110",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersearchcomparison",
-      "community": 483
+      "community": 484
     },
     {
       "label": "renderConsolidationPanel()",
@@ -51601,7 +51673,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L128",
       "id": "memory_evolution_demo_shell_render_consolidation_renderconsolidationpanel",
-      "community": 483
+      "community": 484
     },
     {
       "label": "memory-evolution-demo-shell.js",
@@ -51609,7 +51681,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 987
+      "community": 989
     },
     {
       "label": "init()",
@@ -51617,7 +51689,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 987
+      "community": 989
     },
     {
       "label": "review-candidates-panel-bulk.js",
@@ -51681,7 +51753,7 @@
       "source_file": "static/js/review-candidates-panel-poll-snapshot.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_snapshot_js",
-      "community": 1406
+      "community": 1408
     },
     {
       "label": "review-candidates-panel-health.js",
@@ -51689,7 +51761,7 @@
       "source_file": "static/js/review-candidates-panel-health.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_js",
-      "community": 1407
+      "community": 1409
     },
     {
       "label": "review-candidates-panel-poll-prompt.js",
@@ -51697,7 +51769,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_prompt_js",
-      "community": 724
+      "community": 726
     },
     {
       "label": "isReviewNotifyPromptDismissed()",
@@ -51705,7 +51777,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_prompt_isreviewnotifypromptdismissed",
-      "community": 724
+      "community": 726
     },
     {
       "label": "dismissReviewNotifyPrompt()",
@@ -51713,7 +51785,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L18",
       "id": "review_candidates_panel_poll_prompt_dismissreviewnotifyprompt",
-      "community": 724
+      "community": 726
     },
     {
       "label": "dashboard-auth-dom.js",
@@ -51721,7 +51793,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_dom_js",
-      "community": 725
+      "community": 727
     },
     {
       "label": "selectFirst()",
@@ -51729,7 +51801,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L12",
       "id": "dashboard_auth_dom_selectfirst",
-      "community": 725
+      "community": 727
     },
     {
       "label": "getElementByIdFallback()",
@@ -51737,7 +51809,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L20",
       "id": "dashboard_auth_dom_getelementbyidfallback",
-      "community": 725
+      "community": 727
     },
     {
       "label": "graph-search.js",
@@ -51809,7 +51881,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 726
+      "community": 728
     },
     {
       "label": "refreshChartIfActive()",
@@ -51817,7 +51889,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L13",
       "id": "embedding_map_refreshchartifactive",
-      "community": 726
+      "community": 728
     },
     {
       "label": "initEmbeddingMap()",
@@ -51825,7 +51897,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_initembeddingmap",
-      "community": 726
+      "community": 728
     },
     {
       "label": "anchor-map-search.js",
@@ -51889,7 +51961,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_data_js",
-      "community": 612
+      "community": 613
     },
     {
       "label": "getSelectedAgentId()",
@@ -51897,7 +51969,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L12",
       "id": "anchor_map_data_getselectedagentid",
-      "community": 612
+      "community": 613
     },
     {
       "label": "loadAgentIdOptions()",
@@ -51905,7 +51977,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L17",
       "id": "anchor_map_data_loadagentidoptions",
-      "community": 612
+      "community": 613
     },
     {
       "label": "loadMapData()",
@@ -51913,7 +51985,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L66",
       "id": "anchor_map_data_loadmapdata",
-      "community": 612
+      "community": 613
     },
     {
       "label": "agent-sessions-panel-render-timeline.js",
@@ -51921,7 +51993,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_js",
-      "community": 988
+      "community": 990
     },
     {
       "label": "eventCategory()",
@@ -51929,7 +52001,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L13",
       "id": "agent_sessions_panel_render_timeline_eventcategory",
-      "community": 988
+      "community": 990
     },
     {
       "label": "agent-sessions-panel-render-provenance.js",
@@ -51937,7 +52009,7 @@
       "source_file": "static/js/agent-sessions-panel-render-provenance.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_provenance_js",
-      "community": 1408
+      "community": 1410
     },
     {
       "label": "graph-render.js",
@@ -52033,7 +52105,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_sign_in_js",
-      "community": 989
+      "community": 991
     },
     {
       "label": "handleSignInResponse()",
@@ -52041,7 +52113,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L10",
       "id": "dashboard_auth_sign_in_handlesigninresponse",
-      "community": 989
+      "community": 991
     },
     {
       "label": "embedding-map-chart-colors.js",
@@ -52049,7 +52121,7 @@
       "source_file": "static/js/embedding-map-chart-colors.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_colors_js",
-      "community": 1409
+      "community": 1411
     },
     {
       "label": "review-candidates-panel-poll-cycle.js",
@@ -52057,7 +52129,7 @@
       "source_file": "static/js/review-candidates-panel-poll-cycle.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_cycle_js",
-      "community": 1410
+      "community": 1412
     },
     {
       "label": "dashboard-auth-session-check.js",
@@ -52065,7 +52137,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_session_check_js",
-      "community": 990
+      "community": 992
     },
     {
       "label": "handleSessionCheckResponse()",
@@ -52073,7 +52145,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L10",
       "id": "dashboard_auth_session_check_handlesessioncheckresponse",
-      "community": 990
+      "community": 992
     },
     {
       "label": "agent-sessions-panel-render-sessions.js",
@@ -52081,7 +52153,7 @@
       "source_file": "static/js/agent-sessions-panel-render-sessions.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_sessions_js",
-      "community": 1411
+      "community": 1413
     },
     {
       "label": "review-candidates-panel-render-list.js",
@@ -52297,7 +52369,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_snapshot_js",
-      "community": 613
+      "community": 614
     },
     {
       "label": "renderMemoryGroups()",
@@ -52305,7 +52377,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorygroups",
-      "community": 613
+      "community": 614
     },
     {
       "label": "renderMemoryStats()",
@@ -52313,7 +52385,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorystats",
-      "community": 613
+      "community": 614
     },
     {
       "label": "renderSnapshot()",
@@ -52321,7 +52393,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L92",
       "id": "memory_evolution_demo_shell_render_snapshot_rendersnapshot",
-      "community": 613
+      "community": 614
     },
     {
       "label": "dashboard-auth-requests.js",
@@ -52329,7 +52401,7 @@
       "source_file": "static/js/dashboard-auth-requests.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_requests_js",
-      "community": 1412
+      "community": 1414
     },
     {
       "label": "dashboard-tabs.js",
@@ -52337,7 +52409,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 484
+      "community": 485
     },
     {
       "label": "getTabButtons()",
@@ -52345,7 +52417,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 484
+      "community": 485
     },
     {
       "label": "setRovingTabindex()",
@@ -52353,7 +52425,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L22",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 484
+      "community": 485
     },
     {
       "label": "focusActiveTabButton()",
@@ -52361,7 +52433,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L28",
       "id": "dashboard_tabs_focusactivetabbutton",
-      "community": 484
+      "community": 485
     },
     {
       "label": "activateTab()",
@@ -52369,7 +52441,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L37",
       "id": "dashboard_tabs_activatetab",
-      "community": 484
+      "community": 485
     },
     {
       "label": "review-candidates-panel-health-render.js",
@@ -52433,7 +52505,7 @@
       "source_file": "static/js/review-candidates-panel-render.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_js",
-      "community": 1413
+      "community": 1415
     },
     {
       "label": "dashboard-tabs-panels.js",
@@ -52441,7 +52513,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_panels_js",
-      "community": 614
+      "community": 615
     },
     {
       "label": "getPanel()",
@@ -52449,7 +52521,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L16",
       "id": "dashboard_tabs_panels_getpanel",
-      "community": 614
+      "community": 615
     },
     {
       "label": "setTabButtonsActive()",
@@ -52457,7 +52529,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L23",
       "id": "dashboard_tabs_panels_settabbuttonsactive",
-      "community": 614
+      "community": 615
     },
     {
       "label": "setPanelVisibility()",
@@ -52465,7 +52537,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L31",
       "id": "dashboard_tabs_panels_setpanelvisibility",
-      "community": 614
+      "community": 615
     },
     {
       "label": "dashboard-auth-ui.js",
@@ -52473,7 +52545,7 @@
       "source_file": "static/js/dashboard-auth-ui.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_ui_js",
-      "community": 1414
+      "community": 1416
     },
     {
       "label": "dashboard-auth-render-tabs.js",
@@ -52481,7 +52553,7 @@
       "source_file": "static/js/dashboard-auth-render-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_tabs_js",
-      "community": 1415
+      "community": 1417
     },
     {
       "label": "review-candidates-panel-shared.js",
@@ -52577,7 +52649,7 @@
       "source_file": "static/js/review-candidates-panel-poll-badge.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_badge_js",
-      "community": 1416
+      "community": 1418
     },
     {
       "label": "graph-embed-init.js",
@@ -52585,7 +52657,7 @@
       "source_file": "static/js/graph-embed-init.js",
       "source_location": "L1",
       "id": "static_js_graph_embed_init_js",
-      "community": 1417
+      "community": 1419
     },
     {
       "label": "dashboard-auth-render.js",
@@ -52593,7 +52665,7 @@
       "source_file": "static/js/dashboard-auth-render.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_js",
-      "community": 1418
+      "community": 1420
     },
     {
       "label": "graph-fetch.js",
@@ -52601,7 +52673,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L1",
       "id": "static_js_graph_fetch_js",
-      "community": 727
+      "community": 729
     },
     {
       "label": "resetGraphState()",
@@ -52609,7 +52681,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L48",
       "id": "graph_fetch_resetgraphstate",
-      "community": 727
+      "community": 729
     },
     {
       "label": "handleGraphPayload()",
@@ -52617,7 +52689,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L62",
       "id": "graph_fetch_handlegraphpayload",
-      "community": 727
+      "community": 729
     },
     {
       "label": "embedding-map-panel.js",
@@ -52625,7 +52697,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_panel_js",
-      "community": 615
+      "community": 616
     },
     {
       "label": "appendLabeledLine()",
@@ -52633,7 +52705,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L12",
       "id": "embedding_map_panel_appendlabeledline",
-      "community": 615
+      "community": 616
     },
     {
       "label": "closeSidePanel()",
@@ -52641,7 +52713,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L21",
       "id": "embedding_map_panel_closesidepanel",
-      "community": 615
+      "community": 616
     },
     {
       "label": "openSidePanel()",
@@ -52649,7 +52721,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L29",
       "id": "embedding_map_panel_opensidepanel",
-      "community": 615
+      "community": 616
     }
   ],
   "links": [
@@ -91801,7 +91873,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
-      "source_location": "L33",
+      "source_location": "L42",
       "weight": 1.0,
       "_src": "packages_memento_core_src_shared_validation_source_uri_ts",
       "_tgt": "source_uri_validatesource",
@@ -102793,7 +102865,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L39",
+      "source_location": "L40",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_ts",
       "_tgt": "event_outbox_service_iseventoutboxenabled",
@@ -102805,7 +102877,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L43",
+      "source_location": "L44",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_ts",
       "_tgt": "event_outbox_service_parsepayload",
@@ -102817,7 +102889,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L52",
+      "source_location": "L53",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_ts",
       "_tgt": "event_outbox_service_toevent",
@@ -102829,7 +102901,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_ts",
       "_tgt": "event_outbox_service_eventoutboxservice",
@@ -102841,7 +102913,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L72",
+      "source_location": "L73",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice_enqueue",
       "_tgt": "event_outbox_service_iseventoutboxenabled",
@@ -102853,7 +102925,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L58",
+      "source_location": "L59",
       "weight": 1.0,
       "_src": "event_outbox_service_toevent",
       "_tgt": "event_outbox_service_parsepayload",
@@ -102865,7 +102937,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L69",
+      "source_location": "L70",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice",
       "_tgt": "event_outbox_service_eventoutboxservice_constructor",
@@ -102877,7 +102949,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L71",
+      "source_location": "L72",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice",
       "_tgt": "event_outbox_service_eventoutboxservice_enqueue",
@@ -102889,7 +102961,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L84",
+      "source_location": "L85",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice",
       "_tgt": "event_outbox_service_eventoutboxservice_pending",
@@ -102901,7 +102973,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L94",
+      "source_location": "L95",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice",
       "_tgt": "event_outbox_service_eventoutboxservice_publishpending",
@@ -102913,7 +102985,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
-      "source_location": "L97",
+      "source_location": "L98",
       "weight": 1.0,
       "_src": "event_outbox_service_eventoutboxservice_publishpending",
       "_tgt": "event_outbox_service_eventoutboxservice_pending",
@@ -106213,7 +106285,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
-      "source_location": "L831",
+      "source_location": "L848",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
       "_tgt": "remember_tool_spec_createvalidreflectionnote",
@@ -111253,7 +111325,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L24",
+      "source_location": "L26",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_consolidationalreadyrunningerror",
@@ -111265,7 +111337,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L43",
+      "source_location": "L45",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_newsemanticid",
@@ -111277,7 +111349,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L50",
+      "source_location": "L52",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_cosinesimilarity",
@@ -111289,7 +111361,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L68",
+      "source_location": "L70",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_getmergesimilaritythreshold",
@@ -111301,7 +111373,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L74",
+      "source_location": "L76",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_mergeoriginsourcejson",
@@ -111313,7 +111385,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L101",
+      "source_location": "L103",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_ts",
       "_tgt": "sleep_consolidation_service_sleepconsolidationservice",
@@ -111325,7 +111397,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L25",
+      "source_location": "L27",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_consolidationalreadyrunningerror",
       "_tgt": "sleep_consolidation_service_consolidationalreadyrunningerror_constructor",
@@ -111337,7 +111409,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L276",
+      "source_location": "L313",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice_run",
       "_tgt": "sleep_consolidation_service_newsemanticid",
@@ -111349,7 +111421,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L218",
+      "source_location": "L250",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice_run",
       "_tgt": "sleep_consolidation_service_cosinesimilarity",
@@ -111361,7 +111433,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L205",
+      "source_location": "L237",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice_run",
       "_tgt": "sleep_consolidation_service_getmergesimilaritythreshold",
@@ -111373,7 +111445,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L232",
+      "source_location": "L264",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice_run",
       "_tgt": "sleep_consolidation_service_mergeoriginsourcejson",
@@ -111385,7 +111457,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L112",
+      "source_location": "L114",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice",
       "_tgt": "sleep_consolidation_service_sleepconsolidationservice_constructor",
@@ -111397,7 +111469,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L127",
+      "source_location": "L129",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice",
       "_tgt": "sleep_consolidation_service_sleepconsolidationservice_isrunning",
@@ -111409,11 +111481,35 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
-      "source_location": "L131",
+      "source_location": "L137",
+      "weight": 1.0,
+      "_src": "sleep_consolidation_service_sleepconsolidationservice",
+      "_tgt": "sleep_consolidation_service_sleepconsolidationservice_enqueueconsolidationcompleted",
+      "source": "sleep_consolidation_service_sleepconsolidationservice",
+      "target": "sleep_consolidation_service_sleepconsolidationservice_enqueueconsolidationcompleted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
+      "source_location": "L163",
       "weight": 1.0,
       "_src": "sleep_consolidation_service_sleepconsolidationservice",
       "_tgt": "sleep_consolidation_service_sleepconsolidationservice_run",
       "source": "sleep_consolidation_service_sleepconsolidationservice",
+      "target": "sleep_consolidation_service_sleepconsolidationservice_run",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.ts",
+      "source_location": "L304",
+      "weight": 1.0,
+      "_src": "sleep_consolidation_service_sleepconsolidationservice_run",
+      "_tgt": "sleep_consolidation_service_sleepconsolidationservice_enqueueconsolidationcompleted",
+      "source": "sleep_consolidation_service_sleepconsolidationservice_enqueueconsolidationcompleted",
       "target": "sleep_consolidation_service_sleepconsolidationservice_run",
       "confidence_score": 1.0
     },
@@ -111547,6 +111643,54 @@
       "_tgt": "summarization_service_spec_row",
       "source": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
       "target": "summarization_service_spec_row",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_ts",
+      "_tgt": "consolidation_outbox_worker_consolidationoutboxworker",
+      "source": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_ts",
+      "target": "consolidation_outbox_worker_consolidationoutboxworker",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L22",
+      "weight": 1.0,
+      "_src": "consolidation_outbox_worker_consolidationoutboxworker",
+      "_tgt": "consolidation_outbox_worker_consolidationoutboxworker_constructor",
+      "source": "consolidation_outbox_worker_consolidationoutboxworker",
+      "target": "consolidation_outbox_worker_consolidationoutboxworker_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L26",
+      "weight": 1.0,
+      "_src": "consolidation_outbox_worker_consolidationoutboxworker",
+      "_tgt": "consolidation_outbox_worker_consolidationoutboxworker_publish",
+      "source": "consolidation_outbox_worker_consolidationoutboxworker",
+      "target": "consolidation_outbox_worker_consolidationoutboxworker_publish",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
+      "source_location": "L38",
+      "weight": 1.0,
+      "_src": "consolidation_outbox_worker_consolidationoutboxworker",
+      "_tgt": "consolidation_outbox_worker_consolidationoutboxworker_handled",
+      "source": "consolidation_outbox_worker_consolidationoutboxworker",
+      "target": "consolidation_outbox_worker_consolidationoutboxworker_handled",
       "confidence_score": 1.0
     },
     {
@@ -111691,6 +111835,30 @@
       "_tgt": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
       "source": "sleep_consolidation_service_spec_failingrepo",
       "target": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
+      "_tgt": "consolidation_outbox_worker_spec_insertepisodic",
+      "source": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
+      "target": "consolidation_outbox_worker_spec_insertepisodic",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
+      "source_location": "L18",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
+      "_tgt": "consolidation_outbox_worker_spec_insertembedding",
+      "source": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
+      "target": "consolidation_outbox_worker_spec_insertembedding",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts
@@ -395,7 +395,24 @@ describe('RememberTool', () => {
       const record = DatabaseUtils.get(db, 'SELECT * FROM memory_item WHERE id = ?', [resultData.memory_id]);
       expect(record.content).toBe('React is a JavaScript library for building user interfaces');
       expect(record.type).toBe('semantic');
+      expect(record.source).toBe('agent:documentation');
       expect(record.origin_source).toBeDefined();
+    });
+
+    it('bare workflow source를 agent:로 정규화해 저장한다 (#696)', async () => {
+      const params = {
+        type: 'episodic',
+        content: 'CEO heartbeat completed',
+        source: 'paperclip-ceo-heartbeat',
+      };
+
+      const result = await tool.handle(params, context);
+      const resultData = JSON.parse(result.content[0].text);
+      const record = DatabaseUtils.get(db, 'SELECT source FROM memory_item WHERE id = ?', [
+        resultData.memory_id,
+      ]) as { source: string };
+
+      expect(record.source).toBe('agent:paperclip-ceo-heartbeat');
     });
 
     it('Given: semantic remember 호출 시, When: Fact 메타 미지정, Then: num_times=1·last_mentioned_at·source_session_id·confidence 기본 저장 (Issue #88)', async () => {

--- a/packages/memento-core/src/domains/memory/tools/remember-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool.ts
@@ -165,7 +165,6 @@ export class RememberTool extends BaseTool {
         }
         this.logWarning(`⚠️  remember: ${msg} (source='${source_param}')`);
       } else if (sourceValidation.normalizedSource) {
-        // bare agent/workflow id → agent:<id> (#696)
         parsedParams.source = sourceValidation.normalizedSource;
       }
 

--- a/packages/memento-core/src/domains/memory/tools/remember-tool.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool.ts
@@ -164,6 +164,9 @@ export class RememberTool extends BaseTool {
           throw new Error(`❌ remember: ${msg}`);
         }
         this.logWarning(`⚠️  remember: ${msg} (source='${source_param}')`);
+      } else if (sourceValidation.normalizedSource) {
+        // bare agent/workflow id → agent:<id> (#696)
+        parsedParams.source = sourceValidation.normalizedSource;
       }
 
       const type = (rawType || typeValidation.defaultType || 'episodic') as MemoryTypeRequest;

--- a/packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts
+++ b/packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts
@@ -47,7 +47,7 @@ describe('mapKnowledgeCandidateToRememberParams', () => {
     expect(r.params.type).toBe('semantic');
     expect(r.params.content).toBe('본문');
     expect(r.params.tags).toEqual(['personal-agent', 'preference']);
-    expect(r.params.source).toBe('personal-knowledge-agent');
+    expect(r.params.source).toBe('agent:personal-knowledge-agent');
     expect(r.params.project_id).toBe('p1');
     expect(r.params.owner_id).toBe('agent-1');
     expect(r.params.session_id).toBe('s1');

--- a/packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts
+++ b/packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts
@@ -52,7 +52,7 @@ export function mapKnowledgeCandidateToRememberParams(
   > = {
     tags: candidate.tags,
     importance: candidate.importance,
-    source: 'personal-knowledge-agent',
+    source: 'agent:personal-knowledge-agent',
     privacy_scope: 'private',
     project_id: ctx.projectId,
     owner_id,

--- a/packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts
+++ b/packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts
@@ -44,8 +44,22 @@ describe('validateSource', () => {
     expect(result.type).toBe('memento');
   });
 
-  it('임의 문자열은 거절한다', () => {
-    const result = validateSource('just-a-note');
+  it('agent:<id>를 허용한다', () => {
+    const result = validateSource('agent:paperclip-ceo-heartbeat');
+    expect(result.isValid).toBe(true);
+    expect(result.type).toBe('agent');
+    expect(result.normalizedSource).toBeUndefined();
+  });
+
+  it('bare agent id는 agent:로 정규화한다', () => {
+    const result = validateSource('paperclip-ceo-heartbeat');
+    expect(result.isValid).toBe(true);
+    expect(result.type).toBe('agent');
+    expect(result.normalizedSource).toBe('agent:paperclip-ceo-heartbeat');
+  });
+
+  it('공백이 있는 free-text는 거절한다', () => {
+    const result = validateSource('just a note');
     expect(result.isValid).toBe(false);
     expect(result.message).toBeDefined();
   });

--- a/packages/memento-core/src/shared/validation/source-uri.ts
+++ b/packages/memento-core/src/shared/validation/source-uri.ts
@@ -8,8 +8,7 @@ import { parseMementoResourceUri } from '../utils/memento-resource-uri.js';
  * - https://example.com/path
  * - commit:<sha>
  * - doc:<id>
- * - agent:<id> (에이전트·워크플로 식별자)
- * - bare <id> → agent:<id>로 정규화 (#696)
+ * - agent:<id> (에이전트·워크플로 식별자; bare <id> → agent:<id> 정규화)
  * - memento://<owner>/<resource-kind>/<resource-id>
  * - memento://memory/<memory_id> (legacy alias)
  */
@@ -30,14 +29,12 @@ const COMMIT_URI = /^commit:[0-9a-f]{7,64}$/i;
 /** doc·agent id charset (#671 / #696) */
 const ID_BODY = '[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}';
 const DOC_URI = new RegExp(`^doc:${ID_BODY}$`);
-const AGENT_URI = new RegExp(`^agent:${ID_BODY}$`);
-const BARE_AGENT_ID = new RegExp(`^${ID_BODY}$`);
+const AGENT_OR_BARE = new RegExp(`^(?:agent:)?(${ID_BODY})$`);
 const MEMENTO_URI = /^memento:\/\/memory\/mem_[a-zA-Z0-9_]+$/;
 
 /**
  * source 문자열이 지원 URI 형식인지 검증합니다.
  * 빈 문자열·undefined는 유효(선택 필드)로 처리합니다.
- * bare agent/workflow id는 agent:<id>로 정규화합니다 (#696).
  */
 export function validateSource(source: string | undefined | null): SourceValidationResult {
   if (source === undefined || source === null || source.trim() === '') {
@@ -58,9 +55,17 @@ export function validateSource(source: string | undefined | null): SourceValidat
   if (DOC_URI.test(trimmed)) {
     return { isValid: true, type: 'doc' };
   }
-  if (AGENT_URI.test(trimmed)) {
-    return { isValid: true, type: 'agent' };
+
+  const agentMatch = AGENT_OR_BARE.exec(trimmed);
+  if (agentMatch) {
+    const canonical = `agent:${agentMatch[1]}`;
+    return {
+      isValid: true,
+      type: 'agent',
+      ...(trimmed === canonical ? {} : { normalizedSource: canonical }),
+    };
   }
+
   if (MEMENTO_URI.test(trimmed)) {
     return { isValid: true, type: 'memento' };
   }
@@ -68,14 +73,7 @@ export function validateSource(source: string | undefined | null): SourceValidat
     parseMementoResourceUri(trimmed);
     return { isValid: true, type: 'memento' };
   } catch {
-    // Continue — may still be a bare agent id (#696).
-  }
-  if (BARE_AGENT_ID.test(trimmed)) {
-    return {
-      isValid: true,
-      type: 'agent',
-      normalizedSource: `agent:${trimmed}`,
-    };
+    // not a memento URI
   }
 
   return {

--- a/packages/memento-core/src/shared/validation/source-uri.ts
+++ b/packages/memento-core/src/shared/validation/source-uri.ts
@@ -1,34 +1,43 @@
 import { parseMementoResourceUri } from '../utils/memento-resource-uri.js';
 
 /**
- * remember `source` 필드 URI 검증 (#671)
+ * remember `source` 필드 URI 검증 (#671, #696)
  *
  * 지원 형식:
  * - file://path/to/file
  * - https://example.com/path
  * - commit:<sha>
  * - doc:<id>
+ * - agent:<id> (에이전트·워크플로 식별자)
+ * - bare <id> → agent:<id>로 정규화 (#696)
  * - memento://<owner>/<resource-kind>/<resource-id>
  * - memento://memory/<memory_id> (legacy alias)
  */
 
-export type SourceUriType = 'file' | 'https' | 'commit' | 'doc' | 'memento';
+export type SourceUriType = 'file' | 'https' | 'commit' | 'doc' | 'memento' | 'agent';
 
 export interface SourceValidationResult {
   isValid: boolean;
   type?: SourceUriType;
   message?: string;
+  /** bare agent id가 agent:<id>로 정규화된 경우 저장에 사용할 값 */
+  normalizedSource?: string;
 }
 
 const FILE_URI = /^file:\/\/.+/i;
 const HTTPS_URI = /^https:\/\/[^\s/$.?#].[^\s]*$/i;
 const COMMIT_URI = /^commit:[0-9a-f]{7,64}$/i;
-const DOC_URI = /^doc:[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+/** doc·agent id charset (#671 / #696) */
+const ID_BODY = '[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}';
+const DOC_URI = new RegExp(`^doc:${ID_BODY}$`);
+const AGENT_URI = new RegExp(`^agent:${ID_BODY}$`);
+const BARE_AGENT_ID = new RegExp(`^${ID_BODY}$`);
 const MEMENTO_URI = /^memento:\/\/memory\/mem_[a-zA-Z0-9_]+$/;
 
 /**
  * source 문자열이 지원 URI 형식인지 검증합니다.
  * 빈 문자열·undefined는 유효(선택 필드)로 처리합니다.
+ * bare agent/workflow id는 agent:<id>로 정규화합니다 (#696).
  */
 export function validateSource(source: string | undefined | null): SourceValidationResult {
   if (source === undefined || source === null || source.trim() === '') {
@@ -49,6 +58,9 @@ export function validateSource(source: string | undefined | null): SourceValidat
   if (DOC_URI.test(trimmed)) {
     return { isValid: true, type: 'doc' };
   }
+  if (AGENT_URI.test(trimmed)) {
+    return { isValid: true, type: 'agent' };
+  }
   if (MEMENTO_URI.test(trimmed)) {
     return { isValid: true, type: 'memento' };
   }
@@ -56,12 +68,19 @@ export function validateSource(source: string | undefined | null): SourceValidat
     parseMementoResourceUri(trimmed);
     return { isValid: true, type: 'memento' };
   } catch {
-    // Continue to the shared invalid-source response below.
+    // Continue — may still be a bare agent id (#696).
+  }
+  if (BARE_AGENT_ID.test(trimmed)) {
+    return {
+      isValid: true,
+      type: 'agent',
+      normalizedSource: `agent:${trimmed}`,
+    };
   }
 
   return {
     isValid: false,
     message:
-      "source는 file://, https://, commit:<sha>, doc:<id>, memento://{owner}/{kind}/{id} 형식이어야 합니다",
+      "source는 file://, https://, commit:<sha>, doc:<id>, agent:<id>, memento://{owner}/{kind}/{id} 형식이어야 합니다",
   };
 }

--- a/packages/memento-server/src/server/routes/agent-personal.routes.spec.ts
+++ b/packages/memento-server/src/server/routes/agent-personal.routes.spec.ts
@@ -107,7 +107,7 @@ describe('personal knowledge agent HTTP routes', () => {
     const stored = ctx.db.prepare(`
       SELECT content, type, project_id, session_id, process_id
       FROM memory_item
-      WHERE source = 'personal-knowledge-agent'
+      WHERE source = 'agent:personal-knowledge-agent'
     `).get() as {
       content: string;
       type: string;

--- a/specs/050-fix-remember-source-agent/plan.md
+++ b/specs/050-fix-remember-source-agent/plan.md
@@ -1,0 +1,28 @@
+# Implementation Plan: Issue #696
+
+**Branch**: `issue-696-remember-source-agent`  
+**Spec**: `specs/050-fix-remember-source-agent/spec.md`
+
+## Changes
+
+| Module | Change |
+|--------|--------|
+| `shared/validation/source-uri.ts` | `agent:` URI + bare id → `normalizedSource` |
+| `shared/validation/__tests__/source-uri.spec.ts` | agent·정규화·free-text 거절 테스트 |
+| `domains/memory/tools/remember-tool.ts` | `normalizedSource` 저장, 유효 시 WARN 생략 |
+| `docs/reference/ko/source-field.md` | `agent:`·bare 정규화 문서 |
+| `CHANGELOG.md` | Unreleased Fixed/Changed |
+
+## Design Notes
+
+- bare id charset = `doc:` id와 동일 → `#671` 기계 파싱 가능 형식 유지
+- 저장 값은 항상 `agent:<id>`로 통일 (round-trip·export 일관성)
+- free-text(공백 등)는 기존 warn/strict 유지
+
+## Test Strategy
+
+1. Red: `source-uri.spec.ts`에 agent·bare·spaces 케이스 추가
+2. Green: `source-uri.ts` + remember 저장 경로
+3. `npm test -- packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts`
+4. remember-tool 관련 회귀 1건(선택) 또는 기존 semantic source 테스트가 통과하는지 확인
+5. `npm run lint && npm run type-check`

--- a/specs/050-fix-remember-source-agent/spec.md
+++ b/specs/050-fix-remember-source-agent/spec.md
@@ -1,0 +1,57 @@
+# Feature Specification: remember source agent 식별자 허용
+
+**Feature Branch**: `issue-696-remember-source-agent`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Issue**: [#696](https://github.com/jee1/memento/issues/696) — App warning: remember source 형식 (`source='paperclip-ceo-heartbeat'`)
+
+## Problem
+
+운영 로그 모니터가 `remember` WARN을 3회 감지했다. Paperclip 등 에이전트가 `source`에 워크플로/에이전트 식별자(`paperclip-ceo-heartbeat`)를 넘기는데, `#671` URI 표준(`file://`, `https://`, `commit:`, `doc:`, `memento://memory/`)만 허용해 기본(관대) 모드에서도 매번 WARN이 쌓인다. 저장은 계속되지만 provenance가 스키마화되지 않고 운영 노이즈만 발생한다.
+
+## User Scenarios & Testing
+
+### User Story 1 — 에이전트/워크플로 식별자는 경고 없이 저장 (Priority: P1)
+
+에이전트가 `source: "paperclip-ceo-heartbeat"` 또는 `source: "agent:paperclip-ceo-heartbeat"`로 remember를 호출하면, 서버는 WARN 없이 저장하고 provenance는 `agent:` URI로 기록한다.
+
+**Why this priority**: #696 운영 노이즈의 직접 원인.
+
+**Independent Test**: `validateSource('paperclip-ceo-heartbeat')`가 valid이며 `normalizedSource === 'agent:paperclip-ceo-heartbeat'`.
+
+**Acceptance Scenarios**:
+
+1. **Given** bare agent id (`paperclip-ceo-heartbeat`), **When** `validateSource`, **Then** `isValid=true`, `type=agent`, `normalizedSource=agent:paperclip-ceo-heartbeat`.
+2. **Given** `agent:paperclip-ceo-heartbeat`, **When** `validateSource`, **Then** `isValid=true`, `type=agent`, 정규화 불필요.
+3. **Given** remember에 bare agent id, **When** 저장, **Then** DB `source`가 `agent:…`이고 WARN 로그 없음.
+
+### User Story 2 — 비식별자 free-text는 기존 정책 유지 (Priority: P2)
+
+공백·특수문자가 포함된 free-text `source`는 기존처럼 invalid다. 관대 모드에서는 WARN 후 저장, strict에서는 거절.
+
+**Acceptance Scenarios**:
+
+1. **Given** `source: "just a note"`, **When** `validateSource`, **Then** `isValid=false`.
+2. **Given** 기존 `file://`·`https://`·`commit:`·`doc:`·`memento://` URI, **When** 검증, **Then** 기존과 동일하게 valid.
+
+## Requirements
+
+- **FR-001**: `agent:<id>` URI를 지원한다. `<id>`는 `doc:`와 동일 charset (`[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}`).
+- **FR-002**: 동일 charset의 bare 식별자는 `agent:<id>`로 정규화하고 valid로 처리한다.
+- **FR-003**: remember는 `normalizedSource`가 있으면 그 값을 저장한다.
+- **FR-004**: 정규화된 agent source에 대해 WARN/ERROR를 남기지 않는다.
+- **FR-005**: `docs/reference/ko/source-field.md`에 `agent:` 및 bare 정규화를 문서화한다.
+- **FR-006**: 기존 URI 5종 동작·strict 모드는 유지한다.
+
+## Out of Scope
+
+- Paperclip 클라이언트 코드 수정 (외부)
+- 기존 DB에 저장된 bare free-text의 일괄 마이그레이션
+- 새 env 플래그
+
+## Success Criteria
+
+- **SC-001**: `paperclip-ceo-heartbeat` remember 시 WARN 0건, `source=agent:paperclip-ceo-heartbeat` 저장
+- **SC-002**: `source-uri.spec.ts` 및 관련 게이트 통과
+- **SC-003**: `npm run lint`, `npm run type-check`, 관련 `npm test` 통과
+- **SC-004**: CHANGELOG Unreleased 항목 추가

--- a/specs/050-fix-remember-source-agent/tasks.md
+++ b/specs/050-fix-remember-source-agent/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Issue #696
+
+- [x] T1: `source-uri.spec.ts`에 `agent:`·bare 정규화·공백 free-text 테스트
+- [x] T2: `source-uri.ts`에 `agent` 타입·정규화 구현 (memento owner-scoped URI 유지)
+- [x] T3: `remember-tool.ts`가 `normalizedSource`를 저장하도록 연결
+- [x] T4: `docs/reference/ko/source-field.md` 갱신
+- [x] T5: CHANGELOG Unreleased 항목
+- [ ] T6: lint / type-check / 관련 test
+- [ ] T7: graphify 재빌드 · PR

--- a/specs/050-fix-remember-source-agent/tasks.md
+++ b/specs/050-fix-remember-source-agent/tasks.md
@@ -5,5 +5,5 @@
 - [x] T3: `remember-tool.ts`가 `normalizedSource`를 저장하도록 연결
 - [x] T4: `docs/reference/ko/source-field.md` 갱신
 - [x] T5: CHANGELOG Unreleased 항목
-- [ ] T6: lint / type-check / 관련 test
-- [ ] T7: graphify 재빌드 · PR
+- [x] T6: lint / type-check / 관련 test (+ personal-agent source 정합)
+- [x] T7: graphify 재빌드 · PR


### PR DESCRIPTION
## Summary
- `validateSource`에 `agent:<id>` URI와 bare 에이전트/워크플로 식별자 정규화(`paperclip-ceo-heartbeat` → `agent:…`)를 추가해 #696 WARN 노이즈를 제거합니다.
- `remember`는 정규화된 `source`를 저장하고, personal-knowledge-agent 매퍼도 `agent:personal-knowledge-agent`로 통일합니다.
- Spec Kit: `specs/050-fix-remember-source-agent/`

## Test plan
- [x] `source-uri.spec.ts` (agent / bare / free-text)
- [x] `remember-tool.spec.ts` bare workflow 정규화
- [x] `agent-personal.routes.spec.ts` + mapper spec
- [x] lint / type-check / full `npm test` (pre-commit)

Closes #696

Made with [Cursor](https://cursor.com)