### PR TITLE
chore(docker): 메인 Dockerfile을 node:24로 올림 (#702)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for Memento MCP Server
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN npm run postinstall
 RUN npm run build:packages
 
 # Production stage
-FROM node:20-slim AS production
+FROM node:24-slim AS production
 
 # Use the same cache directory as the builder stage
 ENV XDG_CACHE_HOME=/app/.cache

--- a/docs/operations/ko/docker-deploy-procedure.md
+++ b/docs/operations/ko/docker-deploy-procedure.md
@@ -3,6 +3,8 @@
 Memento MCP/HTTP 서버를 Docker로 **재배포·재시작**할 때 따르는 공식 절차입니다.  
 `memory.db`는 호스트 `~/.memento/data/`에 마운트되므로, 컨테이너 재기동만으로도 DB 무결성 검사(`quick_check`)가 실행됩니다. 손상된 DB는 서버가 **의도적으로 기동을 거부**합니다.
 
+메인 `Dockerfile` 베이스는 **Node 24**입니다 (`node:24-alpine` builder / `node:24-slim` production). `package.json` `engines.node`·CI와 동일 major입니다. 배포 전 무결성 점검은 아래 `npm run db:pre-docker-deploy`를 따릅니다.
+
 관련 문서:
 
 - [배포 전 환경변수 점검](../env-deployment-checklist.md)

--- a/specs/054-node24-dockerfile/plan.md
+++ b/specs/054-node24-dockerfile/plan.md
@@ -1,0 +1,17 @@
+# Implementation Plan: Dockerfile Node 24
+
+## Approach
+
+1. Dockerfile `FROM` 두 줄만 major bump (alpine builder / slim production 유지).
+2. `docker build --build-arg SKIP_TRANSFORMERS_WARMUP=1`로 빌드 검증 (warmup은 선택).
+3. 컨테이너에서 `node -v` + `/health` 스모크.
+4. `docs/operations/ko/docker-deploy-procedure.md`에 베이스 이미지 Node 24 한 줄.
+
+## Risks
+
+- alpine↔slim libc로 sharp/sqlite 바이너리 선택 실패 → 빌드 로그 확인.
+- `useradd -u 1001`과 베이스 이미지 기본 유저 충돌 가능성 → 빌드 실패 시 uid 조정.
+
+## Test Strategy
+
+Docker 빌드·런타임 스모크가 주 검증. 앱 단위 테스트는 이 PR 범위 밖.

--- a/specs/054-node24-dockerfile/spec.md
+++ b/specs/054-node24-dockerfile/spec.md
@@ -1,0 +1,40 @@
+# Feature Specification: 메인 Dockerfile Node 24
+
+**Feature Branch**: `issue-702-dockerfile-node24`  
+**Created**: 2026-07-27  
+**Status**: Active  
+**Input**: GitHub Issue #702 — chore(docker): 메인 Dockerfile을 node:24로 올림  
+**Parent**: #700
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — 컨테이너 런타임이 engines.node와 일치 (Priority: P1)
+
+운영/로컬 Docker 이미지가 Node 24에서 빌드·실행된다.
+
+**Independent Test**: `docker build` 성공 후 컨테이너에서 `node -v`가 24.x, 헬스체크 또는 기동 스모크
+
+**Acceptance Scenarios**:
+
+1. **Given** 메인 Dockerfile, **When** 검사, **Then** `node:20` 잔존 없음.
+2. **Given** `docker build`, **When** 완료, **Then** exit 0.
+3. **Given** 실행 중 컨테이너, **When** `node -v`, **Then** v24.x.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: builder `node:24-alpine`, production `node:24-slim`으로 변경.
+- **FR-002**: alpine/slim 조합 유지; native 모듈이 Node 24 ABI로 설치되는지 빌드로 확인.
+- **FR-003**: 배포 문서에 베이스 이미지가 Node 24임을 필요 시 한 줄 정합.
+- **FR-004**: 배포 전 `npm run db:pre-docker-deploy` 런북은 기존 문서 유지·확인.
+
+## Out of Scope
+
+- `.nvmrc` (#701), `@types/node` (#703)
+- vitest 4 / eslint 10 major
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Dockerfile에 `node:20` 없음
+- **SC-002**: `docker build` 성공
+- **SC-003**: 컨테이너 `node -v`가 24.x
+- **SC-004**: MCP/HTTP 기동 스모크 또는 `/health` 통과

--- a/specs/054-node24-dockerfile/tasks.md
+++ b/specs/054-node24-dockerfile/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: 054-node24-dockerfile
+
+- [x] T1: Dockerfile builder/production → node:24-* (FR-001)
+- [x] T2: docker-deploy-procedure에 Node 24 베이스 한 줄 (FR-003/004)
+- [x] T3: `docker build` (SKIP_TRANSFORMERS_WARMUP=1) (SC-002)
+- [x] T4: 컨테이너 `node -v` + health 스모크 (SC-003/004)
+- [ ] T5: PR (Closes #702)


### PR DESCRIPTION
## Summary
- 메인 `Dockerfile` builder `node:24-alpine` / production `node:24-slim`
- `docs/operations/ko/docker-deploy-procedure.md`에 Node 24 베이스 한 줄
- Spec Kit: `specs/054-node24-dockerfile/`

Closes #702
Part of #700

## Test plan
- [x] `docker build --build-arg SKIP_TRANSFORMERS_WARMUP=1 -t memento-node24-test:702 .`
- [x] 컨테이너 `node -v` → `v24.18.0`
- [x] `PORT=9001` + `ADMIN_API_KEY` + `MEMENTO_HTTP_BIND_HOST=0.0.0.0`에서 `GET /health` → `healthy`
- [x] `npm run lint` / `npm test` (worktree, Cursor agent Node 24.5 + rebuild-native)
- [ ] 리뷰어: 운영 compose로 한 번 재빌드·기동 확인


Made with [Cursor](https://cursor.com)