### PR TITLE
fix(remember): persist hybrid relation extraction candidates to memory_relation

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-08-01)
 
 ## Corpus Check
-- 1429 files · ~1,572,345 words
+- 1430 files · ~1,573,149 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6594 nodes · 7522 edges · 1421 communities detected
+- 6598 nodes · 7526 edges · 1422 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1431,6 +1431,7 @@
 - [[_COMMUNITY_Community 1418|Community 1418]]
 - [[_COMMUNITY_Community 1419|Community 1419]]
 - [[_COMMUNITY_Community 1420|Community 1420]]
+- [[_COMMUNITY_Community 1421|Community 1421]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 47 edges
@@ -2115,168 +2116,168 @@ Cohesion: 0.22
 Nodes (1): VectorSearchContainer
 
 ### Community 164 - "Community 164"
+Cohesion: 0.33
+Nodes (7): checkDbConnection(), getRetryCount(), persistRelationCandidates(), runEmbeddingAndNeighbors(), runRelationExtraction(), runTripleExtractionJob(), updateTripleStatus()
+
+### Community 165 - "Community 165"
 Cohesion: 0.22
 Nodes (1): ConsolidationRepository
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.29
 Nodes (1): PredicateCanonicalizer
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.24
 Nodes (2): scopeSearchFilters(), SqliteHybridAgentContextSource
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.38
 Nodes (1): QualityMetricsCollector
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.31
 Nodes (6): countMagicNumbers(), findMagicNumbers(), getAllTsFiles(), isCoreModule(), isExcluded(), main()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.36
 Nodes (9): checkSqlInjection(), findFiles(), findSqlInjectionPatterns(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.36
 Nodes (9): countAnyTypes(), findAnyTypes(), findFiles(), main(), matchesPattern(), parseArgs(), printHelp(), printResults() (+1 more)
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.36
 Nodes (8): cursorKey(), findLastNewlineBefore(), readDockerLogs(), readIncrementalJsonlLines(), readJsonlFiles(), readStreamLines(), resolveDockerLogsRef(), runDocker()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.22
 Nodes (1): MementoAssistant
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.31
 Nodes (2): HttpTransport, toClientSearchFilters()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.36
 Nodes (3): getToolResponseContent(), parseToolJson(), StdioTransport
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.39
 Nodes (8): findSubcommandWithIndex(), main(), parseCli(), parseGlobalFlags(), stripGlobalArgvForAgentDetection(), subcommandArgvFrom(), writeStderr(), writeStdout()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.28
 Nodes (4): registerHandlers(), runHeavyInit(), Semaphore, startServer()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.42
 Nodes (8): createAdminSessionCookie(), runTests(), setupTestDatabase(), testAdminAPIs(), testBasicEndpoints(), testMCPTools(), testSSE(), testWebSocket()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.44
 Nodes (8): applySizePolicy(), buildBatch(), cloneEvent(), reducibleText(), removeOptionalFields(), truncateToFit(), utf8Size(), validateBatch()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.47
 Nodes (6): hasOnlyKeys(), isRecord(), validateAgentEvent(), validatePayload(), validIdentifier(), validJsonValue()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.44
 Nodes (7): defaultGit(), detectClaudeCodeScope(), detectCodexScope(), explicit(), normalizeRemote(), processFromBranch(), value()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.36
 Nodes (1): TripleExtractionLogger
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.31
 Nodes (1): MigrationRunner
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (1): AnchorTableMigration
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.36
 Nodes (1): FactMetadataFieldsMigration
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.39
 Nodes (1): MemoryItemIsConsolidatedMigration
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.39
 Nodes (1): TripleExtractionFieldsMigration
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.42
 Nodes (1): FeedbackEventAttributionMigration
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (1): ProceduralVersionIndexesMigration
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.36
 Nodes (1): MemoryItemAttributionMigration
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.36
 Nodes (1): KgTripleTableMigration
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.39
 Nodes (1): SoftDeleteFieldsMigration
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.36
 Nodes (1): MemoryItemOwnerIdMigration
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.25
 Nodes (1): RetryManager
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.36
 Nodes (1): FileLogger
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.28
 Nodes (3): convertMemoryRowToItem(), isMemoryType(), isPrivacyScope()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.31
 Nodes (1): LoggingRateLimiter
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.36
 Nodes (7): canonicalizeHttpBindHostForListen(), formatHttpBindHostForUrl(), getMementoHttpSecurityStartupViolationMessage(), isHttpBindHostRemotelyReachable(), isIpv4Loopback127Block(), isIpv4MappedLoopback(), MementoHttpSecurityStartupError
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.36
 Nodes (1): AnchorReanchorService
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (1): NHopLinkedMemoryService
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.22
 Nodes (2): DefaultSearchLogger, HybridSearchFactory
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.22
 Nodes (0): 
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.36
 Nodes (1): SearchEngineFtsAvailability
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.31
 Nodes (4): EventOutboxService, isEventOutboxEnabled(), parsePayload(), toEvent()
-
-### Community 204 - "Community 204"
-Cohesion: 0.36
-Nodes (6): checkDbConnection(), getRetryCount(), runEmbeddingAndNeighbors(), runRelationExtraction(), runTripleExtractionJob(), updateTripleStatus()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.33
@@ -4224,19 +4225,19 @@ Nodes (0):
 
 ### Community 691 - "Community 691"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 692 - "Community 692"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 693 - "Community 693"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 694 - "Community 694"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 695 - "Community 695"
 Cohesion: 0.67
@@ -4267,24 +4268,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 703 - "Community 703"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 704 - "Community 704"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
-Nodes (1): AgentIntegrationError
+Nodes (0): 
 
 ### Community 706 - "Community 706"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): AgentIntegrationError
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
@@ -4295,16 +4296,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 709 - "Community 709"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 710 - "Community 710"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 711 - "Community 711"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
@@ -4315,52 +4316,52 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 714 - "Community 714"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 715 - "Community 715"
 Cohesion: 1.0
 Nodes (2): calculateRanks(), calculateSpearmanRho()
 
-### Community 715 - "Community 715"
+### Community 716 - "Community 716"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 716 - "Community 716"
+### Community 717 - "Community 717"
 Cohesion: 1.0
 Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
-### Community 717 - "Community 717"
+### Community 718 - "Community 718"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 718 - "Community 718"
-Cohesion: 1.0
-Nodes (2): main(), option()
 
 ### Community 719 - "Community 719"
 Cohesion: 1.0
-Nodes (2): fetchJson(), testDockerServer()
+Nodes (2): main(), option()
 
 ### Community 720 - "Community 720"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): fetchJson(), testDockerServer()
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 723 - "Community 723"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 725 - "Community 725"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 726 - "Community 726"
 Cohesion: 0.67
@@ -4383,7 +4384,7 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 731 - "Community 731"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 732 - "Community 732"
@@ -7142,1388 +7143,1392 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 1421 - "Community 1421"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `TimeoutError`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 731`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 732`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 733`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 734`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 735`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 736`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 737`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 738`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 739`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 740`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 741`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
+- **Thin community `Community 742`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 743`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 744`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 745`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
+- **Thin community `Community 746`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
+- **Thin community `Community 747`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 748`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 749`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
+- **Thin community `Community 750`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 751`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 752`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
+- **Thin community `Community 753`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 754`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
+- **Thin community `Community 755`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
+- **Thin community `Community 756`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
+- **Thin community `Community 757`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
+- **Thin community `Community 758`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 759`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
+- **Thin community `Community 760`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 761`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `request()`, `audit.routes.spec.ts`
+- **Thin community `Community 762`** (2 nodes): `request()`, `audit.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 763`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 764`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
+- **Thin community `Community 765`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 766`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 767`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 768`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 769`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
+- **Thin community `Community 770`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 771`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 772`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 773`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 774`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 775`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
+- **Thin community `Community 776`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
+- **Thin community `Community 777`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `event()`, `codex-hook.spec.ts`
+- **Thin community `Community 778`** (2 nodes): `event()`, `codex-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
+- **Thin community `Community 779`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `agentAskHelpText()`, `help.ts`
+- **Thin community `Community 780`** (2 nodes): `agentAskHelpText()`, `help.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 781`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 782`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 783`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 784`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 785`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 786`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 787`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 788`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 789`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 790`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 791`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 792`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 793`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
+- **Thin community `Community 794`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
+- **Thin community `Community 795`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
+- **Thin community `Community 796`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `runner.ts`, `runCodexHook()`
+- **Thin community `Community 797`** (2 nodes): `runner.ts`, `runCodexHook()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 798`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createMementoClient()`, `factory.ts`
+- **Thin community `Community 799`** (2 nodes): `createMementoClient()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 800`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 801`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 802`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 803`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 804`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 805`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 806`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 807`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 808`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 809`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
+- **Thin community `Community 810`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
+- **Thin community `Community 811`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
+- **Thin community `Community 812`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
+- **Thin community `Community 813`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 814`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 815`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 816`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 817`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 818`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 819`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
+- **Thin community `Community 820`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `log()`, `init-log.ts`
+- **Thin community `Community 821`** (2 nodes): `log()`, `init-log.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 822`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
+- **Thin community `Community 823`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
+- **Thin community `Community 824`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
+- **Thin community `Community 825`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 826`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 827`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 828`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 829`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 830`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 831`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 832`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
+- **Thin community `Community 833`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 834`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 835`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 836`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 837`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 838`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 839`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `runAnchorAutoRefresh()`, `batch-scheduler-anchor-handlers.ts`
+- **Thin community `Community 840`** (2 nodes): `runAnchorAutoRefresh()`, `batch-scheduler-anchor-handlers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
+- **Thin community `Community 841`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 842`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 843`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 844`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
+- **Thin community `Community 845`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
+- **Thin community `Community 846`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 847`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
+- **Thin community `Community 848`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
+- **Thin community `Community 849`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
+- **Thin community `Community 850`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
+- **Thin community `Community 851`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
+- **Thin community `Community 852`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
+- **Thin community `Community 853`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 854`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 855`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 856`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 857`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 858`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 859`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 860`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 861`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 862`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
+- **Thin community `Community 863`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 864`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 865`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `initializeGemini()`, `gemini.ts`
+- **Thin community `Community 866`** (2 nodes): `initializeGemini()`, `gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `initializeOpenAI()`, `openai.ts`
+- **Thin community `Community 867`** (2 nodes): `initializeOpenAI()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `source-uri.ts`, `validateSource()`
+- **Thin community `Community 868`** (2 nodes): `source-uri.ts`, `validateSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 869`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 870`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 871`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 872`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 873`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
+- **Thin community `Community 874`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
+- **Thin community `Community 875`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
+- **Thin community `Community 876`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 877`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 878`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 879`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 880`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
+- **Thin community `Community 881`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 882`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 883`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 884`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 885`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 886`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 887`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
+- **Thin community `Community 888`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 889`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 890`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 891`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 892`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
+- **Thin community `Community 893`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 894`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 895`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
+- **Thin community `Community 896`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
+- **Thin community `Community 897`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 898`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
+- **Thin community `Community 899`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
+- **Thin community `Community 900`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 901`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 902`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
+- **Thin community `Community 903`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 904`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 905`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 906`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 907`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 908`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 909`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 910`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 911`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 912`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 913`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 914`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 915`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 916`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
+- **Thin community `Community 917`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 918`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 919`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 920`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 921`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 922`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 923`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 924`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 925`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 926`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 927`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 928`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 929`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 930`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `matchRelations()`, `matching-rules.ts`
+- **Thin community `Community 931`** (2 nodes): `matchRelations()`, `matching-rules.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
+- **Thin community `Community 932`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
+- **Thin community `Community 933`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 934`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 935`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 936`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 937`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 938`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 939`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 940`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 941`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 942`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 943`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 944`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 945`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 946`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 947`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 948`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 949`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 950`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 951`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 952`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 953`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 954`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 955`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
+- **Thin community `Community 956`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 957`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 958`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 959`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 960`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 961`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 962`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 963`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 964`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 965`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 966`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 967`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 968`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 969`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 970`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 971`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 972`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 973`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 974`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 975`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 976`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 977`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 978`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 979`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 980`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 981`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 982`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 983`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 984`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 985`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 986`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
+- **Thin community `Community 987`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 988`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
+- **Thin community `Community 989`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 990`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
+- **Thin community `Community 991`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
+- **Thin community `Community 992`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
+- **Thin community `Community 993`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 994`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 995`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 996`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 997`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `types.ts`
+- **Thin community `Community 998`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 999`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `index.ts`
+- **Thin community `Community 1000`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 1001`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 1002`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 1003`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 1004`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 1005`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 1006`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `transport.ts`
+- **Thin community `Community 1007`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `index.ts`
+- **Thin community `Community 1008`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 1009`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 1010`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1011`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 1012`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 1013`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 1014`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 1015`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 1016`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 1017`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 1018`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 1019`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 1020`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 1021`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `audit-tool-dispatch.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `audit-tool-dispatch.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 1027`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 1028`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 1029`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 1031`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 1032`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 1033`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 1035`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 1036`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1037`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `context.ts`
+- **Thin community `Community 1038`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 1039`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `mcp-tool-call-error.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 1041`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 1042`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 1043`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `index.ts`
+- **Thin community `Community 1044`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 1045`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 1046`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `agent.routes.types.ts`
+- **Thin community `Community 1047`** (1 nodes): `agent.routes.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `agent.routes.constants.ts`
+- **Thin community `Community 1048`** (1 nodes): `agent.routes.constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `types.ts`
+- **Thin community `Community 1049`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `runtime-transport-parity.spec.ts`
+- **Thin community `Community 1050`** (1 nodes): `runtime-transport-parity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 1051`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 1052`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `agent-ask.ts`
+- **Thin community `Community 1053`** (1 nodes): `agent-ask.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `types.ts`
+- **Thin community `Community 1054`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 1055`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 1056`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 1057`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 1058`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1059`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 1060`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 1061`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 1062`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 1063`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 1064`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1065`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 1066`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 1067`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `types.ts`
+- **Thin community `Community 1068`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 1069`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `index.ts`
+- **Thin community `Community 1070`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1071`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1072`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `types.ts`
+- **Thin community `Community 1073`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1074`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1075`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1076`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `types.ts`
+- **Thin community `Community 1077`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1078`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1079`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `utils.ts`
+- **Thin community `Community 1080`** (1 nodes): `utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `index.ts`
+- **Thin community `Community 1081`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 1082`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `feedback.integration.spec.ts`
+- **Thin community `Community 1083`** (1 nodes): `feedback.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `client-context.ts`
+- **Thin community `Community 1084`** (1 nodes): `client-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `async-optimizer.ts`
+- **Thin community `Community 1085`** (1 nodes): `async-optimizer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `async-optimizer.types.ts`
+- **Thin community `Community 1086`** (1 nodes): `async-optimizer.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 1087`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 1088`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 1089`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 1090`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 1091`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 1092`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 1093`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 1094`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 1095`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `types.ts`
+- **Thin community `Community 1096`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 1097`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 1098`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 1099`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 1100`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `037-memory-forgetting-event.spec.ts`
+- **Thin community `Community 1101`** (1 nodes): `037-memory-forgetting-event.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `039-event-outbox.spec.ts`
+- **Thin community `Community 1102`** (1 nodes): `039-event-outbox.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `040-audit-hash-chain.spec.ts`
+- **Thin community `Community 1103`** (1 nodes): `040-audit-hash-chain.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 1104`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 1105`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 1106`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 1107`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 1108`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 1109`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 1110`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 1111`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 1112`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 1113`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
+- **Thin community `Community 1114`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `maintenance-jobs.spec.ts`
+- **Thin community `Community 1115`** (1 nodes): `maintenance-jobs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `error-handling.spec.ts`
+- **Thin community `Community 1116`** (1 nodes): `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `run-job.spec.ts`
+- **Thin community `Community 1117`** (1 nodes): `run-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `logging.spec.ts`
+- **Thin community `Community 1118`** (1 nodes): `logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `env-defaults.spec.ts`
+- **Thin community `Community 1119`** (1 nodes): `env-defaults.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `lifecycle.spec.ts`
+- **Thin community `Community 1120`** (1 nodes): `lifecycle.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `status-diagnostics.spec.ts`
+- **Thin community `Community 1121`** (1 nodes): `status-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `constructor-config.spec.ts`
+- **Thin community `Community 1122`** (1 nodes): `constructor-config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `relation-validation.spec.ts`
+- **Thin community `Community 1123`** (1 nodes): `relation-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 1124`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 1125`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 1126`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 1127`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 1128`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 1129`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 1130`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1131`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `owner-scope-mode.spec.ts`
+- **Thin community `Community 1132`** (1 nodes): `owner-scope-mode.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 1133`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 1134`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 1135`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1136`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 1137`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 1138`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `pii-masker-api-key.spec.ts`
+- **Thin community `Community 1139`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 1140`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 1141`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `memento-resource-uri.spec.ts`
+- **Thin community `Community 1142`** (1 nodes): `memento-resource-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 1143`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1144`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `external-api-retry-logging.spec.ts`
+- **Thin community `Community 1145`** (1 nodes): `external-api-retry-logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 1146`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 1147`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 1148`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 1149`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 1150`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 1151`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 1152`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 1153`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 1154`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1155`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 1156`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 1157`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 1158`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 1159`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 1160`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 1161`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 1162`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `error-types.ts`
+- **Thin community `Community 1163`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 1164`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 1165`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `search.types.ts`
+- **Thin community `Community 1166`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1167`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 1168`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `constants.ts`
+- **Thin community `Community 1169`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 1170`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 1171`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 1172`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 1173`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 1174`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 1175`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 1176`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 1177`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `schema-version.ts`
+- **Thin community `Community 1178`** (1 nodes): `schema-version.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 1179`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 1180`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 1181`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 1182`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 1183`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 1184`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 1185`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 1186`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 1187`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 1188`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 1189`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 1190`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 1191`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 1192`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 1193`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 1194`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 1195`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 1196`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 1197`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 1198`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 1199`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 1200`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 1201`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `types.ts`
+- **Thin community `Community 1202`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `source-uri.spec.ts`
+- **Thin community `Community 1203`** (1 nodes): `source-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 1204`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 1205`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 1206`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 1207`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 1208`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 1209`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 1210`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 1211`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `index.ts`
+- **Thin community `Community 1212`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 1213`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `database-types.ts`
+- **Thin community `Community 1214`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 1215`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 1216`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 1217`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `types.ts`
+- **Thin community `Community 1218`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `index.ts`
+- **Thin community `Community 1219`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `spec.ts`
+- **Thin community `Community 1220`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 1221`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 1222`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 1223`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `hybrid-search-types.ts`
+- **Thin community `Community 1224`** (1 nodes): `hybrid-search-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `search-ranking.types.ts`
+- **Thin community `Community 1225`** (1 nodes): `search-ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 1226`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 1227`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 1228`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 1229`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 1230`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `search-engine.types.ts`
+- **Thin community `Community 1231`** (1 nodes): `search-engine.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 1232`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1233`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 1234`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `forgetting-event-log.spec.ts`
+- **Thin community `Community 1235`** (1 nodes): `forgetting-event-log.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 1236`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 1237`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 1238`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 1239`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 1240`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 1241`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 1242`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 1243`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `index.ts`
+- **Thin community `Community 1244`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 1245`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
+- **Thin community `Community 1246`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `audit-hash-chain-service.spec.ts`
+- **Thin community `Community 1247`** (1 nodes): `audit-hash-chain-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 1248`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `event-outbox-service.spec.ts`
+- **Thin community `Community 1249`** (1 nodes): `event-outbox-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `index.ts`
+- **Thin community `Community 1250`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 1251`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 1252`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 1253`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 1254`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 1255`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `context-port.ts`
+- **Thin community `Community 1256`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 1257`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 1258`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 1259`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1260`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1261`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1262`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 1263`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 1264`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 1265`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 1266`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 1267`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 1268`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 1269`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 1270`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 1271`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 1272`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `remember-tool-schema.ts`
+- **Thin community `Community 1273`** (1 nodes): `remember-tool-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `remember-tool-host.ts`
+- **Thin community `Community 1274`** (1 nodes): `remember-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `remember-tool-types.ts`
+- **Thin community `Community 1275`** (1 nodes): `remember-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 1276`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 1277`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 1278`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 1279`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 1280`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 1281`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1282`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1283`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1284`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1285`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1286`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1287`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1288`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1289`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1290`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1291`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1292`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1293`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1294`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1295`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1296`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `index.ts`
+- **Thin community `Community 1297`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1298`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1299`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1300`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `relation-tools-registry.spec.ts`
+- **Thin community `Community 1301`** (1 nodes): `relation-tools-registry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1302`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1303`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1304`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1305`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1306`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1307`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1308`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1309`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1310`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
+- **Thin community `Community 1311`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1312`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1313`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1314`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1315`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1316`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1317`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1318`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `triple-extractor.spec.ts`
+- **Thin community `Community 1319`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `triple-parser.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `types.ts`
+- **Thin community `Community 1320`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1321`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1322`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1323`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1324`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1325`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1326`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1327`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1328`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1329`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1330`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1331`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `embedding-reindex-service.spec.ts`
+- **Thin community `Community 1332`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `types.ts`
+- **Thin community `Community 1333`** (1 nodes): `embedding-reindex-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1334`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1335`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1336`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `performance-monitor-types.ts`
+- **Thin community `Community 1337`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1338`** (1 nodes): `performance-monitor-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1339`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1340`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1341`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1342`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `quality-metrics-types.ts`
+- **Thin community `Community 1343`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `types.ts`
+- **Thin community `Community 1344`** (1 nodes): `quality-metrics-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1345`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1346`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1347`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1348`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1349`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1350`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1351`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1352`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1353`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1354`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1355`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1356`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `vector-search-quality-metrics.ts`
+- **Thin community `Community 1357`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `types.ts`
+- **Thin community `Community 1358`** (1 nodes): `vector-search-quality-metrics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `memory-export-import.spec.ts`
+- **Thin community `Community 1359`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `anchor-map.e2e.ts`
+- **Thin community `Community 1360`** (1 nodes): `memory-export-import.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `agent-sessions.e2e.ts`
+- **Thin community `Community 1361`** (1 nodes): `anchor-map.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1362`** (1 nodes): `agent-sessions.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1363`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1364`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1365`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1366`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `longmemeval-validation.spec.ts`
+- **Thin community `Community 1367`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `acquire-longmemeval.spec.ts`
+- **Thin community `Community 1368`** (1 nodes): `longmemeval-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1369`** (1 nodes): `acquire-longmemeval.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1370`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1371`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1372`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1373`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1374`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1375`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1376`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1377`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1378`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `types.ts`
+- **Thin community `Community 1379`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1380`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1381`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1382`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1383`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1384`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1385`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1386`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1387`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1388`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1389`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1390`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1391`** (1 nodes): `entrypoint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `review-candidates-panel-poll-fetch.js`
+- **Thin community `Community 1392`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `embedding-map-state.js`
+- **Thin community `Community 1393`** (1 nodes): `review-candidates-panel-poll-fetch.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1394`** (1 nodes): `embedding-map-state.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `dashboard-auth.js`
+- **Thin community `Community 1395`** (1 nodes): `memory-evolution-demo-shell-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `dashboard-auth-error.js`
+- **Thin community `Community 1396`** (1 nodes): `dashboard-auth.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `review-candidates-panel-poll.js`
+- **Thin community `Community 1397`** (1 nodes): `dashboard-auth-error.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `dashboard-auth-render-message.js`
+- **Thin community `Community 1398`** (1 nodes): `review-candidates-panel-poll.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `graph.js`
+- **Thin community `Community 1399`** (1 nodes): `dashboard-auth-render-message.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `graph-shared.js`
+- **Thin community `Community 1400`** (1 nodes): `graph.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `dashboard-auth-render-form.js`
+- **Thin community `Community 1401`** (1 nodes): `graph-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1402`** (1 nodes): `dashboard-auth-render-form.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `agent-sessions-panel-render.js`
+- **Thin community `Community 1403`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `anchor-map-shared.js`
+- **Thin community `Community 1404`** (1 nodes): `agent-sessions-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `dashboard-auth-render-status.js`
+- **Thin community `Community 1405`** (1 nodes): `anchor-map-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `review-candidates-panel-poll-toast.js`
+- **Thin community `Community 1406`** (1 nodes): `dashboard-auth-render-status.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `agent-sessions-panel-render-injections.js`
+- **Thin community `Community 1407`** (1 nodes): `review-candidates-panel-poll-toast.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
+- **Thin community `Community 1408`** (1 nodes): `agent-sessions-panel-render-injections.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `review-candidates-panel-health.js`
+- **Thin community `Community 1409`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `agent-sessions-panel-render-provenance.js`
+- **Thin community `Community 1410`** (1 nodes): `review-candidates-panel-health.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `embedding-map-chart-colors.js`
+- **Thin community `Community 1411`** (1 nodes): `agent-sessions-panel-render-provenance.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `review-candidates-panel-poll-cycle.js`
+- **Thin community `Community 1412`** (1 nodes): `embedding-map-chart-colors.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `agent-sessions-panel-render-sessions.js`
+- **Thin community `Community 1413`** (1 nodes): `review-candidates-panel-poll-cycle.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `dashboard-auth-requests.js`
+- **Thin community `Community 1414`** (1 nodes): `agent-sessions-panel-render-sessions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `review-candidates-panel-render.js`
+- **Thin community `Community 1415`** (1 nodes): `dashboard-auth-requests.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `dashboard-auth-ui.js`
+- **Thin community `Community 1416`** (1 nodes): `review-candidates-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `dashboard-auth-render-tabs.js`
+- **Thin community `Community 1417`** (1 nodes): `dashboard-auth-ui.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `review-candidates-panel-poll-badge.js`
+- **Thin community `Community 1418`** (1 nodes): `dashboard-auth-render-tabs.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `graph-embed-init.js`
+- **Thin community `Community 1419`** (1 nodes): `review-candidates-panel-poll-badge.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `dashboard-auth-render.js`
+- **Thin community `Community 1420`** (1 nodes): `graph-embed-init.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1421`** (1 nodes): `dashboard-auth-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 993
+      "community": 994
     },
     {
       "label": "playwright.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config_ts",
-      "community": 994
+      "community": 995
     },
     {
       "label": "vitest.config.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 995
+      "community": 996
     },
     {
       "label": "assistant.spec.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 996
+      "community": 997
     },
     {
       "label": "types.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 997
+      "community": 998
     },
     {
       "label": "types.spec.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 998
+      "community": 999
     },
     {
       "label": "assistant.ts",
@@ -57,7 +57,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_ts",
-      "community": 172
+      "community": 173
     },
     {
       "label": "MementoAssistant",
@@ -65,7 +65,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L21",
       "id": "assistant_mementoassistant",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".constructor()",
@@ -73,7 +73,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L34",
       "id": "assistant_mementoassistant_constructor",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".fromEnv()",
@@ -81,7 +81,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L46",
       "id": "assistant_mementoassistant_fromenv",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".beforeUserTurn()",
@@ -89,7 +89,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L61",
       "id": "assistant_mementoassistant_beforeuserturn",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".afterAssistantTurn()",
@@ -97,7 +97,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L67",
       "id": "assistant_mementoassistant_afterassistantturn",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".recall()",
@@ -105,7 +105,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L75",
       "id": "assistant_mementoassistant_recall",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".remember()",
@@ -113,7 +113,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L78",
       "id": "assistant_mementoassistant_remember",
-      "community": 172
+      "community": 173
     },
     {
       "label": ".close()",
@@ -121,7 +121,7 @@
       "source_file": "packages/memento-assistant/src/assistant.ts",
       "source_location": "L81",
       "id": "assistant_mementoassistant_close",
-      "community": 172
+      "community": 173
     },
     {
       "label": "index.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 999
+      "community": 1000
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 1000
+      "community": 1001
     },
     {
       "label": "after-assistant-turn.ts",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 731
+      "community": 732
     },
     {
       "label": "before-user-turn.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 732
+      "community": 733
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 1001
+      "community": 1002
     },
     {
       "label": "auto-remember-policy.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 733
+      "community": 734
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 1002
+      "community": 1003
     },
     {
       "label": "channel-scope.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 1003
+      "community": 1004
     },
     {
       "label": "http-transport.ts",
@@ -289,7 +289,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_ts",
-      "community": 173
+      "community": 174
     },
     {
       "label": "HttpTransport",
@@ -297,7 +297,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L19",
       "id": "http_transport_httptransport",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".constructor()",
@@ -305,7 +305,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L24",
       "id": "http_transport_httptransport_constructor",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".connect()",
@@ -313,7 +313,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L29",
       "id": "http_transport_httptransport_connect",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".recall()",
@@ -321,7 +321,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L39",
       "id": "http_transport_httptransport_recall",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".remember()",
@@ -329,7 +329,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L45",
       "id": "http_transport_httptransport_remember",
-      "community": 173
+      "community": 174
     },
     {
       "label": ".close()",
@@ -337,7 +337,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L59",
       "id": "http_transport_httptransport_close",
-      "community": 173
+      "community": 174
     },
     {
       "label": "toClientSearchFilters()",
@@ -345,7 +345,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L66",
       "id": "http_transport_toclientsearchfilters",
-      "community": 173
+      "community": 174
     },
     {
       "label": "isClientMemoryType()",
@@ -353,7 +353,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.ts",
       "source_location": "L77",
       "id": "http_transport_isclientmemorytype",
-      "community": 173
+      "community": 174
     },
     {
       "label": "stdio-transport.spec.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 1004
+      "community": 1005
     },
     {
       "label": "mock-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 1005
+      "community": 1006
     },
     {
       "label": "transport.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 1006
+      "community": 1007
     },
     {
       "label": "index.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 1007
+      "community": 1008
     },
     {
       "label": "http-transport.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 1008
+      "community": 1009
     },
     {
       "label": "factory.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 734
+      "community": 735
     },
     {
       "label": "createTransportFromEnv()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 734
+      "community": 735
     },
     {
       "label": "stdio-transport.ts",
@@ -417,7 +417,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_ts",
-      "community": 174
+      "community": 175
     },
     {
       "label": "StdioTransport",
@@ -425,7 +425,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L13",
       "id": "stdio_transport_stdiotransport",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".constructor()",
@@ -433,7 +433,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L19",
       "id": "stdio_transport_stdiotransport_constructor",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".connect()",
@@ -441,7 +441,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L21",
       "id": "stdio_transport_stdiotransport_connect",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".recall()",
@@ -449,7 +449,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L45",
       "id": "stdio_transport_stdiotransport_recall",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".remember()",
@@ -457,7 +457,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L54",
       "id": "stdio_transport_stdiotransport_remember",
-      "community": 174
+      "community": 175
     },
     {
       "label": ".close()",
@@ -465,7 +465,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L65",
       "id": "stdio_transport_stdiotransport_close",
-      "community": 174
+      "community": 175
     },
     {
       "label": "parseToolJson()",
@@ -473,7 +473,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L74",
       "id": "stdio_transport_parsetooljson",
-      "community": 174
+      "community": 175
     },
     {
       "label": "getToolResponseContent()",
@@ -481,7 +481,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.ts",
       "source_location": "L85",
       "id": "stdio_transport_gettoolresponsecontent",
-      "community": 174
+      "community": 175
     },
     {
       "label": "factory.spec.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 1009
+      "community": 1010
     },
     {
       "label": "mock-transport.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 1010
+      "community": 1011
     },
     {
       "label": "retry-queue.spec.ts",
@@ -649,7 +649,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 1011
+      "community": 1012
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -657,7 +657,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 1012
+      "community": 1013
     },
     {
       "label": "retry-queue.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 1013
+      "community": 1014
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 1014
+      "community": 1015
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 1015
+      "community": 1016
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 1016
+      "community": 1017
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 1017
+      "community": 1018
     },
     {
       "label": "http.integration.spec.ts",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 1018
+      "community": 1019
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 1019
+      "community": 1020
     },
     {
       "label": "start-http-server.ts",
@@ -809,7 +809,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 1020
+      "community": 1021
     },
     {
       "label": "test-integration.js",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 735
+      "community": 736
     },
     {
       "label": "testBasicFunctionality()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 735
+      "community": 736
     },
     {
       "label": "performance-optimizer.js",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "basicUsageExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 736
+      "community": 737
     },
     {
       "label": "performance-examples.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "advancedUsageExample()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 737
+      "community": 738
     },
     {
       "label": "migration-guide.ts",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "makeNullRunner()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 738
+      "community": 739
     },
     {
       "label": "telemetry-cli.ts",
@@ -1641,7 +1641,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_ts",
-      "community": 175
+      "community": 176
     },
     {
       "label": "writeStdout()",
@@ -1649,7 +1649,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L7",
       "id": "cli_writestdout",
-      "community": 175
+      "community": 176
     },
     {
       "label": "writeStderr()",
@@ -1657,7 +1657,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L19",
       "id": "cli_writestderr",
-      "community": 175
+      "community": 176
     },
     {
       "label": "stripGlobalArgvForAgentDetection()",
@@ -1665,7 +1665,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L45",
       "id": "cli_stripglobalargvforagentdetection",
-      "community": 175
+      "community": 176
     },
     {
       "label": "parseGlobalFlags()",
@@ -1673,7 +1673,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L59",
       "id": "cli_parseglobalflags",
-      "community": 175
+      "community": 176
     },
     {
       "label": "findSubcommandWithIndex()",
@@ -1681,7 +1681,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L75",
       "id": "cli_findsubcommandwithindex",
-      "community": 175
+      "community": 176
     },
     {
       "label": "subcommandArgvFrom()",
@@ -1689,7 +1689,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L91",
       "id": "cli_subcommandargvfrom",
-      "community": 175
+      "community": 176
     },
     {
       "label": "parseCli()",
@@ -1697,7 +1697,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L106",
       "id": "cli_parsecli",
-      "community": 175
+      "community": 176
     },
     {
       "label": "main()",
@@ -1705,7 +1705,7 @@
       "source_file": "packages/memento-server/src/cli.ts",
       "source_location": "L150",
       "id": "cli_main",
-      "community": 175
+      "community": 176
     },
     {
       "label": "check-migration-status.ts",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 1021
+      "community": 1022
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 1022
+      "community": 1023
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 1023
+      "community": 1024
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "readShellSources()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L47",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 739
+      "community": 740
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 1024
+      "community": 1025
     },
     {
       "label": "audit-tool-dispatch.spec.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/audit-tool-dispatch.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_audit_tool_dispatch_spec_ts",
-      "community": 1025
+      "community": 1026
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 1026
+      "community": 1027
     },
     {
       "label": "context.spec.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 1027
+      "community": 1028
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 1028
+      "community": 1029
     },
     {
       "label": "server-factory.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "createServerFactory()",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 740
+      "community": 741
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 1029
+      "community": 1030
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 1030
+      "community": 1031
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_websocket_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "setupWebSocketServer()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L20",
       "id": "http_server_websocket_setupwebsocketserver",
-      "community": 741
+      "community": 742
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "startStdioServer()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 742
+      "community": 743
     },
     {
       "label": "audit-tool-dispatch.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 1031
+      "community": 1032
     },
     {
       "label": "server-state.spec.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 1032
+      "community": 1033
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2537,7 +2537,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_ts",
-      "community": 176
+      "community": 177
     },
     {
       "label": "Semaphore",
@@ -2545,7 +2545,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L54",
       "id": "index_semaphore",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".constructor()",
@@ -2553,7 +2553,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L57",
       "id": "index_semaphore_constructor",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".acquire()",
@@ -2561,7 +2561,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L58",
       "id": "index_semaphore_acquire",
-      "community": 176
+      "community": 177
     },
     {
       "label": ".release()",
@@ -2569,7 +2569,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L62",
       "id": "index_semaphore_release",
-      "community": 176
+      "community": 177
     },
     {
       "label": "runHeavyInit()",
@@ -2577,7 +2577,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L93",
       "id": "index_runheavyinit",
-      "community": 176
+      "community": 177
     },
     {
       "label": "registerHandlers()",
@@ -2585,7 +2585,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L112",
       "id": "index_registerhandlers",
-      "community": 176
+      "community": 177
     },
     {
       "label": "startServer()",
@@ -2593,7 +2593,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L150",
       "id": "index_startserver",
-      "community": 176
+      "community": 177
     },
     {
       "label": "cleanup()",
@@ -2601,7 +2601,7 @@
       "source_file": "packages/memento-server/src/server/index.ts",
       "source_location": "L189",
       "id": "index_cleanup",
-      "community": 176
+      "community": 177
     },
     {
       "label": "owner-scope.integration.spec.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 1033
+      "community": 1034
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 743
+      "community": 744
     },
     {
       "label": "http-server-lifecycle.ts",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 1034
+      "community": 1035
     },
     {
       "label": "bootstrap.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 1035
+      "community": 1036
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 1036
+      "community": 1037
     },
     {
       "label": "sse-server-impl.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 1037
+      "community": 1038
     },
     {
       "label": "batch-run-history.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 1038
+      "community": 1039
     },
     {
       "label": "mcp-tool-call-error.spec.ts",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
-      "community": 1039
+      "community": 1040
     },
     {
       "label": "mcp-tool-call-error.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 744
+      "community": 745
     },
     {
       "label": "tool-result.utils.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_tool_result_utils_ts",
-      "community": 745
+      "community": 746
     },
     {
       "label": "extractToolResultPayload()",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L6",
       "id": "tool_result_utils_extracttoolresultpayload",
-      "community": 745
+      "community": 746
     },
     {
       "label": "anchor-map.handler.spec.ts",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 1040
+      "community": 1041
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 1041
+      "community": 1042
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 1042
+      "community": 1043
     },
     {
       "label": "http-rate-limit.middleware.spec.ts",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_rate_limit_middleware_spec_ts",
-      "community": 746
+      "community": 747
     },
     {
       "label": "getRequest()",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L8",
       "id": "http_rate_limit_middleware_spec_getrequest",
-      "community": 746
+      "community": 747
     },
     {
       "label": "owner-scope.middleware.ts",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 747
+      "community": 748
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L33",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 747
+      "community": 748
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 748
+      "community": 749
     },
     {
       "label": "createMockResponse()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 748
+      "community": 749
     },
     {
       "label": "index.ts",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 1043
+      "community": 1044
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_audit_middleware_spec_ts",
-      "community": 749
+      "community": 750
     },
     {
       "label": "createMockResponse()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L18",
       "id": "http_audit_middleware_spec_createmockresponse",
-      "community": 749
+      "community": 750
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 750
+      "community": 751
     },
     {
       "label": "createServiceInjector()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 750
+      "community": 751
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 751
+      "community": 752
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L16",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 751
+      "community": 752
     },
     {
       "label": "http-rate-limit.middleware.ts",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_spec_ts",
-      "community": 752
+      "community": 753
     },
     {
       "label": "runMiddleware()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L18",
       "id": "owner_scope_middleware_spec_runmiddleware",
-      "community": 752
+      "community": 753
     },
     {
       "label": "session-store.spec.ts",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 1044
+      "community": 1045
     },
     {
       "label": "session-store.ts",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 753
+      "community": 754
     },
     {
       "label": "createSessionStore()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 753
+      "community": 754
     },
     {
       "label": "stdio-server.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_ts",
-      "community": 754
+      "community": 755
     },
     {
       "label": "createAgentRouter()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L44",
       "id": "agent_routes_createagentrouter",
-      "community": 754
+      "community": 755
     },
     {
       "label": "quality.routes.spec.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 1045
+      "community": 1046
     },
     {
       "label": "agent.routes.validation.ts",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_maintenance_routes_spec_ts",
-      "community": 755
+      "community": 756
     },
     {
       "label": "request()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L8",
       "id": "maintenance_routes_spec_request",
-      "community": 755
+      "community": 756
     },
     {
       "label": "agent.routes.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_personal_routes_spec_ts",
-      "community": 756
+      "community": 757
     },
     {
       "label": "invoke()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L33",
       "id": "agent_personal_routes_spec_invoke",
-      "community": 756
+      "community": 757
     },
     {
       "label": "agent.routes.promotions.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_events_ts",
-      "community": 757
+      "community": 758
     },
     {
       "label": "prepareEvent()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L14",
       "id": "agent_routes_events_prepareevent",
-      "community": 757
+      "community": 758
     },
     {
       "label": "agent.routes.types.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_types_ts",
-      "community": 1046
+      "community": 1047
     },
     {
       "label": "admin.routes.ts",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 758
+      "community": 759
     },
     {
       "label": "createAdminRouter()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L29",
       "id": "admin_routes_createadminrouter",
-      "community": 758
+      "community": 759
     },
     {
       "label": "agent.routes.status.ts",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.constants.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_constants_ts",
-      "community": 1047
+      "community": 1048
     },
     {
       "label": "mcp.routes.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_routes_ts",
-      "community": 759
+      "community": 760
     },
     {
       "label": "createMcpRouter()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L17",
       "id": "mcp_routes_createmcprouter",
-      "community": 759
+      "community": 760
     },
     {
       "label": "admin.routes.spec.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 760
+      "community": 761
     },
     {
       "label": "createToolsRouter()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L19",
       "id": "tools_routes_createtoolsrouter",
-      "community": 760
+      "community": 761
     },
     {
       "label": "agent.routes.injection.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_audit_routes_spec_ts",
-      "community": 761
+      "community": 762
     },
     {
       "label": "request()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L8",
       "id": "audit_routes_spec_request",
-      "community": 761
+      "community": 762
     },
     {
       "label": "api.routes.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 762
+      "community": 763
     },
     {
       "label": "createApiRouter()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L24",
       "id": "api_routes_createapirouter",
-      "community": 762
+      "community": 763
     },
     {
       "label": "agent.routes.utils.ts",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 763
+      "community": 764
     },
     {
       "label": "createQualityRouter()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 763
+      "community": 764
     },
     {
       "label": "agent.routes.context.ts",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_types_ts",
-      "community": 1048
+      "community": 1049
     },
     {
       "label": "handlers.ts",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/runtime-transport-parity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_runtime_transport_parity_spec_ts",
-      "community": 1049
+      "community": 1050
     },
     {
       "label": "json-rpc.ts",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_ts",
-      "community": 764
+      "community": 765
     },
     {
       "label": "registerAdminEvolutionDemoRoutes()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L13",
       "id": "admin_evolution_demo_routes_registeradminevolutiondemoroutes",
-      "community": 764
+      "community": 765
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 765
+      "community": 766
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 765
+      "community": 766
     },
     {
       "label": "admin-graph-response.ts",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 766
+      "community": 767
     },
     {
       "label": "buildGraphResponse()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L75",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 766
+      "community": 767
     },
     {
       "label": "admin-tools.routes.ts",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 767
+      "community": 768
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 767
+      "community": 768
     },
     {
       "label": "admin-batch.routes.ts",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 768
+      "community": 769
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 768
+      "community": 769
     },
     {
       "label": "admin-forgetting.routes.ts",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_forgetting_routes_ts",
-      "community": 769
+      "community": 770
     },
     {
       "label": "registerAdminForgettingRoutes()",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L11",
       "id": "admin_forgetting_routes_registeradminforgettingroutes",
-      "community": 769
+      "community": 770
     },
     {
       "label": "admin-graph.routes.ts",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 770
+      "community": 771
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 770
+      "community": 771
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 771
+      "community": 772
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 771
+      "community": 772
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 772
+      "community": 773
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 772
+      "community": 773
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 773
+      "community": 774
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 773
+      "community": 774
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 774
+      "community": 775
     },
     {
       "label": "argv()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 774
+      "community": 775
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 1050
+      "community": 1051
     },
     {
       "label": "agent-ops-demo.ts",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_demo_ts",
-      "community": 775
+      "community": 776
     },
     {
       "label": "runDemo()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L11",
       "id": "agent_ops_demo_rundemo",
-      "community": 775
+      "community": 776
     },
     {
       "label": "env-loader.ts",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 1051
+      "community": 1052
     },
     {
       "label": "codex-hook.ts",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_ts",
-      "community": 1052
+      "community": 1053
     },
     {
       "label": "agent-ops.spec.ts",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_spec_ts",
-      "community": 776
+      "community": 777
     },
     {
       "label": "event()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L7",
       "id": "claude_code_hook_spec_event",
-      "community": 776
+      "community": 777
     },
     {
       "label": "agent-ops.ts",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_spec_ts",
-      "community": 777
+      "community": 778
     },
     {
       "label": "event()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L7",
       "id": "codex_hook_spec_event",
-      "community": 777
+      "community": 778
     },
     {
       "label": "agent-ops-core.ts",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_approval_ts",
-      "community": 778
+      "community": 779
     },
     {
       "label": "promptApproveInteractive()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L7",
       "id": "approval_promptapproveinteractive",
-      "community": 778
+      "community": 779
     },
     {
       "label": "help.ts",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_help_ts",
-      "community": 779
+      "community": 780
     },
     {
       "label": "agentAskHelpText()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "help_agentaskhelptext",
-      "community": 779
+      "community": 780
     },
     {
       "label": "types.ts",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 1053
+      "community": 1054
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "testSimpleAlerts()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 780
+      "community": 781
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 781
+      "community": 782
     },
     {
       "label": "testBasicFunctionality()",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 781
+      "community": 782
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 782
+      "community": 783
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 782
+      "community": 783
     },
     {
       "label": "test-server-synchronization.ts",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 783
+      "community": 784
     },
     {
       "label": "testErrorLogging()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 783
+      "community": 784
     },
     {
       "label": "debug-http-v2.ts",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 784
+      "community": 785
     },
     {
       "label": "testFetch()",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 784
+      "community": 785
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 785
+      "community": 786
     },
     {
       "label": "initializeTestDatabase()",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 785
+      "community": 786
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 1054
+      "community": 1055
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 1055
+      "community": 1056
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 786
+      "community": 787
     },
     {
       "label": "testReflexionE2E()",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 786
+      "community": 787
     },
     {
       "label": "test-alerts-direct.ts",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 787
+      "community": 788
     },
     {
       "label": "testAlertsDirect()",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 787
+      "community": 788
     },
     {
       "label": "test-client.ts",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 1056
+      "community": 1057
     },
     {
       "label": "test-http-server-v2.ts",
@@ -7081,7 +7081,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_ts",
-      "community": 177
+      "community": 178
     },
     {
       "label": "setupTestDatabase()",
@@ -7089,7 +7089,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L32",
       "id": "test_http_server_v2_setuptestdatabase",
-      "community": 177
+      "community": 178
     },
     {
       "label": "createAdminSessionCookie()",
@@ -7097,7 +7097,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L177",
       "id": "test_http_server_v2_createadminsessioncookie",
-      "community": 177
+      "community": 178
     },
     {
       "label": "testBasicEndpoints()",
@@ -7105,7 +7105,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L189",
       "id": "test_http_server_v2_testbasicendpoints",
-      "community": 177
+      "community": 178
     },
     {
       "label": "testMCPTools()",
@@ -7113,7 +7113,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L227",
       "id": "test_http_server_v2_testmcptools",
-      "community": 177
+      "community": 178
     },
     {
       "label": "testAdminAPIs()",
@@ -7121,7 +7121,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L339",
       "id": "test_http_server_v2_testadminapis",
-      "community": 177
+      "community": 178
     },
     {
       "label": "testWebSocket()",
@@ -7129,7 +7129,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L407",
       "id": "test_http_server_v2_testwebsocket",
-      "community": 177
+      "community": 178
     },
     {
       "label": "testSSE()",
@@ -7137,7 +7137,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L489",
       "id": "test_http_server_v2_testsse",
-      "community": 177
+      "community": 178
     },
     {
       "label": "runTests()",
@@ -7145,7 +7145,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2.ts",
       "source_location": "L600",
       "id": "test_http_server_v2_runtests",
-      "community": 177
+      "community": 178
     },
     {
       "label": "test-performance-alerts.ts",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "testPerformanceAlerts()",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 788
+      "community": 789
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 789
+      "community": 790
     },
     {
       "label": "testPathTraversalE2E()",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 789
+      "community": 790
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 790
+      "community": 791
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 790
+      "community": 791
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 1057
+      "community": 1058
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 1058
+      "community": 1059
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 1059
+      "community": 1060
     },
     {
       "label": "brave-search-provider.ts",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 791
+      "community": 792
     },
     {
       "label": "createSearchProvider()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 791
+      "community": 792
     },
     {
       "label": "search-provider.ts",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 1060
+      "community": 1061
     },
     {
       "label": "llm-provider.ts",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 1061
+      "community": 1062
     },
     {
       "label": "claude-provider.spec.ts",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 1062
+      "community": 1063
     },
     {
       "label": "types.ts",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 792
+      "community": 793
     },
     {
       "label": "loadAgentConfig()",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 792
+      "community": 793
     },
     {
       "label": "system-prompt.ts",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 1063
+      "community": 1064
     },
     {
       "label": "vitest.config.ts",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 1064
+      "community": 1065
     },
     {
       "label": "injection-contract.spec.ts",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 1065
+      "community": 1066
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_queue_runtime_spec_ts",
-      "community": 793
+      "community": 794
     },
     {
       "label": "transport()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L179",
       "id": "queue_runtime_spec_transport",
-      "community": 793
+      "community": 794
     },
     {
       "label": "redaction-size.spec.ts",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 1066
+      "community": 1067
     },
     {
       "label": "injection-contract.ts",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 1067
+      "community": 1068
     },
     {
       "label": "runtime.ts",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_test_fixtures_ts",
-      "community": 794
+      "community": 795
     },
     {
       "label": "eventFixture()",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L15",
       "id": "test_fixtures_eventfixture",
-      "community": 794
+      "community": 795
     },
     {
       "label": "schema-normalize.spec.ts",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 1068
+      "community": 1069
     },
     {
       "label": "normalize.ts",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 1069
+      "community": 1070
     },
     {
       "label": "priority-queue.ts",
@@ -7801,7 +7801,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_size_policy_ts",
-      "community": 178
+      "community": 179
     },
     {
       "label": "utf8Size()",
@@ -7809,7 +7809,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L12",
       "id": "size_policy_utf8size",
-      "community": 178
+      "community": 179
     },
     {
       "label": "cloneEvent()",
@@ -7817,7 +7817,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L16",
       "id": "size_policy_cloneevent",
-      "community": 178
+      "community": 179
     },
     {
       "label": "removeOptionalFields()",
@@ -7825,7 +7825,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L20",
       "id": "size_policy_removeoptionalfields",
-      "community": 178
+      "community": 179
     },
     {
       "label": "reducibleText()",
@@ -7833,7 +7833,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L49",
       "id": "size_policy_reducibletext",
-      "community": 178
+      "community": 179
     },
     {
       "label": "truncateToFit()",
@@ -7841,7 +7841,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L89",
       "id": "size_policy_truncatetofit",
-      "community": 178
+      "community": 179
     },
     {
       "label": "applySizePolicy()",
@@ -7849,7 +7849,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L110",
       "id": "size_policy_applysizepolicy",
-      "community": 178
+      "community": 179
     },
     {
       "label": "buildBatch()",
@@ -7857,7 +7857,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L128",
       "id": "size_policy_buildbatch",
-      "community": 178
+      "community": 179
     },
     {
       "label": "validateBatch()",
@@ -7865,7 +7865,7 @@
       "source_file": "packages/memento-agent-integration/src/size-policy.ts",
       "source_location": "L150",
       "id": "size_policy_validatebatch",
-      "community": 178
+      "community": 179
     },
     {
       "label": "schema.ts",
@@ -7873,7 +7873,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_ts",
-      "community": 179
+      "community": 180
     },
     {
       "label": "isRecord()",
@@ -7881,7 +7881,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L50",
       "id": "schema_isrecord",
-      "community": 179
+      "community": 180
     },
     {
       "label": "hasOnlyKeys()",
@@ -7889,7 +7889,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L54",
       "id": "schema_hasonlykeys",
-      "community": 179
+      "community": 180
     },
     {
       "label": "validIdentifier()",
@@ -7897,7 +7897,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L58",
       "id": "schema_valididentifier",
-      "community": 179
+      "community": 180
     },
     {
       "label": "validJsonValue()",
@@ -7905,7 +7905,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L68",
       "id": "schema_validjsonvalue",
-      "community": 179
+      "community": 180
     },
     {
       "label": "validatePayload()",
@@ -7913,7 +7913,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L94",
       "id": "schema_validatepayload",
-      "community": 179
+      "community": 180
     },
     {
       "label": "validateAgentEvent()",
@@ -7921,7 +7921,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L125",
       "id": "schema_validateagentevent",
-      "community": 179
+      "community": 180
     },
     {
       "label": "eventSchema()",
@@ -7929,7 +7929,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L177",
       "id": "schema_eventschema",
-      "community": 179
+      "community": 180
     },
     {
       "label": "asAgentEvent()",
@@ -7937,7 +7937,7 @@
       "source_file": "packages/memento-agent-integration/src/schema.ts",
       "source_location": "L277",
       "id": "schema_asagentevent",
-      "community": 179
+      "community": 180
     },
     {
       "label": "scope.spec.ts",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 1070
+      "community": 1071
     },
     {
       "label": "adapter.ts",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 1071
+      "community": 1072
     },
     {
       "label": "types.ts",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 1072
+      "community": 1073
     },
     {
       "label": "scope.ts",
@@ -8073,7 +8073,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_ts",
-      "community": 180
+      "community": 181
     },
     {
       "label": "value()",
@@ -8081,7 +8081,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L7",
       "id": "scope_value",
-      "community": 180
+      "community": 181
     },
     {
       "label": "defaultGit()",
@@ -8089,7 +8089,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L12",
       "id": "scope_defaultgit",
-      "community": 180
+      "community": 181
     },
     {
       "label": "normalizeRemote()",
@@ -8097,7 +8097,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L25",
       "id": "scope_normalizeremote",
-      "community": 180
+      "community": 181
     },
     {
       "label": "processFromBranch()",
@@ -8105,7 +8105,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L38",
       "id": "scope_processfrombranch",
-      "community": 180
+      "community": 181
     },
     {
       "label": "detectCodexScope()",
@@ -8113,7 +8113,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.ts",
       "source_location": "L44",
       "id": "scope_detectcodexscope",
-      "community": 180
+      "community": 181
     },
     {
       "label": "diagnostics.spec.ts",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 1073
+      "community": 1074
     },
     {
       "label": "diagnostics.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_ts",
-      "community": 795
+      "community": 796
     },
     {
       "label": "diagnoseCodex()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L21",
       "id": "diagnostics_diagnosecodex",
-      "community": 795
+      "community": 796
     },
     {
       "label": "settings.ts",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_ts",
-      "community": 796
+      "community": 797
     },
     {
       "label": "runCodexHook()",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L6",
       "id": "runner_runcodexhook",
-      "community": 796
+      "community": 797
     },
     {
       "label": "adapter.spec.ts",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 1074
+      "community": 1075
     },
     {
       "label": "adapter.ts",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 1075
+      "community": 1076
     },
     {
       "label": "types.ts",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 1076
+      "community": 1077
     },
     {
       "label": "scope.ts",
@@ -8313,7 +8313,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_ts",
-      "community": 180
+      "community": 181
     },
     {
       "label": "explicit()",
@@ -8321,7 +8321,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L7",
       "id": "scope_explicit",
-      "community": 180
+      "community": 181
     },
     {
       "label": "detectClaudeCodeScope()",
@@ -8329,7 +8329,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.ts",
       "source_location": "L44",
       "id": "scope_detectclaudecodescope",
-      "community": 180
+      "community": 181
     },
     {
       "label": "diagnostics.spec.ts",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 1077
+      "community": 1078
     },
     {
       "label": "diagnostics.ts",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 1078
+      "community": 1079
     },
     {
       "label": "utils.spec.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 797
+      "community": 798
     },
     {
       "label": "buildMemory()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 797
+      "community": 798
     },
     {
       "label": "context-injector.ts",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_ts",
-      "community": 1079
+      "community": 1080
     },
     {
       "label": "index.ts",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 1080
+      "community": 1081
     },
     {
       "label": "agent-api.spec.ts",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 1081
+      "community": 1082
     },
     {
       "label": "logger.ts",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/memento-client/src/__tests__/feedback.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_tests_feedback_integration_spec_ts",
-      "community": 1082
+      "community": 1083
     },
     {
       "label": "http-transport.ts",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/memento-client/src/client/client-context.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_client_context_ts",
-      "community": 1083
+      "community": 1084
     },
     {
       "label": "tools-client.ts",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_factory_ts",
-      "community": 798
+      "community": 799
     },
     {
       "label": "createMementoClient()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L7",
       "id": "factory_createmementoclient",
-      "community": 798
+      "community": 799
     },
     {
       "label": "bootstrap.spec.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 799
+      "community": 800
     },
     {
       "label": "initializeServices()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 799
+      "community": 800
     },
     {
       "label": "context.ts",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 800
+      "community": 801
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 800
+      "community": 801
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 801
+      "community": 802
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L14",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 801
+      "community": 802
     },
     {
       "label": "anchor-stack.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 802
+      "community": 803
     },
     {
       "label": "createAnchorStack()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 802
+      "community": 803
     },
     {
       "label": "failure-reflexion.ts",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 803
+      "community": 804
     },
     {
       "label": "startFailureAndReflexion()",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 803
+      "community": 804
     },
     {
       "label": "search-and-embedding.ts",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 804
+      "community": 805
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 804
+      "community": 805
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 805
+      "community": 806
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 805
+      "community": 806
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 806
+      "community": 807
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 806
+      "community": 807
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_ts",
-      "community": 1084
+      "community": 1085
     },
     {
       "label": "consolidation-score-service.spec.ts",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 807
+      "community": 808
     },
     {
       "label": "createInput()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 807
+      "community": 808
     },
     {
       "label": "reflexion-procedural-memory-service.ts",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 808
+      "community": 809
     },
     {
       "label": "createRelationGraph()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 808
+      "community": 809
     },
     {
       "label": "consolidation-score-service.ts",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_types_ts",
-      "community": 1085
+      "community": 1086
     },
     {
       "label": "async-task-worker.ts",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 1086
+      "community": 1087
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -11081,7 +11081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_ts",
-      "community": 181
+      "community": 182
     },
     {
       "label": "TripleExtractionLogger",
@@ -11089,7 +11089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L61",
       "id": "triple_extraction_logger_tripleextractionlogger",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".constructor()",
@@ -11097,7 +11097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L65",
       "id": "triple_extraction_logger_tripleextractionlogger_constructor",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".logExtraction()",
@@ -11105,7 +11105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L91",
       "id": "triple_extraction_logger_tripleextractionlogger_logextraction",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".createLogEntry()",
@@ -11113,7 +11113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L128",
       "id": "triple_extraction_logger_tripleextractionlogger_createlogentry",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".ensureLogDirectory()",
@@ -11121,7 +11121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L191",
       "id": "triple_extraction_logger_tripleextractionlogger_ensurelogdirectory",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".getLogFilePath()",
@@ -11129,7 +11129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L207",
       "id": "triple_extraction_logger_tripleextractionlogger_getlogfilepath",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".listLogFiles()",
@@ -11137,7 +11137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L233",
       "id": "triple_extraction_logger_tripleextractionlogger_listlogfiles",
-      "community": 181
+      "community": 182
     },
     {
       "label": ".deleteOldLogs()",
@@ -11145,7 +11145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.ts",
       "source_location": "L266",
       "id": "triple_extraction_logger_tripleextractionlogger_deleteoldlogs",
-      "community": 181
+      "community": 182
     },
     {
       "label": "reflexion-worker-event-queue.ts",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_create_ts",
-      "community": 809
+      "community": 810
     },
     {
       "label": "createProceduralMemory()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_create_createproceduralmemory",
-      "community": 809
+      "community": 810
     },
     {
       "label": "reflexion-procedural-update-replace.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_replace_ts",
-      "community": 810
+      "community": 811
     },
     {
       "label": "updateProceduralMemoryReplace()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_replace_updateproceduralmemoryreplace",
-      "community": 810
+      "community": 811
     },
     {
       "label": "reflexion-procedural-extraction.ts",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_extraction_ts",
-      "community": 811
+      "community": 812
     },
     {
       "label": "resolveExtractedProceduralMemory()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_extraction_resolveextractedproceduralmemory",
-      "community": 811
+      "community": 812
     },
     {
       "label": "reflexion-procedural-update-versioned.ts",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_versioned_ts",
-      "community": 812
+      "community": 813
     },
     {
       "label": "updateProceduralMemoryVersioned()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L11",
       "id": "reflexion_procedural_update_versioned_updateproceduralmemoryversioned",
-      "community": 812
+      "community": 813
     },
     {
       "label": "reflexion-procedural-update-incremental.ts",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 813
+      "community": 814
     },
     {
       "label": "createBaseSchema()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 813
+      "community": 814
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -11841,7 +11841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 814
+      "community": 815
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -11849,7 +11849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 814
+      "community": 815
     },
     {
       "label": "migration-monitor-service.ts",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 815
+      "community": 816
     },
     {
       "label": "openLockTestDatabase()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 815
+      "community": 816
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 816
+      "community": 817
     },
     {
       "label": "createProgress()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 816
+      "community": 817
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 1087
+      "community": 1088
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 1088
+      "community": 1089
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 817
+      "community": 818
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 817
+      "community": 818
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 1089
+      "community": 1090
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 818
+      "community": 819
     },
     {
       "label": "createCoreMemoryTable()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 818
+      "community": 819
     },
     {
       "label": "init-bootstrap-new-db.ts",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_bootstrap_new_db_ts",
-      "community": 819
+      "community": 820
     },
     {
       "label": "bootstrapNewDatabaseSchema()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L14",
       "id": "init_bootstrap_new_db_bootstrapnewdatabaseschema",
-      "community": 819
+      "community": 820
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -12113,7 +12113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 1090
+      "community": 1091
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_log_ts",
-      "community": 820
+      "community": 821
     },
     {
       "label": "log()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L5",
       "id": "init_log_log",
-      "community": 820
+      "community": 821
     },
     {
       "label": "init.spec.ts",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 1091
+      "community": 1092
     },
     {
       "label": "init.ts",
@@ -12265,7 +12265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 821
+      "community": 822
     },
     {
       "label": "createDbPath()",
@@ -12273,7 +12273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 821
+      "community": 822
     },
     {
       "label": "init-migrate-existing.ts",
@@ -12281,7 +12281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migrate_existing_ts",
-      "community": 822
+      "community": 823
     },
     {
       "label": "migrateExistingDatabaseIfNeeded()",
@@ -12289,7 +12289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L6",
       "id": "init_migrate_existing_migrateexistingdatabaseifneeded",
-      "community": 822
+      "community": 823
     },
     {
       "label": "migrate.spec.ts",
@@ -12297,7 +12297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 1092
+      "community": 1093
     },
     {
       "label": "init-migration-baseline.ts",
@@ -12305,7 +12305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migration_baseline_ts",
-      "community": 823
+      "community": 824
     },
     {
       "label": "recordBundledSchemaSqlMigrationBaseline()",
@@ -12313,7 +12313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L11",
       "id": "init_migration_baseline_recordbundledschemasqlmigrationbaseline",
-      "community": 823
+      "community": 824
     },
     {
       "label": "init-sqlite-session.ts",
@@ -12321,7 +12321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_sqlite_session_ts",
-      "community": 824
+      "community": 825
     },
     {
       "label": "configureSqliteSession()",
@@ -12329,7 +12329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L8",
       "id": "init_sqlite_session_configuresqlitesession",
-      "community": 824
+      "community": 825
     },
     {
       "label": "init-legacy-schema.ts",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 1093
+      "community": 1094
     },
     {
       "label": "migration-runner.ts",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_ts",
-      "community": 182
+      "community": 183
     },
     {
       "label": "MigrationRunner",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L19",
       "id": "migration_runner_migrationrunner",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".constructor()",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L24",
       "id": "migration_runner_migrationrunner_constructor",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".runMigration()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L33",
       "id": "migration_runner_migrationrunner_runmigration",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".rollbackMigration()",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L174",
       "id": "migration_runner_migrationrunner_rollbackmigration",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".runMigrations()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L199",
       "id": "migration_runner_migrationrunner_runmigrations",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".calculateChecksum()",
@@ -12473,7 +12473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L222",
       "id": "migration_runner_migrationrunner_calculatechecksum",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".getBackupManager()",
@@ -12481,7 +12481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L231",
       "id": "migration_runner_migrationrunner_getbackupmanager",
-      "community": 182
+      "community": 183
     },
     {
       "label": ".getVersionManager()",
@@ -12489,7 +12489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.ts",
       "source_location": "L238",
       "id": "migration_runner_migrationrunner_getversionmanager",
-      "community": 182
+      "community": 183
     },
     {
       "label": "migration-runner.integration.spec.ts",
@@ -12497,7 +12497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 825
+      "community": 826
     },
     {
       "label": "createBaseSchema()",
@@ -12505,7 +12505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 825
+      "community": 826
     },
     {
       "label": "migration-logger.spec.ts",
@@ -12513,7 +12513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 1094
+      "community": 1095
     },
     {
       "label": "migration-detector.ts",
@@ -12705,7 +12705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 1095
+      "community": 1096
     },
     {
       "label": "migration-detector.spec.ts",
@@ -12713,7 +12713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 1096
+      "community": 1097
     },
     {
       "label": "backup-manager.ts",
@@ -12801,7 +12801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 1097
+      "community": 1098
     },
     {
       "label": "dependency-validator.ts",
@@ -12905,7 +12905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 1098
+      "community": 1099
     },
     {
       "label": "schema-version-manager.ts",
@@ -12993,7 +12993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 1099
+      "community": 1100
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -13121,7 +13121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_ts",
-      "community": 183
+      "community": 184
     },
     {
       "label": "AnchorTableMigration",
@@ -13129,7 +13129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L20",
       "id": "004_anchor_table_anchortablemigration",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".executeSQL()",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L29",
       "id": "004_anchor_table_anchortablemigration_executesql",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".tableExists()",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L54",
       "id": "004_anchor_table_anchortablemigration_tableexists",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".indexExists()",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L65",
       "id": "004_anchor_table_anchortablemigration_indexexists",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".validateBefore()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L76",
       "id": "004_anchor_table_anchortablemigration_validatebefore",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".up()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L102",
       "id": "004_anchor_table_anchortablemigration_up",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".down()",
@@ -13177,7 +13177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L136",
       "id": "004_anchor_table_anchortablemigration_down",
-      "community": 183
+      "community": 184
     },
     {
       "label": ".validateAfter()",
@@ -13185,7 +13185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.ts",
       "source_location": "L158",
       "id": "004_anchor_table_anchortablemigration_validateafter",
-      "community": 183
+      "community": 184
     },
     {
       "label": "020-process-attribute-table.ts",
@@ -13257,7 +13257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_ts",
-      "community": 184
+      "community": 185
     },
     {
       "label": "FactMetadataFieldsMigration",
@@ -13265,7 +13265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L18",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".tableExists()",
@@ -13273,7 +13273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L23",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_tableexists",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".columnExists()",
@@ -13281,7 +13281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L30",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_columnexists",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".indexExists()",
@@ -13289,7 +13289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L35",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_indexexists",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".validateBefore()",
@@ -13297,7 +13297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L42",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validatebefore",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".up()",
@@ -13305,7 +13305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L59",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_up",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".down()",
@@ -13313,7 +13313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L68",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_down",
-      "community": 184
+      "community": 185
     },
     {
       "label": ".validateAfter()",
@@ -13321,7 +13321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.ts",
       "source_location": "L96",
       "id": "017_fact_metadata_fields_factmetadatafieldsmigration_validateafter",
-      "community": 184
+      "community": 185
     },
     {
       "label": "032-add-project-id.ts",
@@ -13433,7 +13433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_025_memory_item_is_consolidated_ts",
-      "community": 185
+      "community": 186
     },
     {
       "label": "MemoryItemIsConsolidatedMigration",
@@ -13441,7 +13441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L9",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".tableExists()",
@@ -13449,7 +13449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L14",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_tableexists",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".columnExists()",
@@ -13457,7 +13457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L21",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_columnexists",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".indexExists()",
@@ -13465,7 +13465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L26",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_indexexists",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".validateBefore()",
@@ -13473,7 +13473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L33",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validatebefore",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".up()",
@@ -13481,7 +13481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L35",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_up",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".down()",
@@ -13489,7 +13489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L49",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_down",
-      "community": 185
+      "community": 186
     },
     {
       "label": ".validateAfter()",
@@ -13497,7 +13497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/025-memory-item-is-consolidated.ts",
       "source_location": "L58",
       "id": "025_memory_item_is_consolidated_memoryitemisconsolidatedmigration_validateafter",
-      "community": 185
+      "community": 186
     },
     {
       "label": "030-triple-extraction-fields.spec.ts",
@@ -13825,7 +13825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 826
+      "community": 827
     },
     {
       "label": "createBaseSchema()",
@@ -13833,7 +13833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 826
+      "community": 827
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -14073,7 +14073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 827
+      "community": 828
     },
     {
       "label": "createBaseSchema()",
@@ -14081,7 +14081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 827
+      "community": 828
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -14377,7 +14377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 828
+      "community": 829
     },
     {
       "label": "createBaseSchema()",
@@ -14385,7 +14385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 828
+      "community": 829
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -14545,7 +14545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/037-memory-forgetting-event.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_037_memory_forgetting_event_spec_ts",
-      "community": 1100
+      "community": 1101
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -14641,7 +14641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_ts",
-      "community": 186
+      "community": 187
     },
     {
       "label": "TripleExtractionFieldsMigration",
@@ -14649,7 +14649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".tableExists()",
@@ -14657,7 +14657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L15",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_tableexists",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".columnExists()",
@@ -14665,7 +14665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L22",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_columnexists",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".indexExists()",
@@ -14673,7 +14673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L27",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_indexexists",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".validateBefore()",
@@ -14681,7 +14681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L34",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validatebefore",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".up()",
@@ -14689,7 +14689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L36",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_up",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".down()",
@@ -14697,7 +14697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L61",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_down",
-      "community": 186
+      "community": 187
     },
     {
       "label": ".validateAfter()",
@@ -14705,7 +14705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.ts",
       "source_location": "L69",
       "id": "030_triple_extraction_fields_tripleextractionfieldsmigration_validateafter",
-      "community": 186
+      "community": 187
     },
     {
       "label": "039-event-outbox.spec.ts",
@@ -14713,7 +14713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/039-event-outbox.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_039_event_outbox_spec_ts",
-      "community": 1101
+      "community": 1102
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -14721,7 +14721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_021_feedback_event_attribution_ts",
-      "community": 187
+      "community": 188
     },
     {
       "label": "FeedbackEventAttributionMigration",
@@ -14729,7 +14729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L9",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".tableExists()",
@@ -14737,7 +14737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L14",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_tableexists",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".columnExists()",
@@ -14745,7 +14745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L21",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_columnexists",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".indexExists()",
@@ -14753,7 +14753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L26",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_indexexists",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".validateBefore()",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L33",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validatebefore",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".up()",
@@ -14769,7 +14769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L57",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_up",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".down()",
@@ -14777,7 +14777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L89",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_down",
-      "community": 187
+      "community": 188
     },
     {
       "label": ".validateAfter()",
@@ -14785,7 +14785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/021-feedback-event-attribution.ts",
       "source_location": "L107",
       "id": "021_feedback_event_attribution_feedbackeventattributionmigration_validateafter",
-      "community": 187
+      "community": 188
     },
     {
       "label": "040-audit-hash-chain.spec.ts",
@@ -14793,7 +14793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/040-audit-hash-chain.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_040_audit_hash_chain_spec_ts",
-      "community": 1102
+      "community": 1103
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -15169,7 +15169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_ts",
-      "community": 188
+      "community": 189
     },
     {
       "label": "ProceduralVersionIndexesMigration",
@@ -15177,7 +15177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L18",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".columnExists()",
@@ -15185,7 +15185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L23",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_columnexists",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".tableExists()",
@@ -15193,7 +15193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L28",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_tableexists",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".indexExists()",
@@ -15201,7 +15201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L35",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_indexexists",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".validateBefore()",
@@ -15209,7 +15209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L42",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validatebefore",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".up()",
@@ -15217,7 +15217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L62",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_up",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".down()",
@@ -15225,7 +15225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L73",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_down",
-      "community": 188
+      "community": 189
     },
     {
       "label": ".validateAfter()",
@@ -15233,7 +15233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.ts",
       "source_location": "L81",
       "id": "014_procedural_version_indexes_proceduralversionindexesmigration_validateafter",
-      "community": 188
+      "community": 189
     },
     {
       "label": "002-mirix-schema-expansion.spec.ts",
@@ -15241,7 +15241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 829
+      "community": 830
     },
     {
       "label": "createBaseSchema()",
@@ -15249,7 +15249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 829
+      "community": 830
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -15353,7 +15353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 830
+      "community": 831
     },
     {
       "label": "createSchemaWith018()",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 830
+      "community": 831
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 831
+      "community": 832
     },
     {
       "label": "createBaseSchema()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 831
+      "community": 832
     },
     {
       "label": "037-memory-forgetting-event.ts",
@@ -15473,7 +15473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_ts",
-      "community": 189
+      "community": 190
     },
     {
       "label": "MemoryItemAttributionMigration",
@@ -15481,7 +15481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L18",
       "id": "016_memory_item_attribution_memoryitemattributionmigration",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".tableExists()",
@@ -15489,7 +15489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L23",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_tableexists",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".columnExists()",
@@ -15497,7 +15497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L30",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_columnexists",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".indexExists()",
@@ -15505,7 +15505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L35",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_indexexists",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".validateBefore()",
@@ -15513,7 +15513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L42",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validatebefore",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".up()",
@@ -15521,7 +15521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L62",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_up",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".down()",
@@ -15529,7 +15529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L69",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_down",
-      "community": 189
+      "community": 190
     },
     {
       "label": ".validateAfter()",
@@ -15537,7 +15537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.ts",
       "source_location": "L87",
       "id": "016_memory_item_attribution_memoryitemattributionmigration_validateafter",
-      "community": 189
+      "community": 190
     },
     {
       "label": "036-agent-memory-promotion-schema.ts",
@@ -15649,7 +15649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_038_relation_type_registry_seeds_spec_ts",
-      "community": 832
+      "community": 833
     },
     {
       "label": "applicableTypesFor()",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L12",
       "id": "038_relation_type_registry_seeds_spec_applicabletypesfor",
-      "community": 832
+      "community": 833
     },
     {
       "label": "013-procedural-version-fields.ts",
@@ -15769,7 +15769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_018_kg_triple_table_ts",
-      "community": 190
+      "community": 191
     },
     {
       "label": "KgTripleTableMigration",
@@ -15777,7 +15777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L17",
       "id": "018_kg_triple_table_kgtripletablemigration",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".tableExists()",
@@ -15785,7 +15785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L22",
       "id": "018_kg_triple_table_kgtripletablemigration_tableexists",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".columnExists()",
@@ -15793,7 +15793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L29",
       "id": "018_kg_triple_table_kgtripletablemigration_columnexists",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".indexExists()",
@@ -15801,7 +15801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L34",
       "id": "018_kg_triple_table_kgtripletablemigration_indexexists",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".validateBefore()",
@@ -15809,7 +15809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L41",
       "id": "018_kg_triple_table_kgtripletablemigration_validatebefore",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".up()",
@@ -15817,7 +15817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L58",
       "id": "018_kg_triple_table_kgtripletablemigration_up",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".down()",
@@ -15825,7 +15825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L80",
       "id": "018_kg_triple_table_kgtripletablemigration_down",
-      "community": 190
+      "community": 191
     },
     {
       "label": ".validateAfter()",
@@ -15833,7 +15833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/018-kg-triple-table.ts",
       "source_location": "L91",
       "id": "018_kg_triple_table_kgtripletablemigration_validateafter",
-      "community": 190
+      "community": 191
     },
     {
       "label": "035-agent-integration-schema.contract.spec.ts",
@@ -15841,7 +15841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 1103
+      "community": 1104
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -16073,7 +16073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 1104
+      "community": 1105
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -16145,7 +16145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 833
+      "community": 834
     },
     {
       "label": "createBaseSchema()",
@@ -16153,7 +16153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 833
+      "community": 834
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -16161,7 +16161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_ts",
-      "community": 191
+      "community": 192
     },
     {
       "label": "SoftDeleteFieldsMigration",
@@ -16169,7 +16169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_softdeletefieldsmigration",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".tableExists()",
@@ -16177,7 +16177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L14",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_tableexists",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".columnExists()",
@@ -16185,7 +16185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L21",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_columnexists",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".indexExists()",
@@ -16193,7 +16193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L26",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_indexexists",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".validateBefore()",
@@ -16201,7 +16201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L33",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validatebefore",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".up()",
@@ -16209,7 +16209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_up",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".down()",
@@ -16217,7 +16217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L52",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_down",
-      "community": 191
+      "community": 192
     },
     {
       "label": ".validateAfter()",
@@ -16225,7 +16225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.ts",
       "source_location": "L59",
       "id": "031_soft_delete_fields_softdeletefieldsmigration_validateafter",
-      "community": 191
+      "community": 192
     },
     {
       "label": "006-fts5-reflection-notes.spec.ts",
@@ -16281,7 +16281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 834
+      "community": 835
     },
     {
       "label": "createBaseSchema()",
@@ -16289,7 +16289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 834
+      "community": 835
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_ts",
-      "community": 192
+      "community": 193
     },
     {
       "label": "MemoryItemOwnerIdMigration",
@@ -16337,7 +16337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L17",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".tableExists()",
@@ -16345,7 +16345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L22",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_tableexists",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".columnExists()",
@@ -16353,7 +16353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L29",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_columnexists",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".indexExists()",
@@ -16361,7 +16361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L34",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_indexexists",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".validateBefore()",
@@ -16369,7 +16369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L41",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validatebefore",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".up()",
@@ -16377,7 +16377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L58",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_up",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".down()",
@@ -16385,7 +16385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L63",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_down",
-      "community": 192
+      "community": 193
     },
     {
       "label": ".validateAfter()",
@@ -16393,7 +16393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.ts",
       "source_location": "L75",
       "id": "015_memory_item_owner_id_memoryitemowneridmigration_validateafter",
-      "community": 192
+      "community": 193
     },
     {
       "label": "003-consolidation-score-fields.spec.ts",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 835
+      "community": 836
     },
     {
       "label": "createBaseSchema()",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 835
+      "community": 836
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -16625,7 +16625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 1105
+      "community": 1106
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -17713,7 +17713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 1106
+      "community": 1107
     },
     {
       "label": "cache-service.ts",
@@ -18041,7 +18041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 1107
+      "community": 1108
     },
     {
       "label": "batch-scheduler.ts",
@@ -18513,7 +18513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 836
+      "community": 837
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -18521,7 +18521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 836
+      "community": 837
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -18529,7 +18529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 837
+      "community": 838
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -18537,7 +18537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 837
+      "community": 838
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -18617,7 +18617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 1108
+      "community": 1109
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -18625,7 +18625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 838
+      "community": 839
     },
     {
       "label": "validateBatchJobConfig()",
@@ -18633,7 +18633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 838
+      "community": 839
     },
     {
       "label": "retry-manager.ts",
@@ -18641,7 +18641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_retry_manager_ts",
-      "community": 193
+      "community": 194
     },
     {
       "label": "RetryManager",
@@ -18649,7 +18649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L103",
       "id": "retry_manager_retrymanager",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".constructor()",
@@ -18657,7 +18657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L107",
       "id": "retry_manager_retrymanager_constructor",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".shouldRetry()",
@@ -18665,7 +18665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L119",
       "id": "retry_manager_retrymanager_shouldretry",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".resetErrorCount()",
@@ -18673,7 +18673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L158",
       "id": "retry_manager_retrymanager_reseterrorcount",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".incrementErrorCount()",
@@ -18681,7 +18681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L168",
       "id": "retry_manager_retrymanager_incrementerrorcount",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".getErrorCount()",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L181",
       "id": "retry_manager_retrymanager_geterrorcount",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".clearAllErrorCounts()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L188",
       "id": "retry_manager_retrymanager_clearallerrorcounts",
-      "community": 193
+      "community": 194
     },
     {
       "label": ".retry()",
@@ -18705,7 +18705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/retry-manager.ts",
       "source_location": "L218",
       "id": "retry_manager_retrymanager_retry",
-      "community": 193
+      "community": 194
     },
     {
       "label": "batch-job-execution-coordinator.ts",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_file_logger_ts",
-      "community": 194
+      "community": 195
     },
     {
       "label": "FileLogger",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L38",
       "id": "file_logger_filelogger",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".constructor()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L42",
       "id": "file_logger_filelogger_constructor",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".log()",
@@ -18801,7 +18801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L81",
       "id": "file_logger_filelogger_log",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".logWarn()",
@@ -18809,7 +18809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L128",
       "id": "file_logger_filelogger_logwarn",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".logError()",
@@ -18817,7 +18817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L160",
       "id": "file_logger_filelogger_logerror",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".sanitizeData()",
@@ -18825,7 +18825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L194",
       "id": "file_logger_filelogger_sanitizedata",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".getLogFilePath()",
@@ -18833,7 +18833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L211",
       "id": "file_logger_filelogger_getlogfilepath",
-      "community": 194
+      "community": 195
     },
     {
       "label": ".setEnabled()",
@@ -18841,7 +18841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/file-logger.ts",
       "source_location": "L220",
       "id": "file_logger_filelogger_setenabled",
-      "community": 194
+      "community": 195
     },
     {
       "label": "batch-job-timeout-resolver.ts",
@@ -19153,7 +19153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
-      "community": 839
+      "community": 840
     },
     {
       "label": "runAnchorAutoRefresh()",
@@ -19161,7 +19161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_anchor_handlers_runanchorautorefresh",
-      "community": 839
+      "community": 840
     },
     {
       "label": "batch-scheduler-consolidation-relation-handlers.ts",
@@ -19209,7 +19209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 1109
+      "community": 1110
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -19337,7 +19337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 1110
+      "community": 1111
     },
     {
       "label": "batch-job-execution-coordinator.spec.ts",
@@ -19345,7 +19345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_execution_coordinator_spec_ts",
-      "community": 840
+      "community": 841
     },
     {
       "label": "createCoordinator()",
@@ -19353,7 +19353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L7",
       "id": "batch_job_execution_coordinator_spec_createcoordinator",
-      "community": 840
+      "community": 841
     },
     {
       "label": "health-checker.spec.ts",
@@ -19361,7 +19361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 1111
+      "community": 1112
     },
     {
       "label": "retry-manager.spec.ts",
@@ -19369,7 +19369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 841
+      "community": 842
     },
     {
       "label": "shouldRetry()",
@@ -19377,7 +19377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 841
+      "community": 842
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -19385,7 +19385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 842
+      "community": 843
     },
     {
       "label": "baseResult()",
@@ -19393,7 +19393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 842
+      "community": 843
     },
     {
       "label": "job-queue.spec.ts",
@@ -19441,7 +19441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 1112
+      "community": 1113
     },
     {
       "label": "batch-job-timeout-resolver.spec.ts",
@@ -19449,7 +19449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_timeout_resolver_spec_ts",
-      "community": 1113
+      "community": 1114
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -19457,7 +19457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 843
+      "community": 844
     },
     {
       "label": "initializeTestDatabase()",
@@ -19465,7 +19465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 843
+      "community": 844
     },
     {
       "label": "maintenance-jobs.spec.ts",
@@ -19473,7 +19473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/maintenance-jobs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_maintenance_jobs_spec_ts",
-      "community": 1114
+      "community": 1115
     },
     {
       "label": "error-handling.spec.ts",
@@ -19481,7 +19481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_error_handling_spec_ts",
-      "community": 1115
+      "community": 1116
     },
     {
       "label": "concurrency-queue.spec.ts",
@@ -19545,7 +19545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/run-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_run_job_spec_ts",
-      "community": 1116
+      "community": 1117
     },
     {
       "label": "logging.spec.ts",
@@ -19553,7 +19553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_logging_spec_ts",
-      "community": 1117
+      "community": 1118
     },
     {
       "label": "env-defaults.spec.ts",
@@ -19561,7 +19561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/env-defaults.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_env_defaults_spec_ts",
-      "community": 1118
+      "community": 1119
     },
     {
       "label": "lifecycle.spec.ts",
@@ -19569,7 +19569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/lifecycle.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_lifecycle_spec_ts",
-      "community": 1119
+      "community": 1120
     },
     {
       "label": "job-execution-retry.spec.ts",
@@ -19577,7 +19577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_job_execution_retry_spec_ts",
-      "community": 844
+      "community": 845
     },
     {
       "label": "failingJob()",
@@ -19585,7 +19585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L359",
       "id": "job_execution_retry_spec_failingjob",
-      "community": 844
+      "community": 845
     },
     {
       "label": "status-diagnostics.spec.ts",
@@ -19593,7 +19593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/status-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_status_diagnostics_spec_ts",
-      "community": 1120
+      "community": 1121
     },
     {
       "label": "constructor-config.spec.ts",
@@ -19601,7 +19601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/constructor-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_constructor_config_spec_ts",
-      "community": 1121
+      "community": 1122
     },
     {
       "label": "relation-validation.spec.ts",
@@ -19609,7 +19609,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/relation-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_relation_validation_spec_ts",
-      "community": 1122
+      "community": 1123
     },
     {
       "label": "batch-scheduler.test-setup.ts",
@@ -19617,7 +19617,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_batch_scheduler_test_setup_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "executionCoordinator()",
@@ -19625,7 +19625,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L4",
       "id": "batch_scheduler_test_setup_executioncoordinator",
-      "community": 845
+      "community": 846
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -19665,7 +19665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 1123
+      "community": 1124
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -19705,7 +19705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 1124
+      "community": 1125
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -19801,7 +19801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "createQualityTables()",
@@ -19809,7 +19809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 846
+      "community": 847
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -19865,7 +19865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_types_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "getErrorCode()",
@@ -19873,7 +19873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L3",
       "id": "triple_extraction_batch_job_types_geterrorcode",
-      "community": 847
+      "community": 848
     },
     {
       "label": "triple-extraction-batch-job-memory-status.ts",
@@ -20137,7 +20137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_logging_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "logBatchSchedulerMessage()",
@@ -20145,7 +20145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L18",
       "id": "batch_scheduler_logging_logbatchschedulermessage",
-      "community": 848
+      "community": 849
     },
     {
       "label": "batch-scheduler-health.ts",
@@ -20153,7 +20153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_health_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "checkBatchSchedulerHealth()",
@@ -20161,7 +20161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L17",
       "id": "batch_scheduler_health_checkbatchschedulerhealth",
-      "community": 849
+      "community": 850
     },
     {
       "label": "batch-scheduler-status.ts",
@@ -20361,7 +20361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_stats_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "getBatchSchedulerDetailedStats()",
@@ -20369,7 +20369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L18",
       "id": "batch_scheduler_stats_getbatchschedulerdetailedstats",
-      "community": 850
+      "community": 851
     },
     {
       "label": "batch-scheduler-interval.ts",
@@ -20425,7 +20425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 1125
+      "community": 1126
     },
     {
       "label": "owner-scope-mode.ts",
@@ -20433,7 +20433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "parseOwnerScopeMode()",
@@ -20441,7 +20441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L11",
       "id": "owner_scope_mode_parseownerscopemode",
-      "community": 851
+      "community": 852
     },
     {
       "label": "jsonl-rotation.ts",
@@ -20449,7 +20449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_jsonl_rotation_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "rotateJsonlIfNeeded()",
@@ -20457,7 +20457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L3",
       "id": "jsonl_rotation_rotatejsonlifneeded",
-      "community": 852
+      "community": 853
     },
     {
       "label": "external-api-retry-logging.ts",
@@ -20489,7 +20489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 1126
+      "community": 1127
     },
     {
       "label": "type-guards.ts",
@@ -20497,7 +20497,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_guards_ts",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isMemoryRow()",
@@ -20505,7 +20505,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L32",
       "id": "type_guards_ismemoryrow",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isMemoryType()",
@@ -20513,7 +20513,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L53",
       "id": "type_guards_ismemorytype",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isPrivacyScope()",
@@ -20521,7 +20521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L63",
       "id": "type_guards_isprivacyscope",
-      "community": 195
+      "community": 196
     },
     {
       "label": "convertMemoryRowToItem()",
@@ -20529,7 +20529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L74",
       "id": "type_guards_convertmemoryrowtoitem",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isRelationRow()",
@@ -20537,7 +20537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L144",
       "id": "type_guards_isrelationrow",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isExistingRelationRow()",
@@ -20545,7 +20545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L176",
       "id": "type_guards_isexistingrelationrow",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isMetadataRow()",
@@ -20553,7 +20553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L201",
       "id": "type_guards_ismetadatarow",
-      "community": 195
+      "community": 196
     },
     {
       "label": "isSqlParam()",
@@ -20561,7 +20561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-guards.ts",
       "source_location": "L216",
       "id": "type_guards_issqlparam",
-      "community": 195
+      "community": 196
     },
     {
       "label": "procedural-memory-extractor.ts",
@@ -20617,7 +20617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -20625,7 +20625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 853
+      "community": 854
     },
     {
       "label": "environment-check.ts",
@@ -20665,7 +20665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 1127
+      "community": 1128
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -20673,7 +20673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 1128
+      "community": 1129
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -20817,7 +20817,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -20825,7 +20825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 854
+      "community": 855
     },
     {
       "label": "error-handling.spec.ts",
@@ -20833,7 +20833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "operation()",
@@ -20841,7 +20841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 855
+      "community": 856
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -20905,7 +20905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logging_rate_limiter_ts",
-      "community": 196
+      "community": 197
     },
     {
       "label": "LoggingRateLimiter",
@@ -20913,7 +20913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L31",
       "id": "logging_rate_limiter_loggingratelimiter",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".constructor()",
@@ -20921,7 +20921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L38",
       "id": "logging_rate_limiter_loggingratelimiter_constructor",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".canSend()",
@@ -20929,7 +20929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L52",
       "id": "logging_rate_limiter_loggingratelimiter_cansend",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".consume()",
@@ -20937,7 +20937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L61",
       "id": "logging_rate_limiter_loggingratelimiter_consume",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".refill()",
@@ -20945,7 +20945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L76",
       "id": "logging_rate_limiter_loggingratelimiter_refill",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".getDroppedCount()",
@@ -20953,7 +20953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L88",
       "id": "logging_rate_limiter_loggingratelimiter_getdroppedcount",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".resetDroppedCount()",
@@ -20961,7 +20961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L95",
       "id": "logging_rate_limiter_loggingratelimiter_resetdroppedcount",
-      "community": 196
+      "community": 197
     },
     {
       "label": ".getAvailableTokens()",
@@ -20969,7 +20969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logging-rate-limiter.ts",
       "source_location": "L102",
       "id": "logging_rate_limiter_loggingratelimiter_getavailabletokens",
-      "community": 196
+      "community": 197
     },
     {
       "label": "type-param-validator.ts",
@@ -21081,7 +21081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 1129
+      "community": 1130
     },
     {
       "label": "relation-visualizer.ts",
@@ -21465,7 +21465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 1130
+      "community": 1131
     },
     {
       "label": "owner-scope-mode.spec.ts",
@@ -21473,7 +21473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_spec_ts",
-      "community": 1131
+      "community": 1132
     },
     {
       "label": "cache-key-generator.ts",
@@ -21665,7 +21665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 1132
+      "community": 1133
     },
     {
       "label": "path-validator.ts",
@@ -21729,7 +21729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -21737,7 +21737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 856
+      "community": 857
     },
     {
       "label": "error-handling.ts",
@@ -21745,7 +21745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "withErrorHandling()",
@@ -21753,7 +21753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 857
+      "community": 858
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -21761,7 +21761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 1133
+      "community": 1134
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -21769,7 +21769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 1134
+      "community": 1135
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -21977,7 +21977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -21985,7 +21985,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 858
+      "community": 859
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -22017,7 +22017,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "initializeTestDatabase()",
@@ -22025,7 +22025,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 859
+      "community": 860
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -22033,7 +22033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -22041,7 +22041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 860
+      "community": 861
     },
     {
       "label": "procedural-memory-field-extractors.ts",
@@ -22185,7 +22185,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 1135
+      "community": 1136
     },
     {
       "label": "pii-masker.ts",
@@ -22297,7 +22297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 1136
+      "community": 1137
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -22305,7 +22305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 1137
+      "community": 1138
     },
     {
       "label": "pii-masker-api-key.spec.ts",
@@ -22313,7 +22313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
-      "community": 1138
+      "community": 1139
     },
     {
       "label": "path-validator.spec.ts",
@@ -22321,7 +22321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 1139
+      "community": 1140
     },
     {
       "label": "triple-cache.spec.ts",
@@ -22329,7 +22329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 1140
+      "community": 1141
     },
     {
       "label": "memento-resource-uri.spec.ts",
@@ -22337,7 +22337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/memento-resource-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_memento_resource_uri_spec_ts",
-      "community": 1141
+      "community": 1142
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -22345,7 +22345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 1142
+      "community": 1143
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -22353,7 +22353,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 1143
+      "community": 1144
     },
     {
       "label": "external-api-retry-logging.spec.ts",
@@ -22361,7 +22361,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/external-api-retry-logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_external_api_retry_logging_spec_ts",
-      "community": 1144
+      "community": 1145
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -22369,7 +22369,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 1145
+      "community": 1146
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -22377,7 +22377,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 1146
+      "community": 1147
     },
     {
       "label": "logger-schema.spec.ts",
@@ -22385,7 +22385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 1147
+      "community": 1148
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -22393,7 +22393,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 1148
+      "community": 1149
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -22401,7 +22401,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "initializeTestDatabase()",
@@ -22409,7 +22409,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 861
+      "community": 862
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -22417,7 +22417,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 1149
+      "community": 1150
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -22425,7 +22425,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 1150
+      "community": 1151
     },
     {
       "label": "database-error-helpers.ts",
@@ -22593,7 +22593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_schema_initialization_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "initializeDatabase()",
@@ -22601,7 +22601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L8",
       "id": "schema_initialization_initializedatabase",
-      "community": 862
+      "community": 863
     },
     {
       "label": "benchmark.types.ts",
@@ -22609,7 +22609,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "assertMacroCategory()",
@@ -22617,7 +22617,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L28",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 863
+      "community": 864
     },
     {
       "label": "migration.types.ts",
@@ -22625,7 +22625,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 1151
+      "community": 1152
     },
     {
       "label": "consolidation-score.types.ts",
@@ -22633,7 +22633,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 1152
+      "community": 1153
     },
     {
       "label": "consolidation.types.ts",
@@ -22641,7 +22641,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 1153
+      "community": 1154
     },
     {
       "label": "vector-search.types.ts",
@@ -22649,7 +22649,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 1154
+      "community": 1155
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -22657,7 +22657,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 1155
+      "community": 1156
     },
     {
       "label": "procedural-versioning.ts",
@@ -22665,7 +22665,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 1156
+      "community": 1157
     },
     {
       "label": "triple-extraction.ts",
@@ -22673,7 +22673,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 1157
+      "community": 1158
     },
     {
       "label": "feedback.types.ts",
@@ -22681,7 +22681,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 1158
+      "community": 1159
     },
     {
       "label": "embedding.types.ts",
@@ -22689,7 +22689,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 1159
+      "community": 1160
     },
     {
       "label": "relation-graph.ts",
@@ -22697,7 +22697,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 1160
+      "community": 1161
     },
     {
       "label": "failure-event.ts",
@@ -22705,7 +22705,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 1161
+      "community": 1162
     },
     {
       "label": "index.ts",
@@ -22737,7 +22737,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 1162
+      "community": 1163
     },
     {
       "label": "ranking.types.ts",
@@ -22745,7 +22745,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 1163
+      "community": 1164
     },
     {
       "label": "alerts.types.ts",
@@ -22753,7 +22753,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 1164
+      "community": 1165
     },
     {
       "label": "relation.ts",
@@ -22793,7 +22793,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 1165
+      "community": 1166
     },
     {
       "label": "index.spec.ts",
@@ -22801,7 +22801,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 1166
+      "community": 1167
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -22809,7 +22809,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 1167
+      "community": 1168
     },
     {
       "label": "constants.ts",
@@ -22817,7 +22817,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 1168
+      "community": 1169
     },
     {
       "label": "environment.ts",
@@ -22961,7 +22961,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 1169
+      "community": 1170
     },
     {
       "label": "retry-options-loader.ts",
@@ -23041,7 +23041,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "validateConfig()",
@@ -23049,7 +23049,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L170",
       "id": "index_validateconfig",
-      "community": 864
+      "community": 865
     },
     {
       "label": "config-loader-utils.ts",
@@ -23121,7 +23121,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 1170
+      "community": 1171
     },
     {
       "label": "constants.spec.ts",
@@ -23129,7 +23129,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 1171
+      "community": 1172
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -23137,7 +23137,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 1172
+      "community": 1173
     },
     {
       "label": "config-validation.spec.ts",
@@ -23145,7 +23145,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 1173
+      "community": 1174
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -23153,7 +23153,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 1174
+      "community": 1175
     },
     {
       "label": "environment-paths.spec.ts",
@@ -23161,7 +23161,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 1175
+      "community": 1176
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -23169,7 +23169,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 1176
+      "community": 1177
     },
     {
       "label": "schema-version.ts",
@@ -23177,7 +23177,7 @@
       "source_file": "packages/memento-core/src/shared/constants/schema-version.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_schema_version_ts",
-      "community": 1177
+      "community": 1178
     },
     {
       "label": "relation-constants.ts",
@@ -23185,7 +23185,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 1178
+      "community": 1179
     },
     {
       "label": "introspection-constants.ts",
@@ -23193,7 +23193,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 1179
+      "community": 1180
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -23201,7 +23201,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 1180
+      "community": 1181
     },
     {
       "label": "http-bind-policy.ts",
@@ -23209,7 +23209,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_ts",
-      "community": 197
+      "community": 198
     },
     {
       "label": "MementoHttpSecurityStartupError",
@@ -23217,7 +23217,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L5",
       "id": "http_bind_policy_mementohttpsecuritystartuperror",
-      "community": 197
+      "community": 198
     },
     {
       "label": ".constructor()",
@@ -23225,7 +23225,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L8",
       "id": "http_bind_policy_mementohttpsecuritystartuperror_constructor",
-      "community": 197
+      "community": 198
     },
     {
       "label": "isIpv4Loopback127Block()",
@@ -23233,7 +23233,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L17",
       "id": "http_bind_policy_isipv4loopback127block",
-      "community": 197
+      "community": 198
     },
     {
       "label": "isIpv4MappedLoopback()",
@@ -23241,7 +23241,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L32",
       "id": "http_bind_policy_isipv4mappedloopback",
-      "community": 197
+      "community": 198
     },
     {
       "label": "canonicalizeHttpBindHostForListen()",
@@ -23249,7 +23249,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L53",
       "id": "http_bind_policy_canonicalizehttpbindhostforlisten",
-      "community": 197
+      "community": 198
     },
     {
       "label": "formatHttpBindHostForUrl()",
@@ -23257,7 +23257,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L64",
       "id": "http_bind_policy_formathttpbindhostforurl",
-      "community": 197
+      "community": 198
     },
     {
       "label": "isHttpBindHostRemotelyReachable()",
@@ -23265,7 +23265,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L72",
       "id": "http_bind_policy_ishttpbindhostremotelyreachable",
-      "community": 197
+      "community": 198
     },
     {
       "label": "getMementoHttpSecurityStartupViolationMessage()",
@@ -23273,7 +23273,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.ts",
       "source_location": "L87",
       "id": "http_bind_policy_getmementohttpsecuritystartupviolationmessage",
-      "community": 197
+      "community": 198
     },
     {
       "label": "reflexion-worker.interface.ts",
@@ -23281,7 +23281,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 1181
+      "community": 1182
     },
     {
       "label": "retry-manager.interface.ts",
@@ -23289,7 +23289,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 1182
+      "community": 1183
     },
     {
       "label": "cache.interface.ts",
@@ -23297,7 +23297,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 1183
+      "community": 1184
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -23305,7 +23305,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 1184
+      "community": 1185
     },
     {
       "label": "error-logging.interface.ts",
@@ -23313,7 +23313,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 1185
+      "community": 1186
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -23321,7 +23321,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 1186
+      "community": 1187
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -23329,7 +23329,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 1187
+      "community": 1188
     },
     {
       "label": "database.interface.ts",
@@ -23337,7 +23337,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 1188
+      "community": 1189
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -23345,7 +23345,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 1189
+      "community": 1190
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -23353,7 +23353,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 1190
+      "community": 1191
     },
     {
       "label": "llm-client-initializer.ts",
@@ -23425,7 +23425,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 1191
+      "community": 1192
     },
     {
       "label": "openai-client.spec.ts",
@@ -23433,7 +23433,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 1192
+      "community": 1193
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -23441,7 +23441,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 1193
+      "community": 1194
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -23449,7 +23449,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 1194
+      "community": 1195
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -23457,7 +23457,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 1195
+      "community": 1196
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -23465,7 +23465,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 1196
+      "community": 1197
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -23473,7 +23473,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 1197
+      "community": 1198
     },
     {
       "label": "environment-priority.spec.ts",
@@ -23481,7 +23481,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 1198
+      "community": 1199
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -23489,7 +23489,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 1199
+      "community": 1200
     },
     {
       "label": "gemini-client.spec.ts",
@@ -23497,7 +23497,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 1200
+      "community": 1201
     },
     {
       "label": "provider-resolution.ts",
@@ -23553,7 +23553,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_types_ts",
-      "community": 1201
+      "community": 1202
     },
     {
       "label": "shared-helpers.ts",
@@ -23617,7 +23617,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_gemini_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "initializeGemini()",
@@ -23625,7 +23625,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L18",
       "id": "gemini_initializegemini",
-      "community": 865
+      "community": 866
     },
     {
       "label": "ollama.ts",
@@ -23673,7 +23673,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_openai_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "initializeOpenAI()",
@@ -23681,7 +23681,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L14",
       "id": "openai_initializeopenai",
-      "community": 866
+      "community": 867
     },
     {
       "label": "source-uri.ts",
@@ -23689,7 +23689,7 @@
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_source_uri_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "validateSource()",
@@ -23697,7 +23697,7 @@
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
       "source_location": "L39",
       "id": "source_uri_validatesource",
-      "community": 867
+      "community": 868
     },
     {
       "label": "source-uri.spec.ts",
@@ -23705,7 +23705,7 @@
       "source_file": "packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_tests_source_uri_spec_ts",
-      "community": 1202
+      "community": 1203
     },
     {
       "label": "search-local-tool.ts",
@@ -23993,7 +23993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "initializeTestDatabase()",
@@ -24001,7 +24001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 868
+      "community": 869
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -24009,7 +24009,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "initializeTestDatabase()",
@@ -24017,7 +24017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 869
+      "community": 870
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -24025,7 +24025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 1203
+      "community": 1204
     },
     {
       "label": "query-filter-strategy.ts",
@@ -24073,7 +24073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 1204
+      "community": 1205
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -24081,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 1205
+      "community": 1206
     },
     {
       "label": "local-search-service.ts",
@@ -24153,7 +24153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 1206
+      "community": 1207
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -24161,7 +24161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 1207
+      "community": 1208
     },
     {
       "label": "anchor-interfaces.ts",
@@ -24289,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 1208
+      "community": 1209
     },
     {
       "label": "anchor-reanchor-service.ts",
@@ -24297,7 +24297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_reanchor_service_ts",
-      "community": 198
+      "community": 199
     },
     {
       "label": "AnchorReanchorService",
@@ -24305,7 +24305,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L24",
       "id": "anchor_reanchor_service_anchorreanchorservice",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".constructor()",
@@ -24313,7 +24313,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L25",
       "id": "anchor_reanchor_service_anchorreanchorservice_constructor",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".calculateReanchorScore()",
@@ -24321,7 +24321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L33",
       "id": "anchor_reanchor_service_anchorreanchorservice_calculatereanchorscore",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".analyzeAnchorUsage()",
@@ -24329,7 +24329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L117",
       "id": "anchor_reanchor_service_anchorreanchorservice_analyzeanchorusage",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".autoReanchor()",
@@ -24337,7 +24337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L185",
       "id": "anchor_reanchor_service_anchorreanchorservice_autoreanchor",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".checkAndAutoReanchor()",
@@ -24345,7 +24345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L305",
       "id": "anchor_reanchor_service_anchorreanchorservice_checkandautoreanchor",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".cosineSimilarity()",
@@ -24353,7 +24353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L326",
       "id": "anchor_reanchor_service_anchorreanchorservice_cosinesimilarity",
-      "community": 198
+      "community": 199
     },
     {
       "label": ".generateReanchorReason()",
@@ -24361,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-reanchor-service.ts",
       "source_location": "L362",
       "id": "anchor_reanchor_service_anchorreanchorservice_generatereanchorreason",
-      "community": 198
+      "community": 199
     },
     {
       "label": "vector-search-engine-types.ts",
@@ -24369,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -24377,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 870
+      "community": 871
     },
     {
       "label": "embedding-types.ts",
@@ -24385,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 1209
+      "community": 1210
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -24393,7 +24393,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 1210
+      "community": 1211
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -24625,7 +24625,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 1211
+      "community": 1212
     },
     {
       "label": "fallback-strategy.ts",
@@ -24793,7 +24793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 1212
+      "community": 1213
     },
     {
       "label": "anchor-cache-service.ts",
@@ -24993,7 +24993,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 1213
+      "community": 1214
     },
     {
       "label": "n-hop-linked-memory-service.ts",
@@ -25001,7 +25001,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_linked_memory_service_ts",
-      "community": 199
+      "community": 200
     },
     {
       "label": "getRelationTypeBoost()",
@@ -25009,7 +25009,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L35",
       "id": "n_hop_linked_memory_service_getrelationtypeboost",
-      "community": 199
+      "community": 200
     },
     {
       "label": "NHopLinkedMemoryService",
@@ -25017,7 +25017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L47",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".constructor()",
@@ -25025,7 +25025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L48",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_constructor",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".mergeHopCandidates()",
@@ -25033,7 +25033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L54",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_mergehopcandidates",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".materializeHopDiscoveries()",
@@ -25041,7 +25041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L95",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_materializehopdiscoveries",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".getLinkedMemoriesBatch()",
@@ -25049,7 +25049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L142",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_getlinkedmemoriesbatch",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".tryGetNextHopSeed()",
@@ -25057,7 +25057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L191",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_trygetnexthopseed",
-      "community": 199
+      "community": 200
     },
     {
       "label": ".getLinkedMemories()",
@@ -25065,7 +25065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-linked-memory-service.ts",
       "source_location": "L206",
       "id": "n_hop_linked_memory_service_nhoplinkedmemoryservice_getlinkedmemories",
-      "community": 199
+      "community": 200
     },
     {
       "label": "local-search-service.spec.ts",
@@ -25073,7 +25073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 1214
+      "community": 1215
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -25081,7 +25081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 1215
+      "community": 1216
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -25089,7 +25089,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 1216
+      "community": 1217
     },
     {
       "label": "store.ts",
@@ -25129,7 +25129,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 1217
+      "community": 1218
     },
     {
       "label": "index.ts",
@@ -25137,7 +25137,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 1218
+      "community": 1219
     },
     {
       "label": "getters.ts",
@@ -25185,7 +25185,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 1219
+      "community": 1220
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -25193,7 +25193,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 1220
+      "community": 1221
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -25201,7 +25201,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 1221
+      "community": 1222
     },
     {
       "label": "vector-search.factory.ts",
@@ -25257,7 +25257,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_hybrid_search_factory_ts",
-      "community": 200
+      "community": 201
     },
     {
       "label": "DefaultSearchLogger",
@@ -25265,7 +25265,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L27",
       "id": "hybrid_search_factory_defaultsearchlogger",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".logSearchStart()",
@@ -25273,7 +25273,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L28",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstart",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".logSearchStep()",
@@ -25281,7 +25281,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L32",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchstep",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".logSearchComplete()",
@@ -25289,7 +25289,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L36",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearchcomplete",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".logSearchError()",
@@ -25297,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L48",
       "id": "hybrid_search_factory_defaultsearchlogger_logsearcherror",
-      "community": 200
+      "community": 201
     },
     {
       "label": "HybridSearchFactory",
@@ -25305,7 +25305,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L58",
       "id": "hybrid_search_factory_hybridsearchfactory",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".createDefaultEngine()",
@@ -25313,7 +25313,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L62",
       "id": "hybrid_search_factory_hybridsearchfactory_createdefaultengine",
-      "community": 200
+      "community": 201
     },
     {
       "label": ".createEngine()",
@@ -25321,7 +25321,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/hybrid-search.factory.ts",
       "source_location": "L91",
       "id": "hybrid_search_factory_hybridsearchfactory_createengine",
-      "community": 200
+      "community": 201
     },
     {
       "label": "hybrid-search.factory.spec.ts",
@@ -25329,7 +25329,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -25337,7 +25337,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 871
+      "community": 872
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -25345,7 +25345,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 1222
+      "community": 1223
     },
     {
       "label": "search-result-combiner.ts",
@@ -26241,7 +26241,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -26249,7 +26249,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 872
+      "community": 873
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -26305,7 +26305,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_types_ts",
-      "community": 1223
+      "community": 1224
     },
     {
       "label": "search-error.ts",
@@ -26489,7 +26489,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking/search-ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_ranking_search_ranking_types_ts",
-      "community": 1224
+      "community": 1225
     },
     {
       "label": "search-ranking-composite.ts",
@@ -26753,7 +26753,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 1225
+      "community": 1226
     },
     {
       "label": "search-ranking.spec.ts",
@@ -26761,7 +26761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 1226
+      "community": 1227
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -26793,7 +26793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_spec_ts",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockTextSearchEngine()",
@@ -26801,7 +26801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L44",
       "id": "hybrid_search_engine_spec_createmocktextsearchengine",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockEmbeddingService()",
@@ -26809,7 +26809,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L48",
       "id": "hybrid_search_engine_spec_createmockembeddingservice",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -26817,7 +26817,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L54",
       "id": "hybrid_search_engine_spec_createmockvectorsearchengine",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockResultCombiner()",
@@ -26825,7 +26825,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L60",
       "id": "hybrid_search_engine_spec_createmockresultcombiner",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockWeightCalculator()",
@@ -26833,7 +26833,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L64",
       "id": "hybrid_search_engine_spec_createmockweightcalculator",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createMockLogger()",
@@ -26841,7 +26841,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L68",
       "id": "hybrid_search_engine_spec_createmocklogger",
-      "community": 201
+      "community": 202
     },
     {
       "label": "createTestMemory()",
@@ -26849,7 +26849,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L596",
       "id": "hybrid_search_engine_spec_createtestmemory",
-      "community": 201
+      "community": 202
     },
     {
       "label": "p95()",
@@ -26857,7 +26857,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine.spec.ts",
       "source_location": "L2681",
       "id": "hybrid_search_engine_spec_p95",
-      "community": 201
+      "community": 202
     },
     {
       "label": "hybrid-search-engine-consolidation.spec.ts",
@@ -26865,7 +26865,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 1227
+      "community": 1228
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -26873,7 +26873,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 1228
+      "community": 1229
     },
     {
       "label": "search-engine.spec.ts",
@@ -26913,7 +26913,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 1229
+      "community": 1230
     },
     {
       "label": "search-engine-ranking.ts",
@@ -26993,7 +26993,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_types_ts",
-      "community": 1230
+      "community": 1231
     },
     {
       "label": "search-engine-sql-builder.ts",
@@ -27001,7 +27001,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_sql_builder_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "buildSearchStatement()",
@@ -27009,7 +27009,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L7",
       "id": "search_engine_sql_builder_buildsearchstatement",
-      "community": 873
+      "community": 874
     },
     {
       "label": "search-engine-fts-availability.ts",
@@ -27017,7 +27017,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_fts_availability_ts",
-      "community": 202
+      "community": 203
     },
     {
       "label": "SearchEngineFtsAvailability",
@@ -27025,7 +27025,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L10",
       "id": "search_engine_fts_availability_searchengineftsavailability",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".isTestEnvironment()",
@@ -27033,7 +27033,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L15",
       "id": "search_engine_fts_availability_searchengineftsavailability_istestenvironment",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".logFallbackWarning()",
@@ -27041,7 +27041,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L19",
       "id": "search_engine_fts_availability_searchengineftsavailability_logfallbackwarning",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".logReflectionNotesConfigFallbackWarning()",
@@ -27049,7 +27049,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L23",
       "id": "search_engine_fts_availability_searchengineftsavailability_logreflectionnotesconfigfallbackwarning",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".invalidateFts5Cache()",
@@ -27057,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L38",
       "id": "search_engine_fts_availability_searchengineftsavailability_invalidatefts5cache",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".checkFTS5Availability()",
@@ -27065,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L42",
       "id": "search_engine_fts_availability_searchengineftsavailability_checkfts5availability",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".checkReflectionNotesAvailability()",
@@ -27073,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L85",
       "id": "search_engine_fts_availability_searchengineftsavailability_checkreflectionnotesavailability",
-      "community": 202
+      "community": 203
     },
     {
       "label": ".buildReflectionNotesSearchCondition()",
@@ -27081,7 +27081,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-availability.ts",
       "source_location": "L131",
       "id": "search_engine_fts_availability_searchengineftsavailability_buildreflectionnotessearchcondition",
-      "community": 202
+      "community": 203
     },
     {
       "label": "vector-search.repository.ts",
@@ -27257,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 1231
+      "community": 1232
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -27265,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "seedScopedHybridMemories()",
@@ -27273,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L407",
       "id": "vector_search_repository_spec_seedscopedhybridmemories",
-      "community": 874
+      "community": 875
     },
     {
       "label": "vector-search.types.ts",
@@ -27281,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_types_ts",
-      "community": 1232
+      "community": 1233
     },
     {
       "label": "vector-search-result-mapper.ts",
@@ -27457,7 +27457,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_scope_ts",
-      "community": 875
+      "community": 876
     },
     {
       "label": "parseVectorSearchScope()",
@@ -27465,7 +27465,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L8",
       "id": "vector_search_scope_parsevectorsearchscope",
-      "community": 875
+      "community": 876
     },
     {
       "label": "vector-search-hybrid-query.ts",
@@ -27601,7 +27601,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 876
+      "community": 877
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -27609,7 +27609,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 876
+      "community": 877
     },
     {
       "label": "vector-performance-tester.ts",
@@ -27673,7 +27673,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 877
+      "community": 878
     },
     {
       "label": "createMockRepository()",
@@ -27681,7 +27681,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 877
+      "community": 878
     },
     {
       "label": "vector-index-manager.ts",
@@ -27985,7 +27985,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 878
+      "community": 879
     },
     {
       "label": "createMockRepositories()",
@@ -27993,7 +27993,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 878
+      "community": 879
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -28001,7 +28001,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 1233
+      "community": 1234
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -28009,7 +28009,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 879
+      "community": 880
     },
     {
       "label": "createMockIndexRepository()",
@@ -28017,7 +28017,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 879
+      "community": 880
     },
     {
       "label": "forgetting-event-log.spec.ts",
@@ -28025,7 +28025,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/__tests__/forgetting-event-log.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tests_forgetting_event_log_spec_ts",
-      "community": 1234
+      "community": 1235
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -28201,7 +28201,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 1235
+      "community": 1236
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -28209,7 +28209,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 1236
+      "community": 1237
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -28217,7 +28217,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 1237
+      "community": 1238
     },
     {
       "label": "spaced-repetition.ts",
@@ -28545,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 1238
+      "community": 1239
     },
     {
       "label": "forgetting-event-repository.ts",
@@ -28641,7 +28641,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 1239
+      "community": 1240
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -28777,7 +28777,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 1240
+      "community": 1241
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -28785,7 +28785,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 1241
+      "community": 1242
     },
     {
       "label": "priority-calculation.service.ts",
@@ -29665,7 +29665,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 1242
+      "community": 1243
     },
     {
       "label": "recall-probability.service.ts",
@@ -29769,7 +29769,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 1243
+      "community": 1244
     },
     {
       "label": "telemetry.types.ts",
@@ -29777,7 +29777,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 1244
+      "community": 1245
     },
     {
       "label": "telemetry-system-metrics-query.ts",
@@ -29817,7 +29817,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_ts",
-      "community": 880
+      "community": 881
     },
     {
       "label": "queryFeedbackQuality()",
@@ -29825,7 +29825,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L6",
       "id": "telemetry_feedback_quality_query_queryfeedbackquality",
-      "community": 880
+      "community": 881
     },
     {
       "label": "telemetry-feedback-quality-query.spec.ts",
@@ -29833,7 +29833,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_spec_ts",
-      "community": 1245
+      "community": 1246
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -29841,7 +29841,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 881
+      "community": 882
     },
     {
       "label": "openTelemetryDb()",
@@ -29849,7 +29849,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 881
+      "community": 882
     },
     {
       "label": "telemetry-search-quality-query.ts",
@@ -30257,7 +30257,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/audit-hash-chain-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_audit_hash_chain_service_spec_ts",
-      "community": 1246
+      "community": 1247
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -30265,7 +30265,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 1247
+      "community": 1248
     },
     {
       "label": "event-outbox-service.ts",
@@ -30273,7 +30273,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_ts",
-      "community": 203
+      "community": 204
     },
     {
       "label": "isEventOutboxEnabled()",
@@ -30281,7 +30281,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L40",
       "id": "event_outbox_service_iseventoutboxenabled",
-      "community": 203
+      "community": 204
     },
     {
       "label": "parsePayload()",
@@ -30289,7 +30289,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L44",
       "id": "event_outbox_service_parsepayload",
-      "community": 203
+      "community": 204
     },
     {
       "label": "toEvent()",
@@ -30297,7 +30297,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L53",
       "id": "event_outbox_service_toevent",
-      "community": 203
+      "community": 204
     },
     {
       "label": "EventOutboxService",
@@ -30305,7 +30305,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L69",
       "id": "event_outbox_service_eventoutboxservice",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".constructor()",
@@ -30313,7 +30313,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L70",
       "id": "event_outbox_service_eventoutboxservice_constructor",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".enqueue()",
@@ -30321,7 +30321,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L72",
       "id": "event_outbox_service_eventoutboxservice_enqueue",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".pending()",
@@ -30329,7 +30329,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L85",
       "id": "event_outbox_service_eventoutboxservice_pending",
-      "community": 203
+      "community": 204
     },
     {
       "label": ".publishPending()",
@@ -30337,7 +30337,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.ts",
       "source_location": "L95",
       "id": "event_outbox_service_eventoutboxservice_publishpending",
-      "community": 203
+      "community": 204
     },
     {
       "label": "telemetry-service.ts",
@@ -30473,7 +30473,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_spec_ts",
-      "community": 1248
+      "community": 1249
     },
     {
       "label": "index.ts",
@@ -30481,7 +30481,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 1249
+      "community": 1250
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -30489,7 +30489,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 1250
+      "community": 1251
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -30497,7 +30497,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 1251
+      "community": 1252
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -30505,7 +30505,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 882
+      "community": 883
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -30513,7 +30513,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 882
+      "community": 883
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -30585,7 +30585,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 1252
+      "community": 1253
     },
     {
       "label": "llm-port.ts",
@@ -30593,7 +30593,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 1253
+      "community": 1254
     },
     {
       "label": "persistence-port.ts",
@@ -30601,7 +30601,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 1254
+      "community": 1255
     },
     {
       "label": "context-port.ts",
@@ -30609,7 +30609,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 1255
+      "community": 1256
     },
     {
       "label": "agent-types.ts",
@@ -30617,7 +30617,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 1256
+      "community": 1257
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -30649,7 +30649,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 1257
+      "community": 1258
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -30657,7 +30657,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 1258
+      "community": 1259
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -30737,7 +30737,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 1259
+      "community": 1260
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -30889,7 +30889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 1260
+      "community": 1261
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -30897,7 +30897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 1261
+      "community": 1262
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -30905,7 +30905,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 1262
+      "community": 1263
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -30913,7 +30913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 883
+      "community": 884
     },
     {
       "label": "baseCandidate()",
@@ -30921,7 +30921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 883
+      "community": 884
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -30969,7 +30969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 1263
+      "community": 1264
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -30977,7 +30977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 884
+      "community": 885
     },
     {
       "label": "makeDeps()",
@@ -30985,7 +30985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 884
+      "community": 885
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -31033,7 +31033,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 885
+      "community": 886
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -31041,7 +31041,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 885
+      "community": 886
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -31049,7 +31049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 886
+      "community": 887
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -31057,7 +31057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 886
+      "community": 887
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -31065,7 +31065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 1264
+      "community": 1265
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -31073,7 +31073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 1265
+      "community": 1266
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -31081,7 +31081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 887
+      "community": 888
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -31089,7 +31089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L9",
       "id": "feedback_repository_interface_sigmoidnormalizednet",
-      "community": 887
+      "community": 888
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -31097,7 +31097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 1266
+      "community": 1267
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -31105,7 +31105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 1267
+      "community": 1268
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -31113,7 +31113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 1268
+      "community": 1269
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -31121,7 +31121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 888
+      "community": 889
     },
     {
       "label": "createKgTripleTable()",
@@ -31129,7 +31129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 888
+      "community": 889
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -31137,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 889
+      "community": 890
     },
     {
       "label": "createProcessAttributeTable()",
@@ -31145,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 889
+      "community": 890
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -31153,7 +31153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 890
+      "community": 891
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -31161,7 +31161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 890
+      "community": 891
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -31169,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 1269
+      "community": 1270
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -31177,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 891
+      "community": 892
     },
     {
       "label": "createCoreMemoryTable()",
@@ -31185,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 891
+      "community": 892
     },
     {
       "label": "recall-tool-host.ts",
@@ -31193,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 1270
+      "community": 1271
     },
     {
       "label": "remember-tool-memory-item.ts",
@@ -31233,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 1271
+      "community": 1272
     },
     {
       "label": "remember-tool-schema.ts",
@@ -31241,7 +31241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_schema_ts",
-      "community": 1272
+      "community": 1273
     },
     {
       "label": "remember-tool-reflection.ts",
@@ -31321,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_vault_ts",
-      "community": 892
+      "community": 893
     },
     {
       "label": "handleVaultMemory()",
@@ -31329,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L20",
       "id": "remember_tool_vault_handlevaultmemory",
-      "community": 892
+      "community": 893
     },
     {
       "label": "recall-tool-validation.ts",
@@ -31361,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 893
+      "community": 894
     },
     {
       "label": "normalizeProviderFilter()",
@@ -31369,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 893
+      "community": 894
     },
     {
       "label": "remember-tool-db-helpers.ts",
@@ -31713,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_host_ts",
-      "community": 1273
+      "community": 1274
     },
     {
       "label": "recall-tool-search-execution.ts",
@@ -31721,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 894
+      "community": 895
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -31729,7 +31729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 894
+      "community": 895
     },
     {
       "label": "pin-tool.ts",
@@ -31905,7 +31905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_neighbors_fetch_ts",
-      "community": 895
+      "community": 896
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -31913,7 +31913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L16",
       "id": "recall_tool_neighbors_fetch_handleincludeneighbors",
-      "community": 895
+      "community": 896
     },
     {
       "label": "recall-tool-anchor-rotation.ts",
@@ -31921,7 +31921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_anchor_rotation_ts",
-      "community": 896
+      "community": 897
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -31929,7 +31929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L12",
       "id": "recall_tool_anchor_rotation_handleautosetanchor",
-      "community": 896
+      "community": 897
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -31969,7 +31969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_types_ts",
-      "community": 1274
+      "community": 1275
     },
     {
       "label": "recall-tool-direct.ts",
@@ -32113,71 +32113,79 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
-      "community": 204
+      "community": 164
     },
     {
       "label": "checkDbConnection()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L34",
+      "source_location": "L35",
       "id": "remember_tool_augmentation_checkdbconnection",
-      "community": 204
+      "community": 164
     },
     {
       "label": "runEmbeddingAndNeighbors()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L46",
+      "source_location": "L47",
       "id": "remember_tool_augmentation_runembeddingandneighbors",
-      "community": 204
+      "community": 164
+    },
+    {
+      "label": "persistRelationCandidates()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
+      "source_location": "L93",
+      "id": "remember_tool_augmentation_persistrelationcandidates",
+      "community": 164
     },
     {
       "label": "runRelationExtraction()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L88",
+      "source_location": "L135",
       "id": "remember_tool_augmentation_runrelationextraction",
-      "community": 204
+      "community": 164
     },
     {
       "label": "updateTripleStatus()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L136",
+      "source_location": "L185",
       "id": "remember_tool_augmentation_updatetriplestatus",
-      "community": 204
+      "community": 164
     },
     {
       "label": "getRetryCount()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L156",
+      "source_location": "L205",
       "id": "remember_tool_augmentation_getretrycount",
-      "community": 204
+      "community": 164
     },
     {
       "label": "runTripleExtractionJob()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L172",
+      "source_location": "L221",
       "id": "remember_tool_augmentation_runtripleextractionjob",
-      "community": 204
+      "community": 164
     },
     {
       "label": "runTripleExtraction()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L309",
+      "source_location": "L358",
       "id": "remember_tool_augmentation_runtripleextraction",
-      "community": 204
+      "community": 164
     },
     {
       "label": "launchBackgroundAugmentation()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L371",
+      "source_location": "L420",
       "id": "remember_tool_augmentation_launchbackgroundaugmentation",
-      "community": 204
+      "community": 164
     },
     {
       "label": "get-introspection-summary-tool.ts",
@@ -32385,7 +32393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 897
+      "community": 898
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -32393,7 +32401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L12",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 897
+      "community": 898
     },
     {
       "label": "recall-tool.ts",
@@ -32465,7 +32473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 1275
+      "community": 1276
     },
     {
       "label": "forget-tool.ts",
@@ -32609,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_core_ts",
-      "community": 898
+      "community": 899
     },
     {
       "label": "handleCoreMemory()",
@@ -32617,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L19",
       "id": "remember_tool_core_handlecorememory",
-      "community": 898
+      "community": 899
     },
     {
       "label": "recall-tool-anchor-rotation.spec.ts",
@@ -32625,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_anchor_rotation_spec_ts",
-      "community": 899
+      "community": 900
     },
     {
       "label": "createAnchorTable()",
@@ -32633,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L10",
       "id": "recall_tool_anchor_rotation_spec_createanchortable",
-      "community": 899
+      "community": 900
     },
     {
       "label": "procedural-diff-tool.spec.ts",
@@ -32641,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 900
+      "community": 901
     },
     {
       "label": "createSchema()",
@@ -32649,7 +32657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 900
+      "community": 901
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -32657,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 1276
+      "community": 1277
     },
     {
       "label": "remember-tool.spec.ts",
@@ -32684,12 +32692,36 @@
       "community": 688
     },
     {
+      "label": "remember-tool-relation-persist.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
+      "community": 689
+    },
+    {
+      "label": "initializeSchema()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
+      "source_location": "L12",
+      "id": "remember_tool_relation_persist_spec_initializeschema",
+      "community": 689
+    },
+    {
+      "label": "createHost()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
+      "source_location": "L44",
+      "id": "remember_tool_relation_persist_spec_createhost",
+      "community": 689
+    },
+    {
       "label": "telemetry-instrumentation.integration.spec.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 1277
+      "community": 1278
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -32697,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 901
+      "community": 902
     },
     {
       "label": "createSchema()",
@@ -32705,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 901
+      "community": 902
     },
     {
       "label": "export-memories-tool.spec.ts",
@@ -32713,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_export_memories_tool_spec_ts",
-      "community": 902
+      "community": 903
     },
     {
       "label": "initializeTestDatabase()",
@@ -32721,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L6",
       "id": "export_memories_tool_spec_initializetestdatabase",
-      "community": 902
+      "community": 903
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -32761,7 +32793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 1278
+      "community": 1279
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -32769,7 +32801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 1279
+      "community": 1280
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -32777,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 903
+      "community": 904
     },
     {
       "label": "initializeTestDatabase()",
@@ -32785,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 903
+      "community": 904
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -32793,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 904
+      "community": 905
     },
     {
       "label": "parseData()",
@@ -32801,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 904
+      "community": 905
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -32809,7 +32841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 1280
+      "community": 1281
     },
     {
       "label": "recall-tool.spec.ts",
@@ -32817,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "initializeTestDatabase()",
@@ -32825,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 689
+      "community": 690
     },
     {
       "label": "createValidReflectionNote()",
@@ -32833,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1508",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 689
+      "community": 690
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -32841,7 +32873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1281
+      "community": 1282
     },
     {
       "label": "remember-tool-relation-load.spec.ts",
@@ -32849,7 +32881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "initializeProductionLikeSchema()",
@@ -32857,7 +32889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L15",
       "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
-      "community": 690
+      "community": 691
     },
     {
       "label": "createHost()",
@@ -32865,7 +32897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L33",
       "id": "remember_tool_relation_load_spec_createhost",
-      "community": 690
+      "community": 691
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -32873,7 +32905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1282
+      "community": 1283
     },
     {
       "label": "pin-tool.spec.ts",
@@ -32881,7 +32913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1283
+      "community": 1284
     },
     {
       "label": "meta-memory-service.ts",
@@ -33129,7 +33161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 905
+      "community": 906
     },
     {
       "label": "createBaseSchema()",
@@ -33137,7 +33169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L24",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 905
+      "community": 906
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -33217,7 +33249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 906
+      "community": 907
     },
     {
       "label": "baseRow()",
@@ -33225,7 +33257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 906
+      "community": 907
     },
     {
       "label": "procedural-versioning.ts",
@@ -33265,7 +33297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -33273,7 +33305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 691
+      "community": 692
     },
     {
       "label": ".runScan()",
@@ -33281,7 +33313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 691
+      "community": 692
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -33289,7 +33321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "generateMemoryId()",
@@ -33297,7 +33329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 692
+      "community": 693
     },
     {
       "label": "rollbackToVersion()",
@@ -33305,7 +33337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 692
+      "community": 693
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -33377,7 +33409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "selectionWindowLimit()",
@@ -33385,7 +33417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 693
+      "community": 694
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -33393,7 +33425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 693
+      "community": 694
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -33441,7 +33473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1284
+      "community": 1285
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -33449,7 +33481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 907
+      "community": 908
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -33457,7 +33489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 907
+      "community": 908
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -33465,7 +33497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 908
+      "community": 909
     },
     {
       "label": "openDb()",
@@ -33473,7 +33505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 908
+      "community": 909
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -34233,7 +34265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 909
+      "community": 910
     },
     {
       "label": "createBaseSchema()",
@@ -34241,7 +34273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 909
+      "community": 910
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -34505,7 +34537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1285
+      "community": 1286
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -34513,7 +34545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -34521,7 +34553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 694
+      "community": 695
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -34529,7 +34561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 694
+      "community": 695
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -34537,7 +34569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1286
+      "community": 1287
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -34545,7 +34577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1287
+      "community": 1288
     },
     {
       "label": "core-memory-service.ts",
@@ -34705,7 +34737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 910
+      "community": 911
     },
     {
       "label": "createBaseSchema()",
@@ -34713,7 +34745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 910
+      "community": 911
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -34721,7 +34753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 911
+      "community": 912
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -34729,7 +34761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 911
+      "community": 912
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -34809,7 +34841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1288
+      "community": 1289
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -34817,7 +34849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1289
+      "community": 1290
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -34825,7 +34857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 912
+      "community": 913
     },
     {
       "label": "createSchema()",
@@ -34833,7 +34865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 912
+      "community": 913
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -34841,7 +34873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1290
+      "community": 1291
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -34849,7 +34881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 913
+      "community": 914
     },
     {
       "label": "createSchema()",
@@ -34857,7 +34889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 913
+      "community": 914
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -34865,7 +34897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1291
+      "community": 1292
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -34873,7 +34905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 914
+      "community": 915
     },
     {
       "label": "createBaseSchema()",
@@ -34881,7 +34913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 914
+      "community": 915
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -34889,7 +34921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1292
+      "community": 1293
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -34897,7 +34929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 915
+      "community": 916
     },
     {
       "label": "createSchema()",
@@ -34905,7 +34937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 915
+      "community": 916
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -34913,7 +34945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1293
+      "community": 1294
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -34921,7 +34953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1294
+      "community": 1295
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -35041,7 +35073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1295
+      "community": 1296
     },
     {
       "label": "semantic-memory-crud.ts",
@@ -35377,7 +35409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_types_ts",
-      "community": 916
+      "community": 917
     },
     {
       "label": "generateSemanticMemoryId()",
@@ -35385,7 +35417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L14",
       "id": "semantic_memory_update_types_generatesemanticmemoryid",
-      "community": 916
+      "community": 917
     },
     {
       "label": "semantic-memory-update-service.ts",
@@ -35441,7 +35473,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1296
+      "community": 1297
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -35449,7 +35481,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 917
+      "community": 918
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -35457,7 +35489,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 917
+      "community": 918
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -35465,7 +35497,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1297
+      "community": 1298
     },
     {
       "label": "consolidation-repository.ts",
@@ -35473,7 +35505,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_ts",
-      "community": 164
+      "community": 165
     },
     {
       "label": "ConsolidationRepository",
@@ -35481,7 +35513,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L25",
       "id": "consolidation_repository_consolidationrepository",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".constructor()",
@@ -35489,7 +35521,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L26",
       "id": "consolidation_repository_consolidationrepository_constructor",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".getLookbackDays()",
@@ -35497,7 +35529,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L28",
       "id": "consolidation_repository_consolidationrepository_getlookbackdays",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".findEpisodicCandidates()",
@@ -35505,7 +35537,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L37",
       "id": "consolidation_repository_consolidationrepository_findepisodiccandidates",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".findSemanticsByOwner()",
@@ -35513,7 +35545,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L87",
       "id": "consolidation_repository_consolidationrepository_findsemanticsbyowner",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".updateSemanticMemory()",
@@ -35521,7 +35553,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L103",
       "id": "consolidation_repository_consolidationrepository_updatesemanticmemory",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".loadEmbeddingsMap()",
@@ -35529,7 +35561,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L118",
       "id": "consolidation_repository_consolidationrepository_loadembeddingsmap",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".insertSemanticMemory()",
@@ -35537,7 +35569,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L151",
       "id": "consolidation_repository_consolidationrepository_insertsemanticmemory",
-      "community": 164
+      "community": 165
     },
     {
       "label": ".markEpisodicsConsolidated()",
@@ -35545,7 +35577,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.ts",
       "source_location": "L177",
       "id": "consolidation_repository_consolidationrepository_markepisodicsconsolidated",
-      "community": 164
+      "community": 165
     },
     {
       "label": "sleep-consolidation-service.ts",
@@ -35705,7 +35737,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 918
+      "community": 919
     },
     {
       "label": "row()",
@@ -35713,7 +35745,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 918
+      "community": 919
     },
     {
       "label": "consolidation-outbox-worker.ts",
@@ -35849,7 +35881,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "insertEpisodic()",
@@ -35857,7 +35889,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L10",
       "id": "consolidation_outbox_worker_spec_insertepisodic",
-      "community": 695
+      "community": 696
     },
     {
       "label": "insertEmbedding()",
@@ -35865,7 +35897,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L18",
       "id": "consolidation_outbox_worker_spec_insertembedding",
-      "community": 695
+      "community": 696
     },
     {
       "label": "clustering-service.spec.ts",
@@ -35873,7 +35905,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 919
+      "community": 920
     },
     {
       "label": "ep()",
@@ -35881,7 +35913,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 919
+      "community": 920
     },
     {
       "label": "relation-graph.port.ts",
@@ -35889,7 +35921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1298
+      "community": 1299
     },
     {
       "label": "get-relations-tool.ts",
@@ -35953,7 +35985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 920
+      "community": 921
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -35961,7 +35993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 920
+      "community": 921
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -36161,7 +36193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -36169,7 +36201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createTestMemory()",
@@ -36177,7 +36209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L53",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 696
+      "community": 697
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -36185,7 +36217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "createBaseSchema()",
@@ -36193,7 +36225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 697
+      "community": 698
     },
     {
       "label": "createTestMemory()",
@@ -36201,7 +36233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 697
+      "community": 698
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -36209,7 +36241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "createBaseSchema()",
@@ -36217,7 +36249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 698
+      "community": 699
     },
     {
       "label": "createTestMemory()",
@@ -36225,7 +36257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 698
+      "community": 699
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -36233,7 +36265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1299
+      "community": 1300
     },
     {
       "label": "relation-tools-registry.spec.ts",
@@ -36241,7 +36273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/relation-tools-registry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_relation_tools_registry_spec_ts",
-      "community": 1300
+      "community": 1301
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -36249,7 +36281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "createBaseSchema()",
@@ -36257,7 +36289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 699
+      "community": 700
     },
     {
       "label": "createTestMemory()",
@@ -36265,7 +36297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L53",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 699
+      "community": 700
     },
     {
       "label": "relation-retry-manager.ts",
@@ -37313,7 +37345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1301
+      "community": 1302
     },
     {
       "label": "relation-graph.spec.ts",
@@ -37321,7 +37353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "createBaseSchema()",
@@ -37329,7 +37361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 700
+      "community": 701
     },
     {
       "label": "createTestMemory()",
@@ -37337,7 +37369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 700
+      "community": 701
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -37345,7 +37377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 921
+      "community": 922
     },
     {
       "label": "createTestMemory()",
@@ -37353,7 +37385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L65",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 921
+      "community": 922
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -37393,7 +37425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 922
+      "community": 923
     },
     {
       "label": "createTestMemory()",
@@ -37401,7 +37433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 922
+      "community": 923
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -37465,7 +37497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1302
+      "community": 1303
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -37473,7 +37505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1303
+      "community": 1304
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -37481,7 +37513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "getMockMementoConfig()",
@@ -37489,7 +37521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 701
+      "community": 702
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -37497,7 +37529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 701
+      "community": 702
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -37505,7 +37537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1304
+      "community": 1305
     },
     {
       "label": "provider-openai.spec.ts",
@@ -37513,7 +37545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1305
+      "community": 1306
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -37521,7 +37553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1306
+      "community": 1307
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -37529,7 +37561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1307
+      "community": 1308
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -37849,7 +37881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 923
+      "community": 924
     },
     {
       "label": "extract()",
@@ -37857,7 +37889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 923
+      "community": 924
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -37865,7 +37897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "tripleDedupeKey()",
@@ -37873,7 +37905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 702
+      "community": 703
     },
     {
       "label": "mergeTripleLists()",
@@ -37881,7 +37913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 702
+      "community": 703
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -37889,7 +37921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1308
+      "community": 1309
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -38097,7 +38129,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1309
+      "community": 1310
     },
     {
       "label": "triple-extraction-llm-pipeline.spec.ts",
@@ -38105,7 +38137,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_spec_ts",
-      "community": 1310
+      "community": 1311
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -38113,7 +38145,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1311
+      "community": 1312
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -38121,7 +38153,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1312
+      "community": 1313
     },
     {
       "label": "triple-extractor.ts",
@@ -38297,7 +38329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1313
+      "community": 1314
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -38337,7 +38369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1314
+      "community": 1315
     },
     {
       "label": "triple-parser.ts",
@@ -38385,7 +38417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 924
+      "community": 925
     },
     {
       "label": "splitTextIntoChunks()",
@@ -38393,7 +38425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 924
+      "community": 925
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -38401,7 +38433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 925
+      "community": 926
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -38409,7 +38441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 925
+      "community": 926
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -38417,7 +38449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_ts",
-      "community": 165
+      "community": 166
     },
     {
       "label": "PredicateCanonicalizer",
@@ -38425,7 +38457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L95",
       "id": "predicate_canonicalizer_predicatecanonicalizer",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".constructor()",
@@ -38433,7 +38465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L99",
       "id": "predicate_canonicalizer_predicatecanonicalizer_constructor",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".buildReverseIndex()",
@@ -38441,7 +38473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L107",
       "id": "predicate_canonicalizer_predicatecanonicalizer_buildreverseindex",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".normalizeKey()",
@@ -38449,7 +38481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L125",
       "id": "predicate_canonicalizer_predicatecanonicalizer_normalizekey",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".canonicalize()",
@@ -38457,7 +38489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L135",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalize",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".canonicalizeBatch()",
@@ -38465,7 +38497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L177",
       "id": "predicate_canonicalizer_predicatecanonicalizer_canonicalizebatch",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".addPredicate()",
@@ -38473,7 +38505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L187",
       "id": "predicate_canonicalizer_predicatecanonicalizer_addpredicate",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".getDictionary()",
@@ -38481,7 +38513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L206",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getdictionary",
-      "community": 165
+      "community": 166
     },
     {
       "label": ".getCanonicalPredicates()",
@@ -38489,7 +38521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.ts",
       "source_location": "L213",
       "id": "predicate_canonicalizer_predicatecanonicalizer_getcanonicalpredicates",
-      "community": 165
+      "community": 166
     },
     {
       "label": "entity-linker.spec.ts",
@@ -38497,7 +38529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1315
+      "community": 1316
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -38505,7 +38537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1316
+      "community": 1317
     },
     {
       "label": "interfaces.spec.ts",
@@ -38513,7 +38545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1317
+      "community": 1318
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -38521,7 +38553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1318
+      "community": 1319
     },
     {
       "label": "triple-parser.spec.ts",
@@ -38529,7 +38561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1319
+      "community": 1320
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -38537,7 +38569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 926
+      "community": 927
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -38545,7 +38577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 926
+      "community": 927
     },
     {
       "label": "extract-relations-openai.ts",
@@ -38553,7 +38585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 927
+      "community": 928
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -38561,7 +38593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 927
+      "community": 928
     },
     {
       "label": "types.ts",
@@ -38569,7 +38601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1320
+      "community": 1321
     },
     {
       "label": "ollama-chat-support.ts",
@@ -38609,7 +38641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 928
+      "community": 929
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -38617,7 +38649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 928
+      "community": 929
     },
     {
       "label": "provider-selection.ts",
@@ -38625,7 +38657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -38633,7 +38665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 703
+      "community": 704
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -38641,7 +38673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 703
+      "community": 704
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -38649,7 +38681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 929
+      "community": 930
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -38657,7 +38689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 929
+      "community": 930
     },
     {
       "label": "llm-response-parse.ts",
@@ -38705,7 +38737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_types_ts",
-      "community": 1321
+      "community": 1322
     },
     {
       "label": "analysis-rules.ts",
@@ -38833,7 +38865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_matching_rules_ts",
-      "community": 930
+      "community": 931
     },
     {
       "label": "matchRelations()",
@@ -38841,7 +38873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L7",
       "id": "matching_rules_matchrelations",
-      "community": 930
+      "community": 931
     },
     {
       "label": "types.ts",
@@ -38849,7 +38881,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1322
+      "community": 1323
     },
     {
       "label": "agent-integration-repository.ts",
@@ -38857,7 +38889,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1323
+      "community": 1324
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -38865,7 +38897,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "candidate()",
@@ -38873,7 +38905,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 704
+      "community": 705
     },
     {
       "label": "source()",
@@ -38881,7 +38913,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 704
+      "community": 705
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -38889,7 +38921,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1324
+      "community": 1325
     },
     {
       "label": "agent-integration-error.ts",
@@ -38897,7 +38929,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "AgentIntegrationError",
@@ -38905,7 +38937,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 705
+      "community": 706
     },
     {
       "label": ".constructor()",
@@ -38913,7 +38945,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 705
+      "community": 706
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -38921,7 +38953,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1325
+      "community": 1326
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -38929,7 +38961,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "createSession()",
@@ -38937,7 +38969,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 706
+      "community": 707
     },
     {
       "label": "addObservation()",
@@ -38945,7 +38977,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 706
+      "community": 707
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -39409,7 +39441,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_provenance_graph_ts",
-      "community": 931
+      "community": 932
     },
     {
       "label": "buildProvenanceTrace()",
@@ -39417,7 +39449,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L10",
       "id": "agent_provenance_graph_buildprovenancetrace",
-      "community": 931
+      "community": 932
     },
     {
       "label": "agent-context-injection-service.spec.ts",
@@ -39425,7 +39457,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1326
+      "community": 1327
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -39433,7 +39465,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_ts",
-      "community": 166
+      "community": 167
     },
     {
       "label": "SqliteHybridAgentContextSource",
@@ -39441,7 +39473,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L20",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".constructor()",
@@ -39449,7 +39481,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L25",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_constructor",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".recall()",
@@ -39457,7 +39489,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L30",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_recall",
-      "community": 166
+      "community": 167
     },
     {
       "label": ".loadMemoryRows()",
@@ -39465,7 +39497,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L94",
       "id": "sqlite_hybrid_agent_context_source_sqlitehybridagentcontextsource_loadmemoryrows",
-      "community": 166
+      "community": 167
     },
     {
       "label": "scopeSearchFilters()",
@@ -39473,7 +39505,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L125",
       "id": "sqlite_hybrid_agent_context_source_scopesearchfilters",
-      "community": 166
+      "community": 167
     },
     {
       "label": "asMemoryType()",
@@ -39481,7 +39513,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L151",
       "id": "sqlite_hybrid_agent_context_source_asmemorytype",
-      "community": 166
+      "community": 167
     },
     {
       "label": "asPrivacyScope()",
@@ -39489,7 +39521,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L160",
       "id": "sqlite_hybrid_agent_context_source_asprivacyscope",
-      "community": 166
+      "community": 167
     },
     {
       "label": "clampConfidence()",
@@ -39497,7 +39529,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L166",
       "id": "sqlite_hybrid_agent_context_source_clampconfidence",
-      "community": 166
+      "community": 167
     },
     {
       "label": "parseTags()",
@@ -39505,7 +39537,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.ts",
       "source_location": "L173",
       "id": "sqlite_hybrid_agent_context_source_parsetags",
-      "community": 166
+      "community": 167
     },
     {
       "label": "agent-memory-promotion-service.spec.ts",
@@ -39513,7 +39545,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "addObservation()",
@@ -39521,7 +39553,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 707
+      "community": 708
     },
     {
       "label": "finishAndSummarize()",
@@ -39529,7 +39561,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 707
+      "community": 708
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -39537,7 +39569,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_capture_transaction_ts",
-      "community": 932
+      "community": 933
     },
     {
       "label": "executeAgentCaptureTransaction()",
@@ -39545,7 +39577,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L21",
       "id": "agent_capture_transaction_executeagentcapturetransaction",
-      "community": 932
+      "community": 933
     },
     {
       "label": "agent-lifecycle-service.ts",
@@ -39953,7 +39985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1327
+      "community": 1328
     },
     {
       "label": "minilm-embedding-service.ts",
@@ -40969,7 +41001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1328
+      "community": 1329
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -40977,7 +41009,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1329
+      "community": 1330
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -40985,7 +41017,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "createSchema()",
@@ -40993,7 +41025,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 708
+      "community": 709
     },
     {
       "label": "seedMemoryItem()",
@@ -41001,7 +41033,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 708
+      "community": 709
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -41009,7 +41041,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1330
+      "community": 1331
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -41017,7 +41049,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1331
+      "community": 1332
     },
     {
       "label": "embedding-reindex-service.spec.ts",
@@ -41025,7 +41057,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-reindex-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_reindex_service_spec_ts",
-      "community": 1332
+      "community": 1333
     },
     {
       "label": "types.ts",
@@ -41033,7 +41065,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_types_ts",
-      "community": 1333
+      "community": 1334
     },
     {
       "label": "migration-execution.ts",
@@ -41289,7 +41321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 933
+      "community": 934
     },
     {
       "label": "executeResolveError()",
@@ -41297,7 +41329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 933
+      "community": 934
     },
     {
       "label": "error-stats.ts",
@@ -41305,7 +41337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 934
+      "community": 935
     },
     {
       "label": "executeErrorStats()",
@@ -41313,7 +41345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 934
+      "community": 935
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -41321,7 +41353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1334
+      "community": 1335
     },
     {
       "label": "resolve-error.spec.ts",
@@ -41329,7 +41361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1335
+      "community": 1336
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -41337,7 +41369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 935
+      "community": 936
     },
     {
       "label": "createBaseSchema()",
@@ -41345,7 +41377,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 935
+      "community": 936
     },
     {
       "label": "error-stats.spec.ts",
@@ -41353,7 +41385,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1336
+      "community": 1337
     },
     {
       "label": "performance-monitor-types.ts",
@@ -41361,7 +41393,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_monitor_types_ts",
-      "community": 1337
+      "community": 1338
     },
     {
       "label": "performance-monitor.ts",
@@ -42569,7 +42601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1338
+      "community": 1339
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -42577,7 +42609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1339
+      "community": 1340
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -42585,7 +42617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1340
+      "community": 1341
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -42593,7 +42625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1341
+      "community": 1342
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -42641,7 +42673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 936
+      "community": 937
     },
     {
       "label": "restoreEnvValue()",
@@ -42649,7 +42681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 936
+      "community": 937
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -42793,7 +42825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 937
+      "community": 938
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42801,7 +42833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 937
+      "community": 938
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -42881,7 +42913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 938
+      "community": 939
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42889,7 +42921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 938
+      "community": 939
     },
     {
       "label": "category-quality-aggregator.ts",
@@ -43137,7 +43169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1342
+      "community": 1343
     },
     {
       "label": "quality-assurance-service.ts",
@@ -43257,7 +43289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_ts",
-      "community": 167
+      "community": 168
     },
     {
       "label": "QualityMetricsCollector",
@@ -43265,7 +43297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L31",
       "id": "quality_metrics_collector_qualitymetricscollector",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".constructor()",
@@ -43273,7 +43305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L38",
       "id": "quality_metrics_collector_qualitymetricscollector_constructor",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectSearchMetrics()",
@@ -43281,7 +43313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L50",
       "id": "quality_metrics_collector_qualitymetricscollector_collectsearchmetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectRelationMetrics()",
@@ -43289,7 +43321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L57",
       "id": "quality_metrics_collector_qualitymetricscollector_collectrelationmetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectConsolidationMetrics()",
@@ -43297,7 +43329,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L64",
       "id": "quality_metrics_collector_qualitymetricscollector_collectconsolidationmetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectStorageMetrics()",
@@ -43305,7 +43337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L71",
       "id": "quality_metrics_collector_qualitymetricscollector_collectstoragemetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectAllMetrics()",
@@ -43313,7 +43345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L75",
       "id": "quality_metrics_collector_qualitymetricscollector_collectallmetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectMetricsByNamespace()",
@@ -43321,7 +43353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L84",
       "id": "quality_metrics_collector_qualitymetricscollector_collectmetricsbynamespace",
-      "community": 167
+      "community": 168
     },
     {
       "label": ".collectCategoryMetrics()",
@@ -43329,7 +43361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.ts",
       "source_location": "L102",
       "id": "quality_metrics_collector_qualitymetricscollector_collectcategorymetrics",
-      "community": 167
+      "community": 168
     },
     {
       "label": "search-metrics-collector.ts",
@@ -43449,7 +43481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_types_ts",
-      "community": 1343
+      "community": 1344
     },
     {
       "label": "quality-recorder.spec.ts",
@@ -43673,7 +43705,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1344
+      "community": 1345
     },
     {
       "label": "base-tool.ts",
@@ -43969,7 +44001,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 939
+      "community": 940
     },
     {
       "label": "testBootstrapIntegration()",
@@ -43977,7 +44009,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 939
+      "community": 940
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -43985,7 +44017,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 940
+      "community": 941
     },
     {
       "label": "measureRecall()",
@@ -43993,7 +44025,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 940
+      "community": 941
     },
     {
       "label": "test-embedding.ts",
@@ -44001,7 +44033,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 941
+      "community": 942
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -44009,7 +44041,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 941
+      "community": 942
     },
     {
       "label": "test-tool-consistency.ts",
@@ -44017,7 +44049,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "compareToolResults()",
@@ -44025,7 +44057,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 709
+      "community": 710
     },
     {
       "label": "testToolConsistency()",
@@ -44033,7 +44065,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 709
+      "community": 710
     },
     {
       "label": "test-quality-assurance.ts",
@@ -44041,7 +44073,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "createQualityTables()",
@@ -44049,7 +44081,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 710
+      "community": 711
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -44057,7 +44089,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 710
+      "community": 711
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -44105,7 +44137,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 942
+      "community": 943
     },
     {
       "label": "testSearchFunctionality()",
@@ -44113,7 +44145,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 942
+      "community": 943
     },
     {
       "label": "test-forgetting.ts",
@@ -44121,7 +44153,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 943
+      "community": 944
     },
     {
       "label": "testForgettingFunctionality()",
@@ -44129,7 +44161,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 943
+      "community": 944
     },
     {
       "label": "mock-database.spec.ts",
@@ -44137,7 +44169,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1345
+      "community": 1346
     },
     {
       "label": "test-m1-completion.ts",
@@ -44145,7 +44177,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 944
+      "community": 945
     },
     {
       "label": "testM1Completion()",
@@ -44153,7 +44185,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 944
+      "community": 945
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -44161,7 +44193,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 945
+      "community": 946
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -44169,7 +44201,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 945
+      "community": 946
     },
     {
       "label": "vitest.setup.ts",
@@ -44177,7 +44209,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1346
+      "community": 1347
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -44185,7 +44217,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 946
+      "community": 947
     },
     {
       "label": "parseItems()",
@@ -44193,7 +44225,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 946
+      "community": 947
     },
     {
       "label": "test-memory-resource.ts",
@@ -44201,7 +44233,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "setupResourceHandlers()",
@@ -44209,7 +44241,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 711
+      "community": 712
     },
     {
       "label": "createTestMemories()",
@@ -44217,7 +44249,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 711
+      "community": 712
     },
     {
       "label": "test-regression.ts",
@@ -44225,7 +44257,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 947
+      "community": 948
     },
     {
       "label": "testRegression()",
@@ -44233,7 +44265,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 947
+      "community": 948
     },
     {
       "label": "test-anchor-system.ts",
@@ -44297,7 +44329,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1347
+      "community": 1348
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -44369,7 +44401,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 948
+      "community": 949
     },
     {
       "label": "testSingleProviderRegression()",
@@ -44377,7 +44409,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 948
+      "community": 949
     },
     {
       "label": "visualize-recency.ts",
@@ -44441,7 +44473,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1348
+      "community": 1349
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -44505,7 +44537,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 949
+      "community": 950
     },
     {
       "label": "constructor()",
@@ -44513,7 +44545,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 949
+      "community": 950
     },
     {
       "label": "mock-database.ts",
@@ -44745,7 +44777,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1349
+      "community": 1350
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -44785,7 +44817,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 950
+      "community": 951
     },
     {
       "label": "createTestMemories()",
@@ -44793,7 +44825,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L289",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 950
+      "community": 951
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -44801,7 +44833,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 951
+      "community": 952
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -44809,7 +44841,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 951
+      "community": 952
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -44817,7 +44849,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1350
+      "community": 1351
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -44825,7 +44857,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 952
+      "community": 953
     },
     {
       "label": "seedCluster()",
@@ -44833,7 +44865,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 952
+      "community": 953
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -44841,7 +44873,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "readSource()",
@@ -44849,7 +44881,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 712
+      "community": 713
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -44857,7 +44889,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 712
+      "community": 713
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -44897,7 +44929,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 953
+      "community": 954
     },
     {
       "label": "writeFixtureDir()",
@@ -44905,7 +44937,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 953
+      "community": 954
     },
     {
       "label": "search-quality-metrics.ts",
@@ -45001,7 +45033,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1351
+      "community": 1352
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -45105,7 +45137,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1352
+      "community": 1353
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -45113,7 +45145,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1353
+      "community": 1354
     },
     {
       "label": "test-database.ts",
@@ -45145,7 +45177,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 954
+      "community": 955
     },
     {
       "label": "mergeCandidateIds()",
@@ -45153,7 +45185,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 954
+      "community": 955
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -45161,7 +45193,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -45169,7 +45201,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 713
+      "community": 714
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -45177,7 +45209,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 713
+      "community": 714
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -45185,7 +45217,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1354
+      "community": 1355
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -45193,7 +45225,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1355
+      "community": 1356
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -45393,7 +45425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1356
+      "community": 1357
     },
     {
       "label": "query-counter.ts",
@@ -45433,7 +45465,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_ts",
-      "community": 1357
+      "community": 1358
     },
     {
       "label": "top-k-retention.ts",
@@ -45441,7 +45473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_top_k_retention_ts",
-      "community": 955
+      "community": 956
     },
     {
       "label": "calculateTopKRetention()",
@@ -45449,7 +45481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L29",
       "id": "top_k_retention_calculatetopkretention",
-      "community": 955
+      "community": 956
     },
     {
       "label": "types.ts",
@@ -45457,7 +45489,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_types_ts",
-      "community": 1358
+      "community": 1359
     },
     {
       "label": "kendall-tau.ts",
@@ -45513,7 +45545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spearman_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "calculateSpearmanRho()",
@@ -45521,7 +45553,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L27",
       "id": "spearman_calculatespearmanrho",
-      "community": 714
+      "community": 715
     },
     {
       "label": "calculateRanks()",
@@ -45529,7 +45561,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L81",
       "id": "spearman_calculateranks",
-      "community": 714
+      "community": 715
     },
     {
       "label": "report-comparison.ts",
@@ -45833,7 +45865,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 956
+      "community": 957
     },
     {
       "label": "copyDir()",
@@ -45841,7 +45873,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 956
+      "community": 957
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -45849,7 +45881,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 957
+      "community": 958
     },
     {
       "label": "readRootPackageJson()",
@@ -45857,7 +45889,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 957
+      "community": 958
     },
     {
       "label": "memory-export-import.spec.ts",
@@ -45865,7 +45897,7 @@
       "source_file": "tests/memory-export-import.spec.ts",
       "source_location": "L1",
       "id": "tests_memory_export_import_spec_ts",
-      "community": 1359
+      "community": 1360
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -45873,7 +45905,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 958
+      "community": 959
     },
     {
       "label": "readJson()",
@@ -45881,7 +45913,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 958
+      "community": 959
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -45889,7 +45921,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 959
+      "community": 960
     },
     {
       "label": "readWorkflow()",
@@ -45897,7 +45929,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 959
+      "community": 960
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -45969,7 +46001,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 715
+      "community": 716
     },
     {
       "label": "readStaticFile()",
@@ -45977,7 +46009,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 715
+      "community": 716
     },
     {
       "label": "getFunctionMetrics()",
@@ -45985,7 +46017,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L9",
       "id": "static_design_contracts_spec_getfunctionmetrics",
-      "community": 715
+      "community": 716
     },
     {
       "label": "anchor-map.e2e.ts",
@@ -45993,7 +46025,7 @@
       "source_file": "tests/e2e/dashboard/anchor-map.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_anchor_map_e2e_ts",
-      "community": 1360
+      "community": 1361
     },
     {
       "label": "agent-sessions.e2e.ts",
@@ -46001,7 +46033,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_e2e_ts",
-      "community": 1361
+      "community": 1362
     },
     {
       "label": "agent-sessions.fixtures.ts",
@@ -46065,7 +46097,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 960
+      "community": 961
     },
     {
       "label": "extractFencedBlocks()",
@@ -46073,7 +46105,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 960
+      "community": 961
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -46177,7 +46209,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L1",
       "id": "scripts_check_magic_numbers_ts",
-      "community": 168
+      "community": 169
     },
     {
       "label": "isCoreModule()",
@@ -46185,7 +46217,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L73",
       "id": "check_magic_numbers_iscoremodule",
-      "community": 168
+      "community": 169
     },
     {
       "label": "isExcluded()",
@@ -46193,7 +46225,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L77",
       "id": "check_magic_numbers_isexcluded",
-      "community": 168
+      "community": 169
     },
     {
       "label": "findMagicNumbers()",
@@ -46201,7 +46233,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L82",
       "id": "check_magic_numbers_findmagicnumbers",
-      "community": 168
+      "community": 169
     },
     {
       "label": "getAllTsFiles()",
@@ -46209,7 +46241,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L130",
       "id": "check_magic_numbers_getalltsfiles",
-      "community": 168
+      "community": 169
     },
     {
       "label": "countMagicNumbers()",
@@ -46217,7 +46249,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L161",
       "id": "check_magic_numbers_countmagicnumbers",
-      "community": 168
+      "community": 169
     },
     {
       "label": "printResultsJSON()",
@@ -46225,7 +46257,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L195",
       "id": "check_magic_numbers_printresultsjson",
-      "community": 168
+      "community": 169
     },
     {
       "label": "printResultsCSV()",
@@ -46233,7 +46265,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L214",
       "id": "check_magic_numbers_printresultscsv",
-      "community": 168
+      "community": 169
     },
     {
       "label": "printResultsText()",
@@ -46241,7 +46273,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L222",
       "id": "check_magic_numbers_printresultstext",
-      "community": 168
+      "community": 169
     },
     {
       "label": "main()",
@@ -46249,7 +46281,7 @@
       "source_file": "scripts/check-magic-numbers.ts",
       "source_location": "L233",
       "id": "check_magic_numbers_main",
-      "community": 168
+      "community": 169
     },
     {
       "label": "prepack-bundle-core.js",
@@ -46257,7 +46289,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 961
+      "community": 962
     },
     {
       "label": "shouldInclude()",
@@ -46265,7 +46297,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 961
+      "community": 962
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -46273,7 +46305,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 716
+      "community": 717
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -46281,7 +46313,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 716
+      "community": 717
     },
     {
       "label": "readTarString()",
@@ -46289,7 +46321,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 716
+      "community": 717
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -46353,7 +46385,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 962
+      "community": 963
     },
     {
       "label": "fixMigration()",
@@ -46361,7 +46393,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 962
+      "community": 963
     },
     {
       "label": "sync-root-server-dist.js",
@@ -46369,7 +46401,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1362
+      "community": 1363
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -47161,7 +47193,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 963
+      "community": 964
     },
     {
       "label": "updateEmbeddings()",
@@ -47169,7 +47201,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 963
+      "community": 964
     },
     {
       "label": "memory-export.ts",
@@ -47209,7 +47241,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "temporaryRoot()",
@@ -47217,7 +47249,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 717
+      "community": 718
     },
     {
       "label": "dependencies()",
@@ -47225,7 +47257,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 717
+      "community": 718
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -47321,7 +47353,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L1",
       "id": "scripts_reindex_embeddings_ts",
-      "community": 718
+      "community": 719
     },
     {
       "label": "option()",
@@ -47329,7 +47361,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L3",
       "id": "reindex_embeddings_option",
-      "community": 718
+      "community": 719
     },
     {
       "label": "main()",
@@ -47337,7 +47369,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L8",
       "id": "reindex_embeddings_main",
-      "community": 718
+      "community": 719
     },
     {
       "label": "check-pii-masking.ts",
@@ -47417,7 +47449,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 964
+      "community": 965
     },
     {
       "label": "analyzeEmbeddings()",
@@ -47425,7 +47457,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 964
+      "community": 965
     },
     {
       "label": "test-docker.js",
@@ -47433,7 +47465,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 719
+      "community": 720
     },
     {
       "label": "fetchJson()",
@@ -47441,7 +47473,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L7",
       "id": "test_docker_fetchjson",
-      "community": 719
+      "community": 720
     },
     {
       "label": "testDockerServer()",
@@ -47449,7 +47481,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L23",
       "id": "test_docker_testdockerserver",
-      "community": 719
+      "community": 720
     },
     {
       "label": "pack-with-restore.js",
@@ -47457,7 +47489,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1363
+      "community": 1364
     },
     {
       "label": "run-migration.js",
@@ -47465,7 +47497,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 965
+      "community": 966
     },
     {
       "label": "runMigration()",
@@ -47473,7 +47505,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 965
+      "community": 966
     },
     {
       "label": "safe-migration.js",
@@ -47481,7 +47513,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 966
+      "community": 967
     },
     {
       "label": "safeMigration()",
@@ -47489,7 +47521,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 966
+      "community": 967
     },
     {
       "label": "generate-ground-truth.ts",
@@ -47553,7 +47585,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 967
+      "community": 968
     },
     {
       "label": "saveWorkMemory()",
@@ -47561,7 +47593,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 967
+      "community": 968
     },
     {
       "label": "check-file-sizes.ts",
@@ -47801,7 +47833,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1364
+      "community": 1365
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -47809,7 +47841,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 968
+      "community": 969
     },
     {
       "label": "main()",
@@ -47817,7 +47849,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 968
+      "community": 969
     },
     {
       "label": "agent-integration-release-gate.spec.ts",
@@ -47937,7 +47969,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1365
+      "community": 1366
     },
     {
       "label": "forgetting-events-query.ts",
@@ -47977,7 +48009,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1366
+      "community": 1367
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -48025,7 +48057,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 969
+      "community": 970
     },
     {
       "label": "analyzeEmbeddings()",
@@ -48033,7 +48065,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 969
+      "community": 970
     },
     {
       "label": "memory-import.ts",
@@ -48073,7 +48105,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 970
+      "community": 971
     },
     {
       "label": "fixVectorDimensions()",
@@ -48081,7 +48113,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 970
+      "community": 971
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -48121,7 +48153,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "loadVecExtension()",
@@ -48129,7 +48161,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 720
+      "community": 721
     },
     {
       "label": "fixTfidfDimensions()",
@@ -48137,7 +48169,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 720
+      "community": 721
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -48145,7 +48177,7 @@
       "source_file": "scripts/longmemeval-validation.spec.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_spec_ts",
-      "community": 1367
+      "community": 1368
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -48153,7 +48185,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 971
+      "community": 972
     },
     {
       "label": "runUpdateMigration()",
@@ -48161,7 +48193,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 971
+      "community": 972
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -48169,7 +48201,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "reappearanceRate()",
@@ -48177,7 +48209,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 721
+      "community": 722
     },
     {
       "label": "main()",
@@ -48185,7 +48217,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 721
+      "community": 722
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -48193,7 +48225,7 @@
       "source_file": "scripts/acquire-longmemeval.spec.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_spec_ts",
-      "community": 1368
+      "community": 1369
     },
     {
       "label": "regenerate-embeddings.js",
@@ -48201,7 +48233,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 972
+      "community": 973
     },
     {
       "label": "regenerateEmbeddings()",
@@ -48209,7 +48241,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 972
+      "community": 973
     },
     {
       "label": "generate-relation-report.ts",
@@ -48281,7 +48313,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L1",
       "id": "scripts_check_sql_injection_ts",
-      "community": 169
+      "community": 170
     },
     {
       "label": "parseArgs()",
@@ -48289,7 +48321,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L56",
       "id": "check_sql_injection_parseargs",
-      "community": 169
+      "community": 170
     },
     {
       "label": "printHelp()",
@@ -48297,7 +48329,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L87",
       "id": "check_sql_injection_printhelp",
-      "community": 169
+      "community": 170
     },
     {
       "label": "matchesPattern()",
@@ -48305,7 +48337,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L110",
       "id": "check_sql_injection_matchespattern",
-      "community": 169
+      "community": 170
     },
     {
       "label": "shouldExclude()",
@@ -48313,7 +48345,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L129",
       "id": "check_sql_injection_shouldexclude",
-      "community": 169
+      "community": 170
     },
     {
       "label": "findFiles()",
@@ -48321,7 +48353,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L141",
       "id": "check_sql_injection_findfiles",
-      "community": 169
+      "community": 170
     },
     {
       "label": "findSqlInjectionPatterns()",
@@ -48329,7 +48361,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L179",
       "id": "check_sql_injection_findsqlinjectionpatterns",
-      "community": 169
+      "community": 170
     },
     {
       "label": "checkSqlInjection()",
@@ -48337,7 +48369,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L453",
       "id": "check_sql_injection_checksqlinjection",
-      "community": 169
+      "community": 170
     },
     {
       "label": "printResults()",
@@ -48345,7 +48377,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L483",
       "id": "check_sql_injection_printresults",
-      "community": 169
+      "community": 170
     },
     {
       "label": "main()",
@@ -48353,7 +48385,7 @@
       "source_file": "scripts/check-sql-injection.ts",
       "source_location": "L542",
       "id": "check_sql_injection_main",
-      "community": 169
+      "community": 170
     },
     {
       "label": "quality-benchmark-category-report.spec.ts",
@@ -48361,7 +48393,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 973
+      "community": 974
     },
     {
       "label": "sampleReport()",
@@ -48369,7 +48401,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 973
+      "community": 974
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -48377,7 +48409,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1369
+      "community": 1370
     },
     {
       "label": "debug-embeddings.js",
@@ -48385,7 +48417,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 974
+      "community": 975
     },
     {
       "label": "debugEmbeddings()",
@@ -48393,7 +48425,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 974
+      "community": 975
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -48401,7 +48433,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1370
+      "community": 1371
     },
     {
       "label": "longmemeval-validation.ts",
@@ -49033,7 +49065,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 975
+      "community": 976
     },
     {
       "label": "backupEmbeddings()",
@@ -49041,7 +49073,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 975
+      "community": 976
     },
     {
       "label": "count-any-types.ts",
@@ -49049,7 +49081,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L1",
       "id": "scripts_count_any_types_ts",
-      "community": 170
+      "community": 171
     },
     {
       "label": "parseArgs()",
@@ -49057,7 +49089,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L56",
       "id": "count_any_types_parseargs",
-      "community": 170
+      "community": 171
     },
     {
       "label": "printHelp()",
@@ -49065,7 +49097,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L92",
       "id": "count_any_types_printhelp",
-      "community": 170
+      "community": 171
     },
     {
       "label": "matchesPattern()",
@@ -49073,7 +49105,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L118",
       "id": "count_any_types_matchespattern",
-      "community": 170
+      "community": 171
     },
     {
       "label": "shouldExclude()",
@@ -49081,7 +49113,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L137",
       "id": "count_any_types_shouldexclude",
-      "community": 170
+      "community": 171
     },
     {
       "label": "findFiles()",
@@ -49089,7 +49121,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L149",
       "id": "count_any_types_findfiles",
-      "community": 170
+      "community": 171
     },
     {
       "label": "findAnyTypes()",
@@ -49097,7 +49129,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L186",
       "id": "count_any_types_findanytypes",
-      "community": 170
+      "community": 171
     },
     {
       "label": "countAnyTypes()",
@@ -49105,7 +49137,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L251",
       "id": "count_any_types_countanytypes",
-      "community": 170
+      "community": 171
     },
     {
       "label": "printResults()",
@@ -49113,7 +49145,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L278",
       "id": "count_any_types_printresults",
-      "community": 170
+      "community": 171
     },
     {
       "label": "main()",
@@ -49121,7 +49153,7 @@
       "source_file": "scripts/count-any-types.ts",
       "source_location": "L318",
       "id": "count_any_types_main",
-      "community": 170
+      "community": 171
     },
     {
       "label": "count-console-logs.ts",
@@ -49257,7 +49289,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 976
+      "community": 977
     },
     {
       "label": "makeRng()",
@@ -49265,7 +49297,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 976
+      "community": 977
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -49273,7 +49305,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1371
+      "community": 1372
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -49281,7 +49313,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1372
+      "community": 1373
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -49289,7 +49321,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1373
+      "community": 1374
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -49297,7 +49329,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 977
+      "community": 978
     },
     {
       "label": "jsonEmbedding()",
@@ -49305,7 +49337,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 977
+      "community": 978
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -49313,7 +49345,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1374
+      "community": 1375
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -49321,7 +49353,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1375
+      "community": 1376
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -49329,7 +49361,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1376
+      "community": 1377
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -49337,7 +49369,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 978
+      "community": 979
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -49345,7 +49377,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 978
+      "community": 979
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -49353,7 +49385,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1377
+      "community": 1378
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -49361,7 +49393,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 979
+      "community": 980
     },
     {
       "label": "jsonEmbedding()",
@@ -49369,7 +49401,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 979
+      "community": 980
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -49377,7 +49409,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 980
+      "community": 981
     },
     {
       "label": "main()",
@@ -49385,7 +49417,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 980
+      "community": 981
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -49393,7 +49425,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 981
+      "community": 982
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -49401,7 +49433,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 981
+      "community": 982
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -49409,7 +49441,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "createBackup()",
@@ -49417,7 +49449,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 722
+      "community": 723
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -49425,7 +49457,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 722
+      "community": 723
     },
     {
       "label": "restore-legacy.ps1",
@@ -49433,7 +49465,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1378
+      "community": 1379
     },
     {
       "label": "check-retry-usage.ts",
@@ -49553,7 +49585,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 982
+      "community": 983
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -49561,7 +49593,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 982
+      "community": 983
     },
     {
       "label": "check-no-console-violations.ts",
@@ -49657,7 +49689,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 983
+      "community": 984
     },
     {
       "label": "fixVecTableDimensions()",
@@ -49665,7 +49697,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 983
+      "community": 984
     },
     {
       "label": "sources.ts",
@@ -49673,7 +49705,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sources_ts",
-      "community": 171
+      "community": 172
     },
     {
       "label": "splitJsonlLines()",
@@ -49681,7 +49713,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L17",
       "id": "sources_splitjsonllines",
-      "community": 171
+      "community": 172
     },
     {
       "label": "cursorKey()",
@@ -49689,7 +49721,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L32",
       "id": "sources_cursorkey",
-      "community": 171
+      "community": 172
     },
     {
       "label": "findLastNewlineBefore()",
@@ -49697,7 +49729,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L36",
       "id": "sources_findlastnewlinebefore",
-      "community": 171
+      "community": 172
     },
     {
       "label": "readStreamLines()",
@@ -49705,7 +49737,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L56",
       "id": "sources_readstreamlines",
-      "community": 171
+      "community": 172
     },
     {
       "label": "readIncrementalJsonlLines()",
@@ -49713,7 +49745,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L113",
       "id": "sources_readincrementaljsonllines",
-      "community": 171
+      "community": 172
     },
     {
       "label": "runDocker()",
@@ -49721,7 +49753,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L148",
       "id": "sources_rundocker",
-      "community": 171
+      "community": 172
     },
     {
       "label": "resolveDockerLogsRef()",
@@ -49729,7 +49761,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L168",
       "id": "sources_resolvedockerlogsref",
-      "community": 171
+      "community": 172
     },
     {
       "label": "readDockerLogs()",
@@ -49737,7 +49769,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L215",
       "id": "sources_readdockerlogs",
-      "community": 171
+      "community": 172
     },
     {
       "label": "readJsonlFiles()",
@@ -49745,7 +49777,7 @@
       "source_file": "scripts/log-issue-monitor/sources.ts",
       "source_location": "L244",
       "id": "sources_readjsonlfiles",
-      "community": 171
+      "community": 172
     },
     {
       "label": "types.ts",
@@ -49753,7 +49785,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1379
+      "community": 1380
     },
     {
       "label": "issue-body.ts",
@@ -49793,7 +49825,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "normalizeMessage()",
@@ -49801,7 +49833,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 723
+      "community": 724
     },
     {
       "label": "createFingerprint()",
@@ -49809,7 +49841,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 723
+      "community": 724
     },
     {
       "label": "sanitizer.ts",
@@ -49817,7 +49849,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 724
+      "community": 725
     },
     {
       "label": "limitUtf8Bytes()",
@@ -49825,7 +49857,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 724
+      "community": 725
     },
     {
       "label": "sanitizeExcerpt()",
@@ -49833,7 +49865,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 724
+      "community": 725
     },
     {
       "label": "parsers.ts",
@@ -49905,7 +49937,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 984
+      "community": 985
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -49913,7 +49945,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 984
+      "community": 985
     },
     {
       "label": "state-store.ts",
@@ -50193,7 +50225,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1380
+      "community": 1381
     },
     {
       "label": "issue-body.spec.ts",
@@ -50201,7 +50233,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1381
+      "community": 1382
     },
     {
       "label": "github-client.spec.ts",
@@ -50209,7 +50241,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1382
+      "community": 1383
     },
     {
       "label": "config.spec.ts",
@@ -50217,7 +50249,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1383
+      "community": 1384
     },
     {
       "label": "detectors.spec.ts",
@@ -50225,7 +50257,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1384
+      "community": 1385
     },
     {
       "label": "sources.spec.ts",
@@ -50233,7 +50265,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1385
+      "community": 1386
     },
     {
       "label": "parsers.spec.ts",
@@ -50241,7 +50273,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1386
+      "community": 1387
     },
     {
       "label": "monitor.spec.ts",
@@ -50249,7 +50281,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 985
+      "community": 986
     },
     {
       "label": "config()",
@@ -50257,7 +50289,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 985
+      "community": 986
     },
     {
       "label": "fingerprint.spec.ts",
@@ -50265,7 +50297,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1387
+      "community": 1388
     },
     {
       "label": "state-store.spec.ts",
@@ -50273,7 +50305,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1388
+      "community": 1389
     },
     {
       "label": "sanitizer.spec.ts",
@@ -50281,7 +50313,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1389
+      "community": 1390
     },
     {
       "label": "entrypoint.spec.ts",
@@ -50289,7 +50321,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1390
+      "community": 1391
     },
     {
       "label": "index.ts",
@@ -50329,7 +50361,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1391
+      "community": 1392
     },
     {
       "label": "review-candidates-panel-poll-fetch.js",
@@ -50337,7 +50369,7 @@
       "source_file": "static/js/review-candidates-panel-poll-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_fetch_js",
-      "community": 1392
+      "community": 1393
     },
     {
       "label": "memento-admin-fetch.js",
@@ -50401,7 +50433,7 @@
       "source_file": "static/js/embedding-map-state.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_state_js",
-      "community": 1393
+      "community": 1394
     },
     {
       "label": "memory-evolution-demo-shell-render.js",
@@ -50409,7 +50441,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1394
+      "community": 1395
     },
     {
       "label": "dashboard-auth.js",
@@ -50417,7 +50449,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_js",
-      "community": 1395
+      "community": 1396
     },
     {
       "label": "anchor-map.js",
@@ -50457,7 +50489,7 @@
       "source_file": "static/js/dashboard-auth-error.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_error_js",
-      "community": 1396
+      "community": 1397
     },
     {
       "label": "embedding-map-fetch.js",
@@ -50465,7 +50497,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_js",
-      "community": 725
+      "community": 726
     },
     {
       "label": "buildEmbeddingMapQuery()",
@@ -50473,7 +50505,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L12",
       "id": "embedding_map_fetch_buildembeddingmapquery",
-      "community": 725
+      "community": 726
     },
     {
       "label": "handleEmbeddingMapResponse()",
@@ -50481,7 +50513,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_handleembeddingmapresponse",
-      "community": 725
+      "community": 726
     },
     {
       "label": "review-candidates-panel-poll.js",
@@ -50489,7 +50521,7 @@
       "source_file": "static/js/review-candidates-panel-poll.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_js",
-      "community": 1397
+      "community": 1398
     },
     {
       "label": "review-candidates-panel-poll-notify-os.js",
@@ -50497,7 +50529,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_notify_os_js",
-      "community": 986
+      "community": 987
     },
     {
       "label": "tryOsNotifyReviewQueueGrowth()",
@@ -50505,7 +50537,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_notify_os_tryosnotifyreviewqueuegrowth",
-      "community": 986
+      "community": 987
     },
     {
       "label": "graph-detail.js",
@@ -50577,7 +50609,7 @@
       "source_file": "static/js/dashboard-auth-render-message.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_message_js",
-      "community": 1398
+      "community": 1399
     },
     {
       "label": "review-candidates-panel.js",
@@ -50585,7 +50617,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 987
+      "community": 988
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -50593,7 +50625,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 987
+      "community": 988
     },
     {
       "label": "review-candidates-panel-health-fetch.js",
@@ -50601,7 +50633,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_fetch_js",
-      "community": 726
+      "community": 727
     },
     {
       "label": "loadBatchRunHistory()",
@@ -50609,7 +50641,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L15",
       "id": "review_candidates_panel_health_fetch_loadbatchrunhistory",
-      "community": 726
+      "community": 727
     },
     {
       "label": "loadHealthMetrics()",
@@ -50617,7 +50649,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L61",
       "id": "review_candidates_panel_health_fetch_loadhealthmetrics",
-      "community": 726
+      "community": 727
     },
     {
       "label": "graph.js",
@@ -50625,7 +50657,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L1",
       "id": "static_js_graph_js",
-      "community": 1399
+      "community": 1400
     },
     {
       "label": "dashboard-tabs-init.js",
@@ -50897,7 +50929,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_category_js",
-      "community": 988
+      "community": 989
     },
     {
       "label": "eventCategory()",
@@ -50905,7 +50937,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_render_timeline_category_eventcategory",
-      "community": 988
+      "community": 989
     },
     {
       "label": "graph-shared.js",
@@ -50913,7 +50945,7 @@
       "source_file": "static/js/graph-shared.js",
       "source_location": "L1",
       "id": "static_js_graph_shared_js",
-      "community": 1400
+      "community": 1401
     },
     {
       "label": "dashboard-auth-render-form.js",
@@ -50921,7 +50953,7 @@
       "source_file": "static/js/dashboard-auth-render-form.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_form_js",
-      "community": 1401
+      "community": 1402
     },
     {
       "label": "memory-evolution-demo-shell-shared.js",
@@ -51249,7 +51281,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1402
+      "community": 1403
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -51257,7 +51289,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_js",
-      "community": 1403
+      "community": 1404
     },
     {
       "label": "embedding-map-tooltip.js",
@@ -51369,7 +51401,7 @@
       "source_file": "static/js/anchor-map-shared.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_shared_js",
-      "community": 1404
+      "community": 1405
     },
     {
       "label": "dashboard-auth-render-status.js",
@@ -51377,7 +51409,7 @@
       "source_file": "static/js/dashboard-auth-render-status.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_status_js",
-      "community": 1405
+      "community": 1406
     },
     {
       "label": "review-candidates-panel-poll-toast.js",
@@ -51385,7 +51417,7 @@
       "source_file": "static/js/review-candidates-panel-poll-toast.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_toast_js",
-      "community": 1406
+      "community": 1407
     },
     {
       "label": "embedding-map-chart-scatter.js",
@@ -51529,7 +51561,7 @@
       "source_file": "static/js/agent-sessions-panel-render-injections.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_injections_js",
-      "community": 1407
+      "community": 1408
     },
     {
       "label": "anchor-map-render.js",
@@ -51713,7 +51745,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 989
+      "community": 990
     },
     {
       "label": "init()",
@@ -51721,7 +51753,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 989
+      "community": 990
     },
     {
       "label": "review-candidates-panel-bulk.js",
@@ -51785,7 +51817,7 @@
       "source_file": "static/js/review-candidates-panel-poll-snapshot.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_snapshot_js",
-      "community": 1408
+      "community": 1409
     },
     {
       "label": "review-candidates-panel-health.js",
@@ -51793,7 +51825,7 @@
       "source_file": "static/js/review-candidates-panel-health.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_js",
-      "community": 1409
+      "community": 1410
     },
     {
       "label": "review-candidates-panel-poll-prompt.js",
@@ -51801,7 +51833,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_prompt_js",
-      "community": 727
+      "community": 728
     },
     {
       "label": "isReviewNotifyPromptDismissed()",
@@ -51809,7 +51841,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_prompt_isreviewnotifypromptdismissed",
-      "community": 727
+      "community": 728
     },
     {
       "label": "dismissReviewNotifyPrompt()",
@@ -51817,7 +51849,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L18",
       "id": "review_candidates_panel_poll_prompt_dismissreviewnotifyprompt",
-      "community": 727
+      "community": 728
     },
     {
       "label": "dashboard-auth-dom.js",
@@ -51825,7 +51857,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_dom_js",
-      "community": 728
+      "community": 729
     },
     {
       "label": "selectFirst()",
@@ -51833,7 +51865,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L12",
       "id": "dashboard_auth_dom_selectfirst",
-      "community": 728
+      "community": 729
     },
     {
       "label": "getElementByIdFallback()",
@@ -51841,7 +51873,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L20",
       "id": "dashboard_auth_dom_getelementbyidfallback",
-      "community": 728
+      "community": 729
     },
     {
       "label": "graph-search.js",
@@ -51913,7 +51945,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 729
+      "community": 730
     },
     {
       "label": "refreshChartIfActive()",
@@ -51921,7 +51953,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L13",
       "id": "embedding_map_refreshchartifactive",
-      "community": 729
+      "community": 730
     },
     {
       "label": "initEmbeddingMap()",
@@ -51929,7 +51961,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_initembeddingmap",
-      "community": 729
+      "community": 730
     },
     {
       "label": "anchor-map-search.js",
@@ -52025,7 +52057,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_js",
-      "community": 990
+      "community": 991
     },
     {
       "label": "eventCategory()",
@@ -52033,7 +52065,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L13",
       "id": "agent_sessions_panel_render_timeline_eventcategory",
-      "community": 990
+      "community": 991
     },
     {
       "label": "agent-sessions-panel-render-provenance.js",
@@ -52041,7 +52073,7 @@
       "source_file": "static/js/agent-sessions-panel-render-provenance.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_provenance_js",
-      "community": 1410
+      "community": 1411
     },
     {
       "label": "graph-render.js",
@@ -52137,7 +52169,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_sign_in_js",
-      "community": 991
+      "community": 992
     },
     {
       "label": "handleSignInResponse()",
@@ -52145,7 +52177,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L10",
       "id": "dashboard_auth_sign_in_handlesigninresponse",
-      "community": 991
+      "community": 992
     },
     {
       "label": "embedding-map-chart-colors.js",
@@ -52153,7 +52185,7 @@
       "source_file": "static/js/embedding-map-chart-colors.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_colors_js",
-      "community": 1411
+      "community": 1412
     },
     {
       "label": "review-candidates-panel-poll-cycle.js",
@@ -52161,7 +52193,7 @@
       "source_file": "static/js/review-candidates-panel-poll-cycle.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_cycle_js",
-      "community": 1412
+      "community": 1413
     },
     {
       "label": "dashboard-auth-session-check.js",
@@ -52169,7 +52201,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_session_check_js",
-      "community": 992
+      "community": 993
     },
     {
       "label": "handleSessionCheckResponse()",
@@ -52177,7 +52209,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L10",
       "id": "dashboard_auth_session_check_handlesessioncheckresponse",
-      "community": 992
+      "community": 993
     },
     {
       "label": "agent-sessions-panel-render-sessions.js",
@@ -52185,7 +52217,7 @@
       "source_file": "static/js/agent-sessions-panel-render-sessions.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_sessions_js",
-      "community": 1413
+      "community": 1414
     },
     {
       "label": "review-candidates-panel-render-list.js",
@@ -52433,7 +52465,7 @@
       "source_file": "static/js/dashboard-auth-requests.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_requests_js",
-      "community": 1414
+      "community": 1415
     },
     {
       "label": "dashboard-tabs.js",
@@ -52537,7 +52569,7 @@
       "source_file": "static/js/review-candidates-panel-render.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_js",
-      "community": 1415
+      "community": 1416
     },
     {
       "label": "dashboard-tabs-panels.js",
@@ -52577,7 +52609,7 @@
       "source_file": "static/js/dashboard-auth-ui.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_ui_js",
-      "community": 1416
+      "community": 1417
     },
     {
       "label": "dashboard-auth-render-tabs.js",
@@ -52585,7 +52617,7 @@
       "source_file": "static/js/dashboard-auth-render-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_tabs_js",
-      "community": 1417
+      "community": 1418
     },
     {
       "label": "review-candidates-panel-shared.js",
@@ -52681,7 +52713,7 @@
       "source_file": "static/js/review-candidates-panel-poll-badge.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_badge_js",
-      "community": 1418
+      "community": 1419
     },
     {
       "label": "graph-embed-init.js",
@@ -52689,7 +52721,7 @@
       "source_file": "static/js/graph-embed-init.js",
       "source_location": "L1",
       "id": "static_js_graph_embed_init_js",
-      "community": 1419
+      "community": 1420
     },
     {
       "label": "dashboard-auth-render.js",
@@ -52697,7 +52729,7 @@
       "source_file": "static/js/dashboard-auth-render.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_js",
-      "community": 1420
+      "community": 1421
     },
     {
       "label": "graph-fetch.js",
@@ -52705,7 +52737,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L1",
       "id": "static_js_graph_fetch_js",
-      "community": 730
+      "community": 731
     },
     {
       "label": "resetGraphState()",
@@ -52713,7 +52745,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L48",
       "id": "graph_fetch_resetgraphstate",
-      "community": 730
+      "community": 731
     },
     {
       "label": "handleGraphPayload()",
@@ -52721,7 +52753,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L62",
       "id": "graph_fetch_handlegraphpayload",
-      "community": 730
+      "community": 731
     },
     {
       "label": "embedding-map-panel.js",
@@ -105429,7 +105461,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L34",
+      "source_location": "L35",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_checkdbconnection",
@@ -105441,7 +105473,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L46",
+      "source_location": "L47",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_runembeddingandneighbors",
@@ -105453,7 +105485,19 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L88",
+      "source_location": "L93",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
+      "_tgt": "remember_tool_augmentation_persistrelationcandidates",
+      "source": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
+      "target": "remember_tool_augmentation_persistrelationcandidates",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
+      "source_location": "L135",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_runrelationextraction",
@@ -105465,7 +105509,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L136",
+      "source_location": "L185",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_updatetriplestatus",
@@ -105477,7 +105521,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L156",
+      "source_location": "L205",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_getretrycount",
@@ -105489,7 +105533,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L172",
+      "source_location": "L221",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_runtripleextractionjob",
@@ -105501,7 +105545,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L309",
+      "source_location": "L358",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_runtripleextraction",
@@ -105513,7 +105557,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L371",
+      "source_location": "L420",
       "weight": 1.0,
       "_src": "packages_memento_core_src_domains_memory_tools_remember_tool_augmentation_ts",
       "_tgt": "remember_tool_augmentation_launchbackgroundaugmentation",
@@ -105525,7 +105569,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L68",
+      "source_location": "L69",
       "weight": 1.0,
       "_src": "remember_tool_augmentation_runembeddingandneighbors",
       "_tgt": "remember_tool_augmentation_checkdbconnection",
@@ -105537,7 +105581,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L96",
+      "source_location": "L143",
       "weight": 1.0,
       "_src": "remember_tool_augmentation_runrelationextraction",
       "_tgt": "remember_tool_augmentation_checkdbconnection",
@@ -105549,7 +105593,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L181",
+      "source_location": "L230",
       "weight": 1.0,
       "_src": "remember_tool_augmentation_runtripleextractionjob",
       "_tgt": "remember_tool_augmentation_checkdbconnection",
@@ -105561,7 +105605,19 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L185",
+      "source_location": "L174",
+      "weight": 1.0,
+      "_src": "remember_tool_augmentation_runrelationextraction",
+      "_tgt": "remember_tool_augmentation_persistrelationcandidates",
+      "source": "remember_tool_augmentation_persistrelationcandidates",
+      "target": "remember_tool_augmentation_runrelationextraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
+      "source_location": "L234",
       "weight": 1.0,
       "_src": "remember_tool_augmentation_runtripleextractionjob",
       "_tgt": "remember_tool_augmentation_updatetriplestatus",
@@ -105573,7 +105629,7 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts",
-      "source_location": "L268",
+      "source_location": "L317",
       "weight": 1.0,
       "_src": "remember_tool_augmentation_runtripleextractionjob",
       "_tgt": "remember_tool_augmentation_getretrycount",
@@ -106359,6 +106415,30 @@
       "_tgt": "remember_tool_spec_createvalidreflectionnote",
       "source": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
       "target": "remember_tool_spec_createvalidreflectionnote",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
+      "source_location": "L12",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
+      "_tgt": "remember_tool_relation_persist_spec_initializeschema",
+      "source": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
+      "target": "remember_tool_relation_persist_spec_initializeschema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
+      "source_location": "L44",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
+      "_tgt": "remember_tool_relation_persist_spec_createhost",
+      "source": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
+      "target": "remember_tool_relation_persist_spec_createhost",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts
+++ b/packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { DatabaseUtils } from '../../../../shared/utils/database.js';
+import { createRelationGraph } from '../../../../infrastructure/relation-graph-factory.js';
+import type { ToolContext } from '../../../../tools/types.js';
+import type { RememberToolHost } from '../remember-tool-host.js';
+import { runRelationExtraction } from '../remember-tool-augmentation.js';
+
+/**
+ * Issue #711: 관계 추출 결과(runRelationExtraction)가 memory_relation에 영속화되는지 검증.
+ */
+function initializeSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE memory_item (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      content TEXT NOT NULL,
+      importance REAL DEFAULT 0.5,
+      privacy_scope TEXT DEFAULT 'private',
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_accessed TIMESTAMP,
+      pinned BOOLEAN DEFAULT FALSE,
+      tags TEXT,
+      source TEXT,
+      is_consolidated BOOLEAN DEFAULT FALSE
+    );
+
+    CREATE TABLE memory_relation (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      relation_type TEXT NOT NULL,
+      confidence REAL NOT NULL DEFAULT 0.7 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      metadata TEXT,
+      FOREIGN KEY (source_id) REFERENCES memory_item(id) ON DELETE CASCADE,
+      FOREIGN KEY (target_id) REFERENCES memory_item(id) ON DELETE CASCADE,
+      UNIQUE(source_id, target_id, relation_type)
+    );
+  `);
+}
+
+function createHost(): RememberToolHost & { logInfo: ReturnType<typeof vi.fn>; logWarning: ReturnType<typeof vi.fn> } {
+  return {
+    logInfo: vi.fn(),
+    logWarning: vi.fn(),
+    logError: vi.fn(),
+    createSuccessResult: vi.fn((data: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(data) }] }))
+  };
+}
+
+describe('runRelationExtraction (Issue #711)', () => {
+  let db: Database.Database;
+  let host: ReturnType<typeof createHost>;
+  let context: ToolContext;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    initializeSchema(db);
+
+    DatabaseUtils.run(db, `
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope)
+      VALUES ('mem-existing-1', 'semantic', '문제가 발생한 원인 기록', 0.7, 'private')
+    `);
+    DatabaseUtils.run(db, `
+      INSERT INTO memory_item (id, type, content, importance, privacy_scope)
+      VALUES ('mem-new', 'episodic', '서버 과부하 때문에 장애가 발생했다', 0.6, 'private')
+    `);
+
+    host = createHost();
+    context = {
+      db,
+      services: {
+        relationGraph: createRelationGraph(db)
+      }
+    };
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+  });
+
+  it('하이브리드 추출 후보를 memory_relation에 저장한다 (method/evidence/extracted_at 포함)', async () => {
+    await runRelationExtraction(
+      {
+        dbRef: db,
+        savedMemoryId: 'mem-new',
+        savedMemoryType: 'episodic',
+        content: '서버 과부하 때문에 장애가 발생했다',
+        importance: 0.6,
+        enable_triple_extraction: false
+      },
+      context,
+      host
+    );
+
+    const rows = DatabaseUtils.all(db, `
+      SELECT source_id, target_id, relation_type, confidence, metadata
+      FROM memory_relation
+      WHERE source_id = 'mem-new'
+    `) as Array<{ source_id: string; target_id: string; relation_type: string; confidence: number; metadata: string | null }>;
+
+    expect(rows.length).toBeGreaterThan(0);
+    const row = rows[0]!;
+    expect(row.target_id).toBe('mem-existing-1');
+    expect(row.confidence).toBeGreaterThanOrEqual(0.5);
+
+    const metadata = JSON.parse(row.metadata ?? '{}');
+    expect(metadata.method).toBe('rule');
+    expect(typeof metadata.evidence).toBe('string');
+    expect(metadata.evidence.length).toBeGreaterThan(0);
+    expect(typeof metadata.extracted_at).toBe('string');
+  });
+
+  it('재실행해도 관계 행이 늘어나지 않는다 (idempotent)', async () => {
+    const params = {
+      dbRef: db,
+      savedMemoryId: 'mem-new',
+      savedMemoryType: 'episodic',
+      content: '서버 과부하 때문에 장애가 발생했다',
+      importance: 0.6,
+      enable_triple_extraction: false
+    };
+
+    await runRelationExtraction(params, context, host);
+    const firstCount = (DatabaseUtils.all(db, `SELECT id FROM memory_relation WHERE source_id = 'mem-new'`) as unknown[]).length;
+
+    await runRelationExtraction(params, context, host);
+    const secondCount = (DatabaseUtils.all(db, `SELECT id FROM memory_relation WHERE source_id = 'mem-new'`) as unknown[]).length;
+
+    expect(firstCount).toBeGreaterThan(0);
+    expect(secondCount).toBe(firstCount);
+  });
+
+  it('relationGraph가 없으면 저장을 건너뛰고 warning만 남긴다 (remember 실패로 이어지지 않음)', async () => {
+    const contextWithoutGraph: ToolContext = { db, services: {} };
+
+    await expect(runRelationExtraction(
+      {
+        dbRef: db,
+        savedMemoryId: 'mem-new',
+        savedMemoryType: 'episodic',
+        content: '서버 과부하 때문에 장애가 발생했다',
+        importance: 0.6,
+        enable_triple_extraction: false
+      },
+      contextWithoutGraph,
+      host
+    )).resolves.toBeUndefined();
+
+    expect(host.logWarning).toHaveBeenCalled();
+    const rows = DatabaseUtils.all(db, `SELECT id FROM memory_relation WHERE source_id = 'mem-new'`) as unknown[];
+    expect(rows.length).toBe(0);
+  });
+
+  it('배치 부분 실패 시 warning만 남기고 예외를 던지지 않는다', async () => {
+    const relationGraph = context.services.relationGraph!;
+    vi.spyOn(relationGraph, 'addRelationsBatch').mockResolvedValue({
+      insertedIds: [],
+      failed: [{ source_id: 'mem-new', target_id: 'mem-existing-1', relation_type: 'CAUSES', error: 'boom' }],
+      total: 1,
+      success: 0,
+      failedCount: 1
+    });
+
+    await expect(runRelationExtraction(
+      {
+        dbRef: db,
+        savedMemoryId: 'mem-new',
+        savedMemoryType: 'episodic',
+        content: '서버 과부하 때문에 장애가 발생했다',
+        importance: 0.6,
+        enable_triple_extraction: false
+      },
+      context,
+      host
+    )).resolves.toBeUndefined();
+
+    expect(host.logWarning).toHaveBeenCalled();
+  });
+
+  it('relationGraph.addRelationsBatch가 예외를 던져도 remember 흐름에 영향을 주지 않는다', async () => {
+    const relationGraph = context.services.relationGraph!;
+    vi.spyOn(relationGraph, 'addRelationsBatch').mockRejectedValue(new Error('db down'));
+
+    await expect(runRelationExtraction(
+      {
+        dbRef: db,
+        savedMemoryId: 'mem-new',
+        savedMemoryType: 'episodic',
+        content: '서버 과부하 때문에 장애가 발생했다',
+        importance: 0.6,
+        enable_triple_extraction: false
+      },
+      context,
+      host
+    )).resolves.toBeUndefined();
+
+    expect(host.logWarning).toHaveBeenCalled();
+  });
+});

--- a/packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts
+++ b/packages/memento-core/src/domains/memory/tools/remember-tool-augmentation.ts
@@ -11,6 +11,7 @@ import { DatabaseUtils } from '../../../shared/utils/database.js';
 import { getVectorSearchEngine } from '../../search/algorithms/vector-search-engine.js';
 import { MemoryNeighborService } from '../services/memory-neighbor-service.js';
 import { RelationExtractor } from '../../relation/services/relation-extractor.js';
+import type { RelationCandidate } from '../../../shared/types/relation.js';
 import { UnifiedEmbeddingService } from '../../embedding/services/unified-embedding-service.js';
 import { TripleExtractionService } from '../../relation/services/triple-extraction/triple-extraction-service.js';
 import type { TripleExtractionResult } from '../../../shared/types/triple-extraction.js';
@@ -85,7 +86,53 @@ async function runEmbeddingAndNeighbors(
   }
 }
 
-async function runRelationExtraction(
+/**
+ * 관계 추출 후보를 RelationGraph에 배치로 영속화한다 (#711).
+ * 실패는 warning으로만 남기고 remember 흐름에 영향을 주지 않는다 (isolate).
+ */
+async function persistRelationCandidates(
+  candidates: RelationCandidate[],
+  context: ToolContext,
+  host: RememberToolHost,
+  savedMemoryId: string
+): Promise<void> {
+  const relationGraph = context.services.relationGraph;
+  if (!relationGraph) {
+    host.logWarning('관계 그래프를 사용할 수 없어 추출된 관계를 저장하지 않습니다', { memory_id: savedMemoryId });
+    return;
+  }
+
+  try {
+    const extractedAt = new Date().toISOString();
+    const batchResult = await relationGraph.addRelationsBatch(
+      candidates.map(candidate => ({
+        source_id: candidate.source_id,
+        target_id: candidate.target_id,
+        relation_type: candidate.relation_type,
+        confidence: candidate.confidence,
+        metadata: {
+          method: candidate.method,
+          evidence: candidate.evidence,
+          extracted_at: extractedAt
+        }
+      }))
+    );
+
+    if (batchResult.failedCount > 0) {
+      host.logWarning('추출된 관계 중 일부 저장 실패', {
+        memory_id: savedMemoryId,
+        failed_count: batchResult.failedCount,
+        success_count: batchResult.success
+      });
+    }
+  } catch (error) {
+    host.logWarning(`추출된 관계 저장 실패 (${savedMemoryId})`, {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
+export async function runRelationExtraction(
   params: AugmentationParams,
   context: ToolContext,
   host: RememberToolHost
@@ -123,6 +170,8 @@ async function runRelationExtraction(
           method: c.method
         }))
       });
+
+      await persistRelationCandidates(candidates, context, host, savedMemoryId);
     } else {
       host.logInfo('관계 추출 완료 (관계 없음)', { memory_id: savedMemoryId });
     }

--- a/packages/memento-core/src/shared/types/relation-graph.ts
+++ b/packages/memento-core/src/shared/types/relation-graph.ts
@@ -266,6 +266,33 @@ export interface IRelationGraph {
     targetId: string,
     relationType: RelationType
   ): Promise<boolean>;
+
+  /**
+   * 배치 관계 추가 (개별 실패가 전체 배치를 중단시키지 않음)
+   *
+   * @param relations 추가할 관계 목록
+   * @returns 성공/실패 상세 결과
+   */
+  addRelationsBatch(
+    relations: Array<{
+      source_id: string;
+      target_id: string;
+      relation_type: RelationType;
+      confidence?: number;
+      metadata?: RelationMetadata;
+    }>
+  ): Promise<{
+    insertedIds: number[];
+    failed: Array<{
+      source_id: string;
+      target_id: string;
+      relation_type: RelationType;
+      error: string;
+    }>;
+    total: number;
+    success: number;
+    failedCount: number;
+  }>;
 }
 
 /**


### PR DESCRIPTION
## Summary

`runRelationExtraction` (`remember-tool-augmentation.ts`) called `RelationExtractor.extractRelations` and only **logged** the hybrid candidates — nothing was written to `memory_relation`. This fixes that by persisting via the existing batch API.

- Persist extracted candidates with `context.services.relationGraph.addRelationsBatch` (not per-candidate `addRelation` loops), so the batch's existing duplicate/`updateOnConflict`/confidence handling in `RelationGraphMutations` is reused as-is.
- Preserve metadata: `method`, `evidence`, `extracted_at`.
- `IRelationGraph` port didn't declare `addRelationsBatch` even though `RelationGraph` already implemented it — added the method signature to the interface so `ToolContext.services.relationGraph` callers can type-check against it.
- Failures (missing `relationGraph`, batch partial failure, or a thrown error from `addRelationsBatch`) are isolated to a `logWarning` call; `runRelationExtraction`'s own try/catch plus a dedicated persistence try/catch ensure `remember` success is never affected (fire-and-forget).

## Test plan

- [x] New `remember-tool-relation-persist.spec.ts` (5 tests): candidate → `memory_relation` row with `method`/`evidence`/`extracted_at` metadata; re-run is idempotent (no duplicate rows, same `UNIQUE(source_id, target_id, relation_type)` + `updateOnConflict` path used by the triple-extraction flow); missing `relationGraph` warns without throwing; batch partial failure warns without throwing; `addRelationsBatch` rejection warns without throwing.
- [x] `npx vitest run packages/memento-core` — 324 files / 4035 passed, 1 pre-existing skip.
- [x] `npm run type-check` — clean across all workspaces.
- [x] `npm run lint` — 0 errors (pre-existing unrelated warnings only).
- [x] graphify rebuilt from worktree root (`graphify-out/`).

Closes #711
Parent: #707

Made with [Cursor](https://cursor.com)