### PR TITLE
fix(anchor-map): memory_relation 기반 슬롯→메모리 엣지·관계 링크 생성

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - .  (2026-07-31)
+# Graph Report - .  (2026-08-01)
 
 ## Corpus Check
-- 1429 files · ~1,571,680 words
+- 1429 files · ~1,572,345 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6591 nodes · 7519 edges · 1421 communities detected
+- 6594 nodes · 7522 edges · 1421 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2592,7 +2592,7 @@ Nodes (4): jsonSafeDetails(), recordManualBatchRunFailure(), recordManualBatchRu
 
 ### Community 283 - "Community 283"
 Cohesion: 0.48
-Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkLinks(), buildNetworkNodesAndLinks()
+Nodes (5): broadcastAnchorMapUpdate(), broadcastToSubscribers(), buildAnchorMapData(), buildNetworkNodesAndLinks(), buildRelationLinks()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.52
@@ -3091,68 +3091,68 @@ Cohesion: 0.6
 Nodes (3): getLockFilePath(), isProcessAlive(), tryAcquireLock()
 
 ### Community 408 - "Community 408"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (1): StdioServer
 
-### Community 409 - "Community 409"
-Cohesion: 0.4
-Nodes (1): SseServer
-
 ### Community 410 - "Community 410"
 Cohesion: 0.4
-Nodes (0): 
+Nodes (1): SseServer
 
 ### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (0): 
 
 ### Community 412 - "Community 412"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 413 - "Community 413"
 Cohesion: 0.6
 Nodes (3): parseLimit(), parseQuery(), readSingleQueryValue()
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (2): asNonEmptyString(), parseRequest()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.6
 Nodes (3): createClaudeCodeHttpTransport(), readStream(), runClaudeCodeHookCommand()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.5
 Nodes (2): seedTwoProjectMemories(), stopBatchSchedulerSingleton()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.6
 Nodes (3): createCodexHttpTransport(), readStream(), runCodexHookCommand()
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.6
 Nodes (3): parseOptions(), readSettings(), runClaudeCodeConnect()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (2): debugErr(), writeErr()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (1): ReflexionProceduralMemoryService
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.4
 Nodes (0): 
-
-### Community 422 - "Community 422"
-Cohesion: 0.6
-Nodes (4): autoReflect(), checkQueueBacklog(), processFailureEvent(), queueFailureEvent()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.6
+Nodes (4): autoReflect(), checkQueueBacklog(), processFailureEvent(), queueFailureEvent()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.4
@@ -3175,28 +3175,28 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 429 - "Community 429"
-Cohesion: 0.5
-Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
-
-### Community 430 - "Community 430"
 Cohesion: 0.4
 Nodes (0): 
+
+### Community 430 - "Community 430"
+Cohesion: 0.5
+Nodes (2): countMonitoringAlertBuckets(), runMonitoring()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.4
 Nodes (0): 
 
 ### Community 432 - "Community 432"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 433 - "Community 433"
 Cohesion: 0.6
 Nodes (3): formatMementoResourceUri(), isMementoResourceKind(), parseMementoResourceUri()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (2): getStopWords(), isStopWord()
-
-### Community 434 - "Community 434"
-Cohesion: 0.4
-Nodes (0): 
 
 ### Community 435 - "Community 435"
 Cohesion: 0.4
@@ -3204,15 +3204,15 @@ Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.4
-Nodes (1): LLMClientInitializer
+Nodes (0): 
 
 ### Community 437 - "Community 437"
-Cohesion: 0.6
-Nodes (3): getOllamaErrorMessage(), handleOllamaResponse(), testOllamaConnection()
+Cohesion: 0.4
+Nodes (1): LLMClientInitializer
 
 ### Community 438 - "Community 438"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.6
+Nodes (3): getOllamaErrorMessage(), handleOllamaResponse(), testOllamaConnection()
 
 ### Community 439 - "Community 439"
 Cohesion: 0.4
@@ -3223,200 +3223,200 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 441 - "Community 441"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 442 - "Community 442"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 443 - "Community 443"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 444 - "Community 444"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.4
 Nodes (1): EvolutionDemoNotFoundError
 
-### Community 446 - "Community 446"
+### Community 447 - "Community 447"
 Cohesion: 0.6
 Nodes (1): AdaptiveWeightCalculator
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.5
 Nodes (2): checkVecAvailability(), isVecTableRegistered()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.7
 Nodes (4): buildItemScopeClause(), buildItemWhereSql(), buildScopeParams(), executeHybridQuery()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 456 - "Community 456"
+### Community 457 - "Community 457"
 Cohesion: 0.6
 Nodes (3): getExistingReflectionNotes(), parseReflectionNotes(), prepareReflectionNotes()
 
-### Community 457 - "Community 457"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 458 - "Community 458"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 459 - "Community 459"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 460 - "Community 460"
 Cohesion: 0.4
-Nodes (1): SemanticMemoryCrud
+Nodes (1): IntrospectionScanCache
 
 ### Community 461 - "Community 461"
 Cohesion: 0.4
-Nodes (1): ConsolidationOutboxWorker
+Nodes (1): SemanticMemoryCrud
 
 ### Community 462 - "Community 462"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): ConsolidationOutboxWorker
 
 ### Community 463 - "Community 463"
+Cohesion: 0.4
+Nodes (1): FailingRepo
+
+### Community 464 - "Community 464"
 Cohesion: 0.5
 Nodes (2): AddRelationTool, memoryItemHasOwnerIdColumn()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.4
 Nodes (1): RelationGraphQuery
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.5
 Nodes (1): RelationGraphCycleDetector
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.4
 Nodes (1): TokenBucketRateLimiter
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.5
 Nodes (2): calculateQualityMetrics(), calculateQualityMetricsWithAnalysis()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.5
 Nodes (2): processMigrationRow(), safeParseEmbedding()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.4
 Nodes (1): DatabaseMetricsReader
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.4
 Nodes (1): CpuUsageTracker
 
-### Community 473 - "Community 473"
+### Community 474 - "Community 474"
 Cohesion: 0.5
 Nodes (2): analyzeTrend(), getPerformanceSummary()
 
-### Community 474 - "Community 474"
+### Community 475 - "Community 475"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 475 - "Community 475"
+### Community 476 - "Community 476"
 Cohesion: 0.4
 Nodes (1): RelationMetricsCollector
 
-### Community 476 - "Community 476"
+### Community 477 - "Community 477"
 Cohesion: 0.5
 Nodes (2): calculateMRR(), SearchMetricsCollector
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.7
 Nodes (4): createSeededBenchmarkDatabase(), mulberry32(), normalizeMemoryType(), seedOneCorpusRow()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.7
 Nodes (4): createSessionGate(), ensureSessionGate(), resetSessionGate(), unlockSessionGate()
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.6
 Nodes (4): buildComparisonHintMarkup(), renderPointSegment(), syncSegmentSelection(), updateComparisonHint()
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.7
 Nodes (4): clearPollTimer(), getReviewQueueBoot(), schedulePollAfterMs(), schedulePollAfterMsUnlessSse()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.7
 Nodes (4): renderConsolidationPanel(), renderEpisodicSources(), renderSearchComparison(), renderSemanticResult()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.7
 Nodes (4): activateTab(), focusActiveTabButton(), getTabButtons(), setRovingTabindex()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 489 - "Community 489"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 490 - "Community 490"
 Cohesion: 0.5
@@ -3427,20 +3427,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 492 - "Community 492"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 493 - "Community 493"
 Cohesion: 0.83
 Nodes (3): createOwnerScopeMiddleware(), hasOwnerIdInBody(), isOwnerScopedToolRequest()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 494 - "Community 494"
-Cohesion: 0.67
-Nodes (2): handlePostPersonalRun(), parsePersonalRunBody()
 
 ### Community 495 - "Community 495"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): handlePostPersonalRun(), parsePersonalRunBody()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.5
@@ -3452,23 +3452,23 @@ Nodes (0):
 
 ### Community 498 - "Community 498"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 499 - "Community 499"
-Cohesion: 0.83
-Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
+Cohesion: 0.5
+Nodes (1): BraveSearchProvider
 
 ### Community 500 - "Community 500"
 Cohesion: 0.83
-Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
 
 ### Community 501 - "Community 501"
-Cohesion: 0.67
-Nodes (2): fixture(), fixtureUrl()
+Cohesion: 0.83
+Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
 
 ### Community 502 - "Community 502"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): fixture(), fixtureUrl()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
@@ -3479,24 +3479,24 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 505 - "Community 505"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 506 - "Community 506"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 506 - "Community 506"
+### Community 507 - "Community 507"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 507 - "Community 507"
+### Community 508 - "Community 508"
 Cohesion: 0.67
 Nodes (2): attemptRestart(), performHealthCheck()
 
-### Community 508 - "Community 508"
-Cohesion: 0.5
-Nodes (1): DatabaseOptimizeTool
-
 ### Community 509 - "Community 509"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): DatabaseOptimizeTool
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
@@ -3523,52 +3523,52 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
-Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
+Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
 
 ### Community 518 - "Community 518"
-Cohesion: 0.5
-Nodes (1): TripleExtractionBatchJob
+Cohesion: 0.67
+Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.5
-Nodes (1): QualityMeasurementBatchJob
+Nodes (1): TripleExtractionBatchJob
 
 ### Community 520 - "Community 520"
 Cohesion: 0.5
-Nodes (1): SleepConsolidationBatchJob
+Nodes (1): QualityMeasurementBatchJob
 
 ### Community 521 - "Community 521"
 Cohesion: 0.5
-Nodes (1): TelemetryCleanupBatchJob
+Nodes (1): SleepConsolidationBatchJob
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
+Cohesion: 0.5
+Nodes (1): TelemetryCleanupBatchJob
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
+Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
 
 ### Community 524 - "Community 524"
+Cohesion: 0.67
+Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
+
+### Community 525 - "Community 525"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 526 - "Community 526"
+### Community 527 - "Community 527"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
-
-### Community 527 - "Community 527"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 528 - "Community 528"
 Cohesion: 0.5
@@ -3576,187 +3576,187 @@ Nodes (0):
 
 ### Community 529 - "Community 529"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 530 - "Community 530"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 531 - "Community 531"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 532 - "Community 532"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 533 - "Community 533"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 534 - "Community 534"
+Cohesion: 0.5
+Nodes (1): RestoreAnchorsTool
+
+### Community 535 - "Community 535"
 Cohesion: 0.83
 Nodes (3): buildSnapshotsFromFixture(), getFixtureSnapshot(), key()
 
-### Community 535 - "Community 535"
+### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (1): SearchResultCombiner
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.67
 Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (2): computeProcessAttributeFit(), toSet()
 
-### Community 538 - "Community 538"
+### Community 539 - "Community 539"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.83
 Nodes (3): buildFTSQuery(), makeFTSSafe(), preprocessQuery()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.83
 Nodes (3): buildOuterWhereSql(), buildScopeParams(), executeKnnQuery()
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.5
 Nodes (1): ForgettingStatsTool
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.83
 Nodes (3): mapJob(), querySystemMetrics(), toolBucketFromEvents()
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.5
 Nodes (1): GetTelemetrySummaryTool
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.5
 Nodes (1): PersonalAgentLlmError
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.5
 Nodes (1): OpenAiChatLlmAdapter
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.5
 Nodes (1): OllamaChatLlmAdapter
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.5
 Nodes (1): GeminiChatLlmAdapter
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.83
 Nodes (3): buildSimilarityWarning(), handleMemoryItem(), persistMemoryItem()
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.5
 Nodes (1): RememberTool
 
-### Community 553 - "Community 553"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 554 - "Community 554"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (0): 
 
 ### Community 555 - "Community 555"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 556 - "Community 556"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 557 - "Community 557"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 558 - "Community 558"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 559 - "Community 559"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 560 - "Community 560"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 561 - "Community 561"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 562 - "Community 562"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 563 - "Community 563"
 Cohesion: 0.83
 Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
-### Community 563 - "Community 563"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 564 - "Community 564"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (0): 
 
 ### Community 565 - "Community 565"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 566 - "Community 566"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 567 - "Community 567"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): ExtractRelationsTool
 
 ### Community 568 - "Community 568"
+Cohesion: 0.5
+Nodes (1): RelationRetryManager
+
+### Community 569 - "Community 569"
 Cohesion: 0.67
 Nodes (2): filterRelationRows(), filterRelationRowsWithWarning()
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.5
 Nodes (1): RelationGraphTraversal
 
-### Community 570 - "Community 570"
+### Community 571 - "Community 571"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 571 - "Community 571"
+### Community 572 - "Community 572"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 572 - "Community 572"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 573 - "Community 573"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 574 - "Community 574"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 575 - "Community 575"
 Cohesion: 0.5
@@ -3771,20 +3771,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 578 - "Community 578"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 579 - "Community 579"
 Cohesion: 0.83
 Nodes (3): applyRollbackDelete(), applyRollbackRestore(), rollback()
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.5
 Nodes (1): GetMetaMemoryStatsTool
 
-### Community 580 - "Community 580"
-Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
-
 ### Community 581 - "Community 581"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 582 - "Community 582"
 Cohesion: 0.5
@@ -3792,39 +3792,39 @@ Nodes (0):
 
 ### Community 583 - "Community 583"
 Cohesion: 0.5
-Nodes (1): CategoryQualityAggregator
+Nodes (0): 
 
 ### Community 584 - "Community 584"
 Cohesion: 0.5
-Nodes (1): ConsolidationMetricsCollector
+Nodes (1): CategoryQualityAggregator
 
 ### Community 585 - "Community 585"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): ConsolidationMetricsCollector
 
 ### Community 586 - "Community 586"
 Cohesion: 0.5
-Nodes (1): StorageMetricsCollector
+Nodes (0): 
 
 ### Community 587 - "Community 587"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): StorageMetricsCollector
 
 ### Community 588 - "Community 588"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 589 - "Community 589"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 590 - "Community 590"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 590 - "Community 590"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
 ### Community 591 - "Community 591"
-Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 592 - "Community 592"
 Cohesion: 0.83
@@ -3832,19 +3832,19 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 593 - "Community 593"
 Cohesion: 0.83
-Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 594 - "Community 594"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
 
 ### Community 595 - "Community 595"
-Cohesion: 0.5
-Nodes (0): 
-
-### Community 596 - "Community 596"
 Cohesion: 0.83
 Nodes (3): main(), parseArgs(), printHelp()
+
+### Community 596 - "Community 596"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 597 - "Community 597"
 Cohesion: 0.83
@@ -3856,111 +3856,111 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 599 - "Community 599"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 600 - "Community 600"
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+
+### Community 601 - "Community 601"
 Cohesion: 1.0
 Nodes (3): checkDatabaseIntegrity(), log(), main()
 
-### Community 601 - "Community 601"
+### Community 602 - "Community 602"
 Cohesion: 0.83
 Nodes (3): findLatestRunDir(), main(), parseReportArgs()
 
-### Community 602 - "Community 602"
+### Community 603 - "Community 603"
 Cohesion: 1.0
 Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
-### Community 603 - "Community 603"
+### Community 604 - "Community 604"
 Cohesion: 0.67
 Nodes (2): inferLevel(), parseAppLogLine()
 
-### Community 604 - "Community 604"
+### Community 605 - "Community 605"
 Cohesion: 0.67
 Nodes (2): createMonitorRuntime(), runForever()
 
-### Community 605 - "Community 605"
+### Community 606 - "Community 606"
 Cohesion: 0.67
 Nodes (2): main(), runExample()
 
-### Community 606 - "Community 606"
+### Community 607 - "Community 607"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 607 - "Community 607"
-Cohesion: 0.83
-Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.83
-Nodes (3): postCandidateAction(), showActionToast(), showError()
+Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
 
 ### Community 609 - "Community 609"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): postCandidateAction(), showActionToast(), showError()
 
 ### Community 610 - "Community 610"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 611 - "Community 611"
-Cohesion: 0.67
-Nodes (2): ensureTooltip(), showTooltip()
-
-### Community 612 - "Community 612"
-Cohesion: 0.83
-Nodes (3): initAgentSessionsPanel(), on(), wirePanel()
-
-### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (3): getSelectedAgentId(), loadAgentIdOptions(), loadMapData()
-
-### Community 614 - "Community 614"
-Cohesion: 0.83
-Nodes (3): renderMemoryGroups(), renderMemoryStats(), renderSnapshot()
-
-### Community 615 - "Community 615"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 612 - "Community 612"
+Cohesion: 0.67
+Nodes (2): ensureTooltip(), showTooltip()
+
+### Community 613 - "Community 613"
+Cohesion: 0.83
+Nodes (3): initAgentSessionsPanel(), on(), wirePanel()
+
+### Community 614 - "Community 614"
+Cohesion: 1.0
+Nodes (3): getSelectedAgentId(), loadAgentIdOptions(), loadMapData()
+
+### Community 615 - "Community 615"
+Cohesion: 0.83
+Nodes (3): renderMemoryGroups(), renderMemoryStats(), renderSnapshot()
+
 ### Community 616 - "Community 616"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 617 - "Community 617"
 Cohesion: 0.83
 Nodes (3): appendLabeledLine(), closeSidePanel(), openSidePanel()
 
-### Community 617 - "Community 617"
+### Community 618 - "Community 618"
 Cohesion: 0.67
 Nodes (1): SlowTransport
 
-### Community 618 - "Community 618"
+### Community 619 - "Community 619"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 619 - "Community 619"
+### Community 620 - "Community 620"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 620 - "Community 620"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), sendOptions()
 
 ### Community 621 - "Community 621"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createMockResponse(), sendOptions()
 
 ### Community 622 - "Community 622"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 625 - "Community 625"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
@@ -3987,12 +3987,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 632 - "Community 632"
-Cohesion: 1.0
-Nodes (2): loadEnv(), resolveEnvPath()
-
-### Community 633 - "Community 633"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 633 - "Community 633"
+Cohesion: 1.0
+Nodes (2): loadEnv(), resolveEnvPath()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
@@ -4007,40 +4007,40 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 637 - "Community 637"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 638 - "Community 638"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 639 - "Community 639"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 640 - "Community 640"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (1): git()
+Nodes (1): NoopSearchProvider
 
 ### Community 642 - "Community 642"
-Cohesion: 1.0
-Nodes (2): invalid(), runClaudeCodeHook()
+Cohesion: 0.67
+Nodes (1): git()
 
 ### Community 643 - "Community 643"
 Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Nodes (2): invalid(), runClaudeCodeHook()
 
 ### Community 644 - "Community 644"
 Cohesion: 1.0
-Nodes (2): hybridSearch(), recall()
+Nodes (2): log(), shouldLog()
 
 ### Community 645 - "Community 645"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): hybridSearch(), recall()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
@@ -4051,32 +4051,32 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 648 - "Community 648"
-Cohesion: 1.0
-Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 649 - "Community 649"
 Cohesion: 1.0
-Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
+Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
 
 ### Community 650 - "Community 650"
+Cohesion: 1.0
+Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
+
+### Community 651 - "Community 651"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 651 - "Community 651"
+### Community 652 - "Community 652"
 Cohesion: 1.0
 Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
-### Community 652 - "Community 652"
+### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 653 - "Community 653"
-Cohesion: 1.0
-Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 654 - "Community 654"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isDuplicateColumnError(), migrateDatabase()
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
@@ -4087,12 +4087,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 657 - "Community 657"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
-
-### Community 658 - "Community 658"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 658 - "Community 658"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
@@ -4135,24 +4135,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 669 - "Community 669"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 670 - "Community 670"
 Cohesion: 1.0
 Nodes (2): isTransientCapacityError(), logExternalApiRetry()
 
-### Community 670 - "Community 670"
+### Community 671 - "Community 671"
 Cohesion: 0.67
 Nodes (1): RuleBasedProceduralExtractor
 
-### Community 671 - "Community 671"
+### Community 672 - "Community 672"
 Cohesion: 1.0
 Nodes (2): getVectorTableName(), validateTableName()
 
-### Community 672 - "Community 672"
+### Community 673 - "Community 673"
 Cohesion: 1.0
 Nodes (2): issue(), validateConfiguration()
-
-### Community 673 - "Community 673"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
@@ -4163,36 +4163,36 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 676 - "Community 676"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 677 - "Community 677"
 Cohesion: 1.0
 Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
 
-### Community 677 - "Community 677"
-Cohesion: 0.67
-Nodes (0): 
-
 ### Community 678 - "Community 678"
 Cohesion: 0.67
-Nodes (1): SearchError
+Nodes (0): 
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): SearchError
 
 ### Community 680 - "Community 680"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 681 - "Community 681"
 Cohesion: 1.0
 Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
 
-### Community 681 - "Community 681"
+### Community 682 - "Community 682"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 682 - "Community 682"
-Cohesion: 1.0
-Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
 ### Community 683 - "Community 683"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
@@ -4203,12 +4203,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 686 - "Community 686"
-Cohesion: 1.0
-Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
-
-### Community 687 - "Community 687"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 687 - "Community 687"
+Cohesion: 1.0
+Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
@@ -4220,19 +4220,19 @@ Nodes (0):
 
 ### Community 690 - "Community 690"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 691 - "Community 691"
-Cohesion: 1.0
-Nodes (2): generateMemoryId(), rollbackToVersion()
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
 
 ### Community 692 - "Community 692"
 Cohesion: 1.0
-Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
+Nodes (2): generateMemoryId(), rollbackToVersion()
 
 ### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
@@ -4263,24 +4263,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 701 - "Community 701"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 702 - "Community 702"
 Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
 
 ### Community 703 - "Community 703"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 704 - "Community 704"
 Cohesion: 0.67
-Nodes (1): AgentIntegrationError
+Nodes (0): 
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): AgentIntegrationError
 
 ### Community 706 - "Community 706"
 Cohesion: 0.67
@@ -4291,16 +4291,16 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 708 - "Community 708"
-Cohesion: 1.0
-Nodes (2): compareToolResults(), testToolConsistency()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 709 - "Community 709"
 Cohesion: 1.0
-Nodes (2): createQualityTables(), testQualityAssuranceE2E()
+Nodes (2): compareToolResults(), testToolConsistency()
 
 ### Community 710 - "Community 710"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createQualityTables(), testQualityAssuranceE2E()
 
 ### Community 711 - "Community 711"
 Cohesion: 0.67
@@ -4311,52 +4311,52 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 713 - "Community 713"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 714 - "Community 714"
 Cohesion: 1.0
 Nodes (2): calculateRanks(), calculateSpearmanRho()
 
-### Community 714 - "Community 714"
+### Community 715 - "Community 715"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 715 - "Community 715"
+### Community 716 - "Community 716"
 Cohesion: 1.0
 Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
-### Community 716 - "Community 716"
+### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 717 - "Community 717"
-Cohesion: 1.0
-Nodes (2): main(), option()
 
 ### Community 718 - "Community 718"
 Cohesion: 1.0
-Nodes (2): fetchJson(), testDockerServer()
+Nodes (2): main(), option()
 
 ### Community 719 - "Community 719"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): fetchJson(), testDockerServer()
 
 ### Community 720 - "Community 720"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 723 - "Community 723"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 724 - "Community 724"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 725 - "Community 725"
 Cohesion: 0.67
@@ -4379,7 +4379,7 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 730 - "Community 730"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 731 - "Community 731"
@@ -7145,37 +7145,35 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `TimeoutError`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 730`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 731`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 732`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 733`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 734`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 735`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 736`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 737`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 738`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 739`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 740`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
+- **Thin community `Community 741`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 742`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 743`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 744`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `createAnchorSchema()`, `anchor-map.handler.spec.ts`
+- **Thin community `Community 745`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 746`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -137,7 +137,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 617
+      "community": 618
     },
     {
       "label": "SlowTransport",
@@ -145,7 +145,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 617
+      "community": 618
     },
     {
       "label": ".recall()",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 617
+      "community": 618
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 730
+      "community": 731
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 730
+      "community": 731
     },
     {
       "label": "before-user-turn.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 618
+      "community": 619
     },
     {
       "label": "beforeUserTurn()",
@@ -193,7 +193,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 618
+      "community": 619
     },
     {
       "label": "withTimeout()",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 618
+      "community": 619
     },
     {
       "label": "auto-recall-policy.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 731
+      "community": 732
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 731
+      "community": 732
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 732
+      "community": 733
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 732
+      "community": 733
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 619
+      "community": 620
     },
     {
       "label": "scopeRecallFilters()",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 619
+      "community": 620
     },
     {
       "label": "scopeRememberTags()",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 619
+      "community": 620
     },
     {
       "label": "channel-scope.spec.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 733
+      "community": 734
     },
     {
       "label": "createTransportFromEnv()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 733
+      "community": 734
     },
     {
       "label": "stdio-transport.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 486
+      "community": 487
     },
     {
       "label": "createRateLimitedLogger()",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 486
+      "community": 487
     },
     {
       "label": "levelFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 486
+      "community": 487
     },
     {
       "label": "consoleSink()",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 486
+      "community": 487
     },
     {
       "label": "logger.spec.ts",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 487
+      "community": 488
     },
     {
       "label": "startTestHttpServer()",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 487
+      "community": 488
     },
     {
       "label": "findFreePort()",
@@ -793,7 +793,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 487
+      "community": 488
     },
     {
       "label": "waitForHealth()",
@@ -801,7 +801,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 487
+      "community": 488
     },
     {
       "label": "http-server-runner.js",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 734
+      "community": 735
     },
     {
       "label": "testBasicFunctionality()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 734
+      "community": 735
     },
     {
       "label": "performance-optimizer.js",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 735
+      "community": 736
     },
     {
       "label": "basicUsageExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 735
+      "community": 736
     },
     {
       "label": "performance-examples.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 736
+      "community": 737
     },
     {
       "label": "advancedUsageExample()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 736
+      "community": 737
     },
     {
       "label": "migration-guide.ts",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 737
+      "community": 738
     },
     {
       "label": "makeNullRunner()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 737
+      "community": 738
     },
     {
       "label": "telemetry-cli.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 738
+      "community": 739
     },
     {
       "label": "readShellSources()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L47",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 738
+      "community": 739
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 488
+      "community": 489
     },
     {
       "label": "getRepoRoot()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 488
+      "community": 489
     },
     {
       "label": "collectEnvKeys()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 488
+      "community": 489
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 488
+      "community": 489
     },
     {
       "label": "server-info.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 620
+      "community": 621
     },
     {
       "label": "createMockResponse()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 620
+      "community": 621
     },
     {
       "label": "sendOptions()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 620
+      "community": 621
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 621
+      "community": 622
     },
     {
       "label": "readReviewCandidatesPanelSources()",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L44",
       "id": "dashboard_review_candidates_panel_spec_readreviewcandidatespanelsources",
-      "community": 621
+      "community": 622
     },
     {
       "label": "createPollHarness()",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L67",
       "id": "dashboard_review_candidates_panel_spec_createpollharness",
-      "community": 621
+      "community": 622
     },
     {
       "label": "index-factory.spec.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 739
+      "community": 740
     },
     {
       "label": "createServerFactory()",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 739
+      "community": 740
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "readRepoFile()",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 622
+      "community": 623
     },
     {
       "label": "sectionBetween()",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 622
+      "community": 623
     },
     {
       "label": "http-server.spec.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_websocket_ts",
-      "community": 740
+      "community": 741
     },
     {
       "label": "setupWebSocketServer()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L20",
       "id": "http_server_websocket_setupwebsocketserver",
-      "community": 740
+      "community": 741
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 741
+      "community": 742
     },
     {
       "label": "startStdioServer()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 741
+      "community": 742
     },
     {
       "label": "audit-tool-dispatch.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_owner_scope_integration_spec_ts",
-      "community": 489
+      "community": 490
     },
     {
       "label": "postJson()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L16",
       "id": "owner_scope_integration_spec_postjson",
-      "community": 489
+      "community": 490
     },
     {
       "label": "seedOwnerScopedMemories()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L56",
       "id": "owner_scope_integration_spec_seedownerscopedmemories",
-      "community": 489
+      "community": 490
     },
     {
       "label": "startRealHttpServer()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L69",
       "id": "owner_scope_integration_spec_startrealhttpserver",
-      "community": 489
+      "community": 490
     },
     {
       "label": "server-info.spec.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 742
+      "community": 743
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 742
+      "community": 743
     },
     {
       "label": "http-server-lifecycle.ts",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_lifecycle_ts",
-      "community": 490
+      "community": 491
     },
     {
       "label": "createRuntimeDiagnosticsWriter()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L18",
       "id": "http_server_lifecycle_createruntimediagnosticswriter",
-      "community": 490
+      "community": 491
     },
     {
       "label": "performCleanup()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L37",
       "id": "http_server_lifecycle_performcleanup",
-      "community": 490
+      "community": 491
     },
     {
       "label": "registerCleanupHandlers()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L106",
       "id": "http_server_lifecycle_registercleanuphandlers",
-      "community": 490
+      "community": 491
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "createMockResponse()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 623
+      "community": 624
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 623
+      "community": 624
     },
     {
       "label": "server-state.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "startSseServer()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 491
+      "community": 492
     },
     {
       "label": "stopSseServer()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 491
+      "community": 492
     },
     {
       "label": "cleanupSseServer()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 491
+      "community": 492
     },
     {
       "label": "http-server.ts",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 624
+      "community": 625
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 624
+      "community": 625
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 743
+      "community": 744
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 743
+      "community": 744
     },
     {
       "label": "tool-result.utils.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_tool_result_utils_ts",
-      "community": 744
+      "community": 745
     },
     {
       "label": "extractToolResultPayload()",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L6",
       "id": "tool_result_utils_extracttoolresultpayload",
-      "community": 744
+      "community": 745
     },
     {
       "label": "anchor-map.handler.spec.ts",
@@ -3321,15 +3321,39 @@
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
-      "community": 745
+      "community": 408
     },
     {
       "label": "createAnchorSchema()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "id": "anchor_map_handler_spec_createanchorschema",
-      "community": 745
+      "community": 408
+    },
+    {
+      "label": "createMemoryItemSchema()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L72",
+      "id": "anchor_map_handler_spec_creatememoryitemschema",
+      "community": 408
+    },
+    {
+      "label": "buildFakeAnchorManager()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L94",
+      "id": "anchor_map_handler_spec_buildfakeanchormanager",
+      "community": 408
+    },
+    {
+      "label": "insertMemory()",
+      "file_type": "code",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L123",
+      "id": "anchor_map_handler_spec_insertmemory",
+      "community": 408
     },
     {
       "label": "anchor-map.handler.ts",
@@ -3359,16 +3383,16 @@
       "label": "buildNetworkNodesAndLinks()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L128",
+      "source_location": "L129",
       "id": "anchor_map_handler_buildnetworknodesandlinks",
       "community": 283
     },
     {
-      "label": "buildNetworkLinks()",
+      "label": "buildRelationLinks()",
       "file_type": "code",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L238",
-      "id": "anchor_map_handler_buildnetworklinks",
+      "source_location": "L246",
+      "id": "anchor_map_handler_buildrelationlinks",
       "community": 283
     },
     {
@@ -3433,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "hasOwnerIdInBody()",
@@ -3441,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L10",
       "id": "owner_scope_middleware_hasowneridinbody",
-      "community": 492
+      "community": 493
     },
     {
       "label": "isOwnerScopedToolRequest()",
@@ -3449,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L27",
       "id": "owner_scope_middleware_isownerscopedtoolrequest",
-      "community": 492
+      "community": 493
     },
     {
       "label": "createOwnerScopeMiddleware()",
@@ -3457,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L36",
       "id": "owner_scope_middleware_createownerscopemiddleware",
-      "community": 492
+      "community": 493
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3465,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "makeMocks()",
@@ -3473,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L13",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createMiddleware()",
@@ -3481,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L23",
       "id": "admin_auth_middleware_spec_createmiddleware",
-      "community": 625
+      "community": 626
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3753,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "readCookie()",
@@ -3761,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 493
+      "community": 494
     },
     {
       "label": "writeUnauthorized()",
@@ -3769,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 493
+      "community": 494
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3777,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 493
+      "community": 494
     },
     {
       "label": "http-audit.middleware.spec.ts",
@@ -3889,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createMockResponse()",
@@ -3897,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createRegistry()",
@@ -3905,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "programmatic_auth_middleware_spec_createregistry",
-      "community": 626
+      "community": 627
     },
     {
       "label": "owner-scope.middleware.spec.ts",
@@ -3953,7 +3977,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_stdio_server_ts",
-      "community": 408
+      "community": 409
     },
     {
       "label": "StdioServer",
@@ -3961,7 +3985,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L15",
       "id": "stdio_server_stdioserver",
-      "community": 408
+      "community": 409
     },
     {
       "label": ".start()",
@@ -3969,7 +3993,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L24",
       "id": "stdio_server_stdioserver_start",
-      "community": 408
+      "community": 409
     },
     {
       "label": ".stop()",
@@ -3977,7 +4001,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L43",
       "id": "stdio_server_stdioserver_stop",
-      "community": 408
+      "community": 409
     },
     {
       "label": ".cleanup()",
@@ -3985,7 +4009,7 @@
       "source_file": "packages/memento-server/src/server/servers/stdio-server.ts",
       "source_location": "L65",
       "id": "stdio_server_stdioserver_cleanup",
-      "community": 408
+      "community": 409
     },
     {
       "label": "sse-server.ts",
@@ -3993,7 +4017,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_servers_sse_server_ts",
-      "community": 409
+      "community": 410
     },
     {
       "label": "SseServer",
@@ -4001,7 +4025,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L15",
       "id": "sse_server_sseserver",
-      "community": 409
+      "community": 410
     },
     {
       "label": ".start()",
@@ -4009,7 +4033,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L23",
       "id": "sse_server_sseserver_start",
-      "community": 409
+      "community": 410
     },
     {
       "label": ".stop()",
@@ -4017,7 +4041,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L42",
       "id": "sse_server_sseserver_stop",
-      "community": 409
+      "community": 410
     },
     {
       "label": ".cleanup()",
@@ -4025,7 +4049,7 @@
       "source_file": "packages/memento-server/src/server/servers/sse-server.ts",
       "source_location": "L56",
       "id": "sse_server_sseserver_cleanup",
-      "community": 409
+      "community": 410
     },
     {
       "label": "test-database.ts",
@@ -4137,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_personal_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "parsePersonalRunBody()",
@@ -4145,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L15",
       "id": "agent_routes_personal_parsepersonalrunbody",
-      "community": 494
+      "community": 495
     },
     {
       "label": "handlePostPersonalRun()",
@@ -4153,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L27",
       "id": "agent_routes_personal_handlepostpersonalrun",
-      "community": 494
+      "community": 495
     },
     {
       "label": "handlePostPersonalPersistApproved()",
@@ -4161,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L50",
       "id": "agent_routes_personal_handlepostpersonalpersistapproved",
-      "community": 494
+      "community": 495
     },
     {
       "label": "maintenance.routes.spec.ts",
@@ -4185,7 +4209,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "event()",
@@ -4193,7 +4217,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L13",
       "id": "agent_routes_spec_event",
-      "community": 627
+      "community": 628
     },
     {
       "label": "invoke()",
@@ -4201,7 +4225,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L159",
       "id": "agent_routes_spec_invoke",
-      "community": 627
+      "community": 628
     },
     {
       "label": "agent-transcript-import.spec.ts",
@@ -4209,7 +4233,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_transcript_import_spec_ts",
-      "community": 410
+      "community": 411
     },
     {
       "label": "rawEvent()",
@@ -4217,7 +4241,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L15",
       "id": "agent_transcript_import_spec_rawevent",
-      "community": 410
+      "community": 411
     },
     {
       "label": "preparedEvent()",
@@ -4225,7 +4249,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L26",
       "id": "agent_transcript_import_spec_preparedevent",
-      "community": 410
+      "community": 411
     },
     {
       "label": "jsonl()",
@@ -4233,7 +4257,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L52",
       "id": "agent_transcript_import_spec_jsonl",
-      "community": 410
+      "community": 411
     },
     {
       "label": "importer()",
@@ -4241,7 +4265,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-transcript-import.spec.ts",
       "source_location": "L76",
       "id": "agent_transcript_import_spec_importer",
-      "community": 410
+      "community": 411
     },
     {
       "label": "agent.routes.sessions.ts",
@@ -4345,7 +4369,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.promotions.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_promotions_ts",
-      "community": 411
+      "community": 412
     },
     {
       "label": "handleGetPromotionCandidates()",
@@ -4353,7 +4377,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.promotions.ts",
       "source_location": "L7",
       "id": "agent_routes_promotions_handlegetpromotioncandidates",
-      "community": 411
+      "community": 412
     },
     {
       "label": "handleApproveCandidate()",
@@ -4361,7 +4385,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.promotions.ts",
       "source_location": "L29",
       "id": "agent_routes_promotions_handleapprovecandidate",
-      "community": 411
+      "community": 412
     },
     {
       "label": "handleRejectCandidate()",
@@ -4369,7 +4393,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.promotions.ts",
       "source_location": "L44",
       "id": "agent_routes_promotions_handlerejectcandidate",
-      "community": 411
+      "community": 412
     },
     {
       "label": "handlePostRetentionEnforce()",
@@ -4377,7 +4401,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.promotions.ts",
       "source_location": "L62",
       "id": "agent_routes_promotions_handlepostretentionenforce",
-      "community": 411
+      "community": 412
     },
     {
       "label": "agent.routes.ingest.ts",
@@ -4449,7 +4473,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_audit_routes_ts",
-      "community": 412
+      "community": 413
     },
     {
       "label": "readSingleQueryValue()",
@@ -4457,7 +4481,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.ts",
       "source_location": "L12",
       "id": "audit_routes_readsinglequeryvalue",
-      "community": 412
+      "community": 413
     },
     {
       "label": "parseLimit()",
@@ -4465,7 +4489,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.ts",
       "source_location": "L16",
       "id": "audit_routes_parselimit",
-      "community": 412
+      "community": 413
     },
     {
       "label": "parseQuery()",
@@ -4473,7 +4497,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.ts",
       "source_location": "L23",
       "id": "audit_routes_parsequery",
-      "community": 412
+      "community": 413
     },
     {
       "label": "createAuditRouter()",
@@ -4481,7 +4505,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.ts",
       "source_location": "L39",
       "id": "audit_routes_createauditrouter",
-      "community": 412
+      "community": 413
     },
     {
       "label": "agent.routes.events.ts",
@@ -4593,7 +4617,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_auth_routes_ts",
-      "community": 413
+      "community": 414
     },
     {
       "label": "readBearerToken()",
@@ -4601,7 +4625,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L12",
       "id": "auth_routes_readbearertoken",
-      "community": 413
+      "community": 414
     },
     {
       "label": "readApiKeyHeader()",
@@ -4609,7 +4633,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L21",
       "id": "auth_routes_readapikeyheader",
-      "community": 413
+      "community": 414
     },
     {
       "label": "readCookie()",
@@ -4617,7 +4641,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L30",
       "id": "auth_routes_readcookie",
-      "community": 413
+      "community": 414
     },
     {
       "label": "createAuthRouter()",
@@ -4625,7 +4649,7 @@
       "source_file": "packages/memento-server/src/server/routes/auth.routes.ts",
       "source_location": "L45",
       "id": "auth_routes_createauthrouter",
-      "community": 413
+      "community": 414
     },
     {
       "label": "maintenance.routes.ts",
@@ -4633,7 +4657,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_maintenance_routes_ts",
-      "community": 414
+      "community": 415
     },
     {
       "label": "asNonEmptyString()",
@@ -4641,7 +4665,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.ts",
       "source_location": "L23",
       "id": "maintenance_routes_asnonemptystring",
-      "community": 414
+      "community": 415
     },
     {
       "label": "parseRequest()",
@@ -4649,7 +4673,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.ts",
       "source_location": "L27",
       "id": "maintenance_routes_parserequest",
-      "community": 414
+      "community": 415
     },
     {
       "label": "createMaintenanceRouter()",
@@ -4657,7 +4681,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.ts",
       "source_location": "L50",
       "id": "maintenance_routes_createmaintenancerouter",
-      "community": 414
+      "community": 415
     },
     {
       "label": "resetMaintenanceJobsForTests()",
@@ -4665,7 +4689,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.ts",
       "source_location": "L87",
       "id": "maintenance_routes_resetmaintenancejobsfortests",
-      "community": 414
+      "community": 415
     },
     {
       "label": "agent.routes.constants.ts",
@@ -4961,7 +4985,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_injection_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "initialInjectionQuery()",
@@ -4969,7 +4993,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L5",
       "id": "agent_routes_injection_initialinjectionquery",
-      "community": 495
+      "community": 496
     },
     {
       "label": "injectionScope()",
@@ -4977,7 +5001,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L16",
       "id": "agent_routes_injection_injectionscope",
-      "community": 495
+      "community": 496
     },
     {
       "label": "buildInjectionDetails()",
@@ -4985,7 +5009,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L25",
       "id": "agent_routes_injection_buildinjectiondetails",
-      "community": 495
+      "community": 496
     },
     {
       "label": "audit.routes.spec.ts",
@@ -5385,7 +5409,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_json_rpc_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "isJsonRpcNotification()",
@@ -5393,7 +5417,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L3",
       "id": "json_rpc_isjsonrpcnotification",
-      "community": 496
+      "community": 497
     },
     {
       "label": "isInitializeRequest()",
@@ -5401,7 +5425,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L7",
       "id": "json_rpc_isinitializerequest",
-      "community": 496
+      "community": 497
     },
     {
       "label": "createJsonRpcError()",
@@ -5409,7 +5433,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L11",
       "id": "json_rpc_createjsonrpcerror",
-      "community": 496
+      "community": 497
     },
     {
       "label": "message-processor.ts",
@@ -5521,7 +5545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -5529,7 +5553,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L33",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 497
+      "community": 498
     },
     {
       "label": "parseBulkSelector()",
@@ -5537,7 +5561,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L45",
       "id": "admin_memory_review_routes_parsebulkselector",
-      "community": 497
+      "community": 498
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -5545,7 +5569,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L83",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 497
+      "community": 498
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -5601,7 +5625,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "parseParams()",
@@ -5609,7 +5633,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 628
+      "community": 629
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -5617,7 +5641,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 628
+      "community": 629
     },
     {
       "label": "admin-evolution-demo.routes.spec.ts",
@@ -5625,7 +5649,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_spec_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "listen()",
@@ -5633,7 +5657,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L11",
       "id": "admin_evolution_demo_routes_spec_listen",
-      "community": 629
+      "community": 630
     },
     {
       "label": "getAdmin()",
@@ -5641,7 +5665,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L25",
       "id": "admin_evolution_demo_routes_spec_getadmin",
-      "community": 629
+      "community": 630
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -5745,7 +5769,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "parseCleanupParams()",
@@ -5753,7 +5777,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 630
+      "community": 631
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -5761,7 +5785,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 630
+      "community": 631
     },
     {
       "label": "admin-relations.routes.ts",
@@ -5953,7 +5977,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_export_routes_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "parseTypesQuery()",
@@ -5961,7 +5985,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L12",
       "id": "admin_export_routes_parsetypesquery",
-      "community": 631
+      "community": 632
     },
     {
       "label": "registerAdminExportRoutes()",
@@ -5969,7 +5993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L21",
       "id": "admin_export_routes_registeradminexportroutes",
-      "community": 631
+      "community": 632
     },
     {
       "label": "claude-code-hook.ts",
@@ -5977,7 +6001,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_ts",
-      "community": 415
+      "community": 416
     },
     {
       "label": "route()",
@@ -5985,7 +6009,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L48",
       "id": "claude_code_hook_route",
-      "community": 415
+      "community": 416
     },
     {
       "label": "createClaudeCodeHttpTransport()",
@@ -5993,7 +6017,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L73",
       "id": "claude_code_hook_createclaudecodehttptransport",
-      "community": 415
+      "community": 416
     },
     {
       "label": "readStream()",
@@ -6001,7 +6025,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L109",
       "id": "claude_code_hook_readstream",
-      "community": 415
+      "community": 416
     },
     {
       "label": "runClaudeCodeHookCommand()",
@@ -6009,7 +6033,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.ts",
       "source_location": "L115",
       "id": "claude_code_hook_runclaudecodehookcommand",
-      "community": 415
+      "community": 416
     },
     {
       "label": "agent-ask.spec.ts",
@@ -6033,7 +6057,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_issue237_e2e_spec_ts",
-      "community": 416
+      "community": 417
     },
     {
       "label": "stopBatchSchedulerSingleton()",
@@ -6041,7 +6065,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L22",
       "id": "agent_ask_issue237_e2e_spec_stopbatchschedulersingleton",
-      "community": 416
+      "community": 417
     },
     {
       "label": "argvAgentAsk()",
@@ -6049,7 +6073,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L30",
       "id": "agent_ask_issue237_e2e_spec_argvagentask",
-      "community": 416
+      "community": 417
     },
     {
       "label": "captureStdoutWrite()",
@@ -6057,7 +6081,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L38",
       "id": "agent_ask_issue237_e2e_spec_capturestdoutwrite",
-      "community": 416
+      "community": 417
     },
     {
       "label": "seedTwoProjectMemories()",
@@ -6065,7 +6089,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask-issue237.e2e.spec.ts",
       "source_location": "L52",
       "id": "agent_ask_issue237_e2e_spec_seedtwoprojectmemories",
-      "community": 416
+      "community": 417
     },
     {
       "label": "claude-code-connect.spec.ts",
@@ -6097,7 +6121,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "resolveEnvPath()",
@@ -6105,7 +6129,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 632
+      "community": 633
     },
     {
       "label": "loadEnv()",
@@ -6113,7 +6137,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 632
+      "community": 633
     },
     {
       "label": "codex-connect.spec.ts",
@@ -6129,7 +6153,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_ts",
-      "community": 417
+      "community": 418
     },
     {
       "label": "route()",
@@ -6137,7 +6161,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L48",
       "id": "codex_hook_route",
-      "community": 417
+      "community": 418
     },
     {
       "label": "createCodexHttpTransport()",
@@ -6145,7 +6169,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L67",
       "id": "codex_hook_createcodexhttptransport",
-      "community": 417
+      "community": 418
     },
     {
       "label": "readStream()",
@@ -6153,7 +6177,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L101",
       "id": "codex_hook_readstream",
-      "community": 417
+      "community": 418
     },
     {
       "label": "runCodexHookCommand()",
@@ -6161,7 +6185,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.ts",
       "source_location": "L107",
       "id": "codex_hook_runcodexhookcommand",
-      "community": 417
+      "community": 418
     },
     {
       "label": "review-queue-cleanup.ts",
@@ -6217,7 +6241,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "runCli()",
@@ -6225,7 +6249,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L68",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 633
+      "community": 634
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6233,7 +6257,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L99",
       "id": "cli_ac5_ac6_spec_createreviewqueuedatabase",
-      "community": 633
+      "community": 634
     },
     {
       "label": "agent-ask.ts",
@@ -6249,7 +6273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "response()",
@@ -6257,7 +6281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L9",
       "id": "agent_ops_spec_response",
-      "community": 634
+      "community": 635
     },
     {
       "label": "baseDependencies()",
@@ -6265,7 +6289,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L13",
       "id": "agent_ops_spec_basedependencies",
-      "community": 634
+      "community": 635
     },
     {
       "label": "review-queue-cleanup.spec.ts",
@@ -6273,7 +6297,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_review_queue_cleanup_spec_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6281,7 +6305,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L13",
       "id": "review_queue_cleanup_spec_createreviewqueuedatabase",
-      "community": 635
+      "community": 636
     },
     {
       "label": "pendingCount()",
@@ -6289,7 +6313,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L54",
       "id": "review_queue_cleanup_spec_pendingcount",
-      "community": 635
+      "community": 636
     },
     {
       "label": "claude-code-connect.ts",
@@ -6297,7 +6321,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_ts",
-      "community": 418
+      "community": 419
     },
     {
       "label": "defaultProbe()",
@@ -6305,7 +6329,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L29",
       "id": "claude_code_connect_defaultprobe",
-      "community": 418
+      "community": 419
     },
     {
       "label": "parseOptions()",
@@ -6313,7 +6337,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L46",
       "id": "claude_code_connect_parseoptions",
-      "community": 418
+      "community": 419
     },
     {
       "label": "readSettings()",
@@ -6321,7 +6345,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L68",
       "id": "claude_code_connect_readsettings",
-      "community": 418
+      "community": 419
     },
     {
       "label": "runClaudeCodeConnect()",
@@ -6329,7 +6353,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.ts",
       "source_location": "L78",
       "id": "claude_code_connect_runclaudecodeconnect",
-      "community": 418
+      "community": 419
     },
     {
       "label": "option-map.ts",
@@ -6617,7 +6641,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/io.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_io_ts",
-      "community": 419
+      "community": 420
     },
     {
       "label": "jsonFailure()",
@@ -6625,7 +6649,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/io.ts",
       "source_location": "L14",
       "id": "io_jsonfailure",
-      "community": 419
+      "community": 420
     },
     {
       "label": "writeOut()",
@@ -6633,7 +6657,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/io.ts",
       "source_location": "L26",
       "id": "io_writeout",
-      "community": 419
+      "community": 420
     },
     {
       "label": "writeErr()",
@@ -6641,7 +6665,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/io.ts",
       "source_location": "L32",
       "id": "io_writeerr",
-      "community": 419
+      "community": 420
     },
     {
       "label": "debugErr()",
@@ -6649,7 +6673,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/io.ts",
       "source_location": "L38",
       "id": "io_debugerr",
-      "community": 419
+      "community": 420
     },
     {
       "label": "runtime.ts",
@@ -6833,7 +6857,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -6841,7 +6865,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 636
+      "community": 637
     },
     {
       "label": "runQualityMeasurement()",
@@ -6849,7 +6873,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 636
+      "community": 637
     },
     {
       "label": "test-simple-alerts.ts",
@@ -6905,7 +6929,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "compareServices()",
@@ -6913,7 +6937,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 637
+      "community": 638
     },
     {
       "label": "testServerSynchronization()",
@@ -6921,7 +6945,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 637
+      "community": 638
     },
     {
       "label": "test-error-logging.ts",
@@ -7025,7 +7049,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "assert()",
@@ -7033,7 +7057,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 638
+      "community": 639
     },
     {
       "label": "testMementoClient()",
@@ -7041,7 +7065,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 638
+      "community": 639
     },
     {
       "label": "test-performance-monitor.ts",
@@ -7185,7 +7209,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "createBaseSchema()",
@@ -7193,7 +7217,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 639
+      "community": 640
     },
     {
       "label": "createTestMemory()",
@@ -7201,7 +7225,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 639
+      "community": 640
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -7281,7 +7305,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "BraveSearchProvider",
@@ -7289,7 +7313,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 498
+      "community": 499
     },
     {
       "label": ".constructor()",
@@ -7297,7 +7321,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 498
+      "community": 499
     },
     {
       "label": ".search()",
@@ -7305,7 +7329,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 498
+      "community": 499
     },
     {
       "label": "noop-search-provider.ts",
@@ -7313,7 +7337,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "NoopSearchProvider",
@@ -7321,7 +7345,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 640
+      "community": 641
     },
     {
       "label": ".search()",
@@ -7329,7 +7353,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 640
+      "community": 641
     },
     {
       "label": "search-factory.ts",
@@ -7681,7 +7705,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_normalize_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "normalizeJson()",
@@ -7689,7 +7713,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L4",
       "id": "normalize_normalizejson",
-      "community": 499
+      "community": 500
     },
     {
       "label": "canonicalize()",
@@ -7697,7 +7721,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L33",
       "id": "normalize_canonicalize",
-      "community": 499
+      "community": 500
     },
     {
       "label": "normalizeAgentEvent()",
@@ -7705,7 +7729,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L47",
       "id": "normalize_normalizeagentevent",
-      "community": 499
+      "community": 500
     },
     {
       "label": "index.ts",
@@ -7921,7 +7945,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "git()",
@@ -7929,7 +7953,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L22",
       "id": "scope_spec_git",
-      "community": 641
+      "community": 642
     },
     {
       "label": "runner.spec.ts",
@@ -8177,7 +8201,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_adapter_spec_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "fixture()",
@@ -8185,7 +8209,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L12",
       "id": "adapter_spec_fixture",
-      "community": 501
+      "community": 502
     },
     {
       "label": "scope.spec.ts",
@@ -8193,7 +8217,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_spec_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "runner.spec.ts",
@@ -8321,7 +8345,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "parseVersion()",
@@ -8329,7 +8353,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L19",
       "id": "diagnostics_parseversion",
-      "community": 500
+      "community": 501
     },
     {
       "label": "versionAtLeast()",
@@ -8337,7 +8361,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L31",
       "id": "diagnostics_versionatleast",
-      "community": 500
+      "community": 501
     },
     {
       "label": "diagnoseClaudeCode()",
@@ -8345,7 +8369,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L42",
       "id": "diagnostics_diagnoseclaudecode",
-      "community": 500
+      "community": 501
     },
     {
       "label": "settings.ts",
@@ -8393,7 +8417,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "invalid()",
@@ -8401,7 +8425,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L6",
       "id": "runner_invalid",
-      "community": 642
+      "community": 643
     },
     {
       "label": "runClaudeCodeHook()",
@@ -8409,7 +8433,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L10",
       "id": "runner_runclaudecodehook",
-      "community": 642
+      "community": 643
     },
     {
       "label": "adapter.spec.ts",
@@ -8417,7 +8441,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_adapter_spec_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "fixtureUrl()",
@@ -8425,7 +8449,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L9",
       "id": "adapter_spec_fixtureurl",
-      "community": 501
+      "community": 502
     },
     {
       "label": "vitest.config.ts",
@@ -9217,7 +9241,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "shouldLog()",
@@ -9225,7 +9249,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 643
+      "community": 644
     },
     {
       "label": "log()",
@@ -9233,7 +9257,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 643
+      "community": 644
     },
     {
       "label": "feedback.integration.spec.ts",
@@ -9305,7 +9329,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_client_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "recall()",
@@ -9313,7 +9337,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L16",
       "id": "search_client_recall",
-      "community": 644
+      "community": 645
     },
     {
       "label": "hybridSearch()",
@@ -9321,7 +9345,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L49",
       "id": "search_client_hybridsearch",
-      "community": 644
+      "community": 645
     },
     {
       "label": "client-context.ts",
@@ -9489,7 +9513,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_format_utils_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "toSafeCSVCell()",
@@ -9497,7 +9521,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L6",
       "id": "format_utils_tosafecsvcell",
-      "community": 502
+      "community": 503
     },
     {
       "label": "memoriesToCSV()",
@@ -9505,7 +9529,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L17",
       "id": "format_utils_memoriestocsv",
-      "community": 502
+      "community": 503
     },
     {
       "label": "memoriesToMarkdown()",
@@ -9513,7 +9537,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L52",
       "id": "format_utils_memoriestomarkdown",
-      "community": 502
+      "community": 503
     },
     {
       "label": "memory-utils.ts",
@@ -9577,7 +9601,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_utils_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "normalizeQuery()",
@@ -9585,7 +9609,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L6",
       "id": "search_utils_normalizequery",
-      "community": 503
+      "community": 504
     },
     {
       "label": "normalizeScore()",
@@ -9593,7 +9617,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L17",
       "id": "search_utils_normalizescore",
-      "community": 503
+      "community": 504
     },
     {
       "label": "groupSearchResults()",
@@ -9601,7 +9625,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L25",
       "id": "search_utils_groupsearchresults",
-      "community": 503
+      "community": 504
     },
     {
       "label": "memory-client.ts",
@@ -9665,7 +9689,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_time_utils_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "getRelativeTime()",
@@ -9673,7 +9697,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L4",
       "id": "time_utils_getrelativetime",
-      "community": 645
+      "community": 646
     },
     {
       "label": "createDateRangeFilter()",
@@ -9681,7 +9705,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L26",
       "id": "time_utils_createdaterangefilter",
-      "community": 645
+      "community": 646
     },
     {
       "label": "validation-utils.ts",
@@ -9753,7 +9777,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "constructor()",
@@ -9761,7 +9785,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L246",
       "id": "bootstrap_spec_constructor",
-      "community": 504
+      "community": 505
     },
     {
       "label": "loadBootstrap()",
@@ -9769,7 +9793,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L269",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 504
+      "community": 505
     },
     {
       "label": "installTimeoutSpy()",
@@ -9777,7 +9801,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L273",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 504
+      "community": 505
     },
     {
       "label": "index.ts",
@@ -9785,7 +9809,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "createMementoCore()",
@@ -9793,7 +9817,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 646
+      "community": 647
     },
     {
       "label": "closeDatabase()",
@@ -9801,7 +9825,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 646
+      "community": 647
     },
     {
       "label": "bootstrap.ts",
@@ -9825,7 +9849,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createServerContext()",
@@ -9833,7 +9857,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L17",
       "id": "context_createservercontext",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createToolContext()",
@@ -9841,7 +9865,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L26",
       "id": "context_createtoolcontext",
-      "community": 505
+      "community": 506
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -9849,7 +9873,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L39",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 505
+      "community": 506
     },
     {
       "label": "write-and-meta.ts",
@@ -10297,7 +10321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_ts",
-      "community": 420
+      "community": 421
     },
     {
       "label": "ReflexionProceduralMemoryService",
@@ -10305,7 +10329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service.ts",
       "source_location": "L13",
       "id": "reflexion_procedural_memory_service_reflexionproceduralmemoryservice",
-      "community": 420
+      "community": 421
     },
     {
       "label": ".constructor()",
@@ -10313,7 +10337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service.ts",
       "source_location": "L14",
       "id": "reflexion_procedural_memory_service_reflexionproceduralmemoryservice_constructor",
-      "community": 420
+      "community": 421
     },
     {
       "label": ".convert()",
@@ -10321,7 +10345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service.ts",
       "source_location": "L19",
       "id": "reflexion_procedural_memory_service_reflexionproceduralmemoryservice_convert",
-      "community": 420
+      "community": 421
     },
     {
       "label": ".updateProceduralMemory()",
@@ -10329,7 +10353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service.ts",
       "source_location": "L54",
       "id": "reflexion_procedural_memory_service_reflexionproceduralmemoryservice_updateproceduralmemory",
-      "community": 420
+      "community": 421
     },
     {
       "label": "reflexion-reflection-recorder.ts",
@@ -10465,7 +10489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_spec_ts",
-      "community": 421
+      "community": 422
     },
     {
       "label": "extract()",
@@ -10473,7 +10497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L11",
       "id": "reflexion_worker_spec_extract",
-      "community": 421
+      "community": 422
     },
     {
       "label": "waitForEventProcessing()",
@@ -10481,7 +10505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L41",
       "id": "reflexion_worker_spec_waitforeventprocessing",
-      "community": 421
+      "community": 422
     },
     {
       "label": "createProceduralMemory()",
@@ -10489,7 +10513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L83",
       "id": "reflexion_worker_spec_createproceduralmemory",
-      "community": 421
+      "community": 422
     },
     {
       "label": "createFailureEvent()",
@@ -10497,7 +10521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker.spec.ts",
       "source_location": "L139",
       "id": "reflexion_worker_spec_createfailureevent",
-      "community": 421
+      "community": 422
     },
     {
       "label": "relation-graph-factory.ts",
@@ -10913,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_parsers_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "failedTaskDataToTaskFields()",
@@ -10921,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L4",
       "id": "async_optimizer_parsers_failedtaskdatatotaskfields",
-      "community": 506
+      "community": 507
     },
     {
       "label": "parseMemoryOperationTaskData()",
@@ -10929,7 +10953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L50",
       "id": "async_optimizer_parsers_parsememoryoperationtaskdata",
-      "community": 506
+      "community": 507
     },
     {
       "label": "parseFailureEventTaskData()",
@@ -10937,7 +10961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L69",
       "id": "async_optimizer_parsers_parsefailureeventtaskdata",
-      "community": 506
+      "community": 507
     },
     {
       "label": "async-optimizer.types.ts",
@@ -11129,7 +11153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-event-queue.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_event_queue_ts",
-      "community": 422
+      "community": 423
     },
     {
       "label": "autoReflect()",
@@ -11137,7 +11161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-event-queue.ts",
       "source_location": "L25",
       "id": "reflexion_worker_event_queue_autoreflect",
-      "community": 422
+      "community": 423
     },
     {
       "label": "queueFailureEvent()",
@@ -11145,7 +11169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-event-queue.ts",
       "source_location": "L49",
       "id": "reflexion_worker_event_queue_queuefailureevent",
-      "community": 422
+      "community": 423
     },
     {
       "label": "processFailureEvent()",
@@ -11153,7 +11177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-event-queue.ts",
       "source_location": "L99",
       "id": "reflexion_worker_event_queue_processfailureevent",
-      "community": 422
+      "community": 423
     },
     {
       "label": "checkQueueBacklog()",
@@ -11161,7 +11185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-event-queue.ts",
       "source_location": "L137",
       "id": "reflexion_worker_event_queue_checkqueuebacklog",
-      "community": 422
+      "community": 423
     },
     {
       "label": "reflexion-worker-health.ts",
@@ -11169,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_health_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "startHealthCheck()",
@@ -11177,7 +11201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L20",
       "id": "reflexion_worker_health_starthealthcheck",
-      "community": 507
+      "community": 508
     },
     {
       "label": "performHealthCheck()",
@@ -11185,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L30",
       "id": "reflexion_worker_health_performhealthcheck",
-      "community": 507
+      "community": 508
     },
     {
       "label": "attemptRestart()",
@@ -11193,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L61",
       "id": "reflexion_worker_health_attemptrestart",
-      "community": 507
+      "community": 508
     },
     {
       "label": "reflexion-worker-failure-handler.ts",
@@ -11201,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_failure_handler_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "registerHandler()",
@@ -11209,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L14",
       "id": "reflexion_worker_failure_handler_registerhandler",
-      "community": 647
+      "community": 648
     },
     {
       "label": "updateProceduralMemory()",
@@ -11217,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L22",
       "id": "reflexion_worker_failure_handler_updateproceduralmemory",
-      "community": 647
+      "community": 648
     },
     {
       "label": "reflexion-worker-metrics.ts",
@@ -11225,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_metrics_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "getReflexionMetrics()",
@@ -11233,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L14",
       "id": "reflexion_worker_metrics_getreflexionmetrics",
-      "community": 648
+      "community": 649
     },
     {
       "label": "getIntegratedMetrics()",
@@ -11241,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L42",
       "id": "reflexion_worker_metrics_getintegratedmetrics",
-      "community": 648
+      "community": 649
     },
     {
       "label": "reflexion-procedural-create.ts",
@@ -11313,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_incremental_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "mergeProceduralSteps()",
@@ -11321,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_incremental_mergeproceduralsteps",
-      "community": 649
+      "community": 650
     },
     {
       "label": "updateProceduralMemoryIncremental()",
@@ -11329,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L33",
       "id": "reflexion_procedural_update_incremental_updateproceduralmemoryincremental",
-      "community": 649
+      "community": 650
     },
     {
       "label": "database-optimize-tool.ts",
@@ -11337,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -11345,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 508
+      "community": 509
     },
     {
       "label": ".constructor()",
@@ -11353,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 508
+      "community": 509
     },
     {
       "label": ".handle()",
@@ -11361,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 508
+      "community": 509
     },
     {
       "label": "migration-history-service.ts",
@@ -11681,7 +11705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "createBaseSchema()",
@@ -11689,7 +11713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 650
+      "community": 651
     },
     {
       "label": "measureTime()",
@@ -11697,7 +11721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 650
+      "community": 651
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -11945,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -11953,7 +11977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createPlan()",
@@ -11961,7 +11985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 509
+      "community": 510
     },
     {
       "label": "createResult()",
@@ -11969,7 +11993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 509
+      "community": 510
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -12065,7 +12089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "addMissingColumn()",
@@ -12073,7 +12097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 651
+      "community": 652
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -12081,7 +12105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 651
+      "community": 652
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -12217,7 +12241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "initializeDatabase()",
@@ -12225,7 +12249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L29",
       "id": "init_initializedatabase",
-      "community": 652
+      "community": 653
     },
     {
       "label": "closeDatabase()",
@@ -12233,7 +12257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L116",
       "id": "init_closedatabase",
-      "community": 652
+      "community": 653
     },
     {
       "label": "db-integrity-preflight.spec.ts",
@@ -12369,7 +12393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "isDuplicateColumnError()",
@@ -12377,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L12",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 653
+      "community": 654
     },
     {
       "label": "migrateDatabase()",
@@ -12385,7 +12409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L16",
       "id": "migrate_migratedatabase",
-      "community": 653
+      "community": 654
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -12977,7 +13001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createMemoryItemTable()",
@@ -12985,7 +13009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 510
+      "community": 511
     },
     {
       "label": "columnExists()",
@@ -12993,7 +13017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 510
+      "community": 511
     },
     {
       "label": "indexExists()",
@@ -13001,7 +13025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 510
+      "community": 511
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -13369,7 +13393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_016_memory_item_attribution_spec_ts",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createMemoryItemTable()",
@@ -13377,7 +13401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L19",
       "id": "016_memory_item_attribution_spec_creatememoryitemtable",
-      "community": 423
+      "community": 424
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13385,7 +13409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L36",
       "id": "016_memory_item_attribution_spec_createschemaversiontable",
-      "community": 423
+      "community": 424
     },
     {
       "label": "columnExists()",
@@ -13393,7 +13417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L49",
       "id": "016_memory_item_attribution_spec_columnexists",
-      "community": 423
+      "community": 424
     },
     {
       "label": "indexExists()",
@@ -13401,7 +13425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/016-memory-item-attribution.spec.ts",
       "source_location": "L54",
       "id": "016_memory_item_attribution_spec_indexexists",
-      "community": 423
+      "community": 424
     },
     {
       "label": "025-memory-item-is-consolidated.ts",
@@ -13481,7 +13505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_030_triple_extraction_fields_spec_ts",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createMemoryItemTable()",
@@ -13489,7 +13513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L9",
       "id": "030_triple_extraction_fields_spec_creatememoryitemtable",
-      "community": 424
+      "community": 425
     },
     {
       "label": "createSchemaVersionTable()",
@@ -13497,7 +13521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L25",
       "id": "030_triple_extraction_fields_spec_createschemaversiontable",
-      "community": 424
+      "community": 425
     },
     {
       "label": "columnExists()",
@@ -13505,7 +13529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L38",
       "id": "030_triple_extraction_fields_spec_columnexists",
-      "community": 424
+      "community": 425
     },
     {
       "label": "indexExists()",
@@ -13513,7 +13537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/030-triple-extraction-fields.spec.ts",
       "source_location": "L43",
       "id": "030_triple_extraction_fields_spec_indexexists",
-      "community": 424
+      "community": 425
     },
     {
       "label": "018-kg-triple-table.spec.ts",
@@ -14369,7 +14393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_031_soft_delete_fields_spec_ts",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createMemoryItemTable()",
@@ -14377,7 +14401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L9",
       "id": "031_soft_delete_fields_spec_creatememoryitemtable",
-      "community": 425
+      "community": 426
     },
     {
       "label": "createSchemaVersionTable()",
@@ -14385,7 +14409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L22",
       "id": "031_soft_delete_fields_spec_createschemaversiontable",
-      "community": 425
+      "community": 426
     },
     {
       "label": "columnExists()",
@@ -14393,7 +14417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L35",
       "id": "031_soft_delete_fields_spec_columnexists",
-      "community": 425
+      "community": 426
     },
     {
       "label": "indexExists()",
@@ -14401,7 +14425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/031-soft-delete-fields.spec.ts",
       "source_location": "L40",
       "id": "031_soft_delete_fields_spec_indexexists",
-      "community": 425
+      "community": 426
     },
     {
       "label": "039-event-outbox.ts",
@@ -14865,7 +14889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "createMemoryItemTable()",
@@ -14873,7 +14897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 654
+      "community": 655
     },
     {
       "label": "tableExists()",
@@ -14881,7 +14905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 654
+      "community": 655
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -15121,7 +15145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "createMemoryItemTable()",
@@ -15129,7 +15153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 655
+      "community": 656
     },
     {
       "label": "tableExists()",
@@ -15137,7 +15161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 655
+      "community": 656
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -15417,7 +15441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -15425,7 +15449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 511
+      "community": 512
     },
     {
       "label": "createMemoryLinkTable()",
@@ -15433,7 +15457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 511
+      "community": 512
     },
     {
       "label": "createSchemaVersionTable()",
@@ -15441,7 +15465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 511
+      "community": 512
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -15705,7 +15729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_015_memory_item_owner_id_spec_ts",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createMemoryItemTable()",
@@ -15713,7 +15737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L19",
       "id": "015_memory_item_owner_id_spec_creatememoryitemtable",
-      "community": 426
+      "community": 427
     },
     {
       "label": "createSchemaVersionTable()",
@@ -15721,7 +15745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L35",
       "id": "015_memory_item_owner_id_spec_createschemaversiontable",
-      "community": 426
+      "community": 427
     },
     {
       "label": "columnExists()",
@@ -15729,7 +15753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L48",
       "id": "015_memory_item_owner_id_spec_columnexists",
-      "community": 426
+      "community": 427
     },
     {
       "label": "indexExists()",
@@ -15737,7 +15761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/015-memory-item-owner-id.spec.ts",
       "source_location": "L53",
       "id": "015_memory_item_owner_id_spec_indexexists",
-      "community": 426
+      "community": 427
     },
     {
       "label": "018-kg-triple-table.ts",
@@ -15825,7 +15849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_017_fact_metadata_fields_spec_ts",
-      "community": 427
+      "community": 428
     },
     {
       "label": "createMemoryItemTable()",
@@ -15833,7 +15857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L19",
       "id": "017_fact_metadata_fields_spec_creatememoryitemtable",
-      "community": 427
+      "community": 428
     },
     {
       "label": "createSchemaVersionTable()",
@@ -15841,7 +15865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L38",
       "id": "017_fact_metadata_fields_spec_createschemaversiontable",
-      "community": 427
+      "community": 428
     },
     {
       "label": "columnExists()",
@@ -15849,7 +15873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L51",
       "id": "017_fact_metadata_fields_spec_columnexists",
-      "community": 427
+      "community": 428
     },
     {
       "label": "indexExists()",
@@ -15857,7 +15881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/017-fact-metadata-fields.spec.ts",
       "source_location": "L56",
       "id": "017_fact_metadata_fields_spec_indexexists",
-      "community": 427
+      "community": 428
     },
     {
       "label": "006-fts5-reflection-notes.ts",
@@ -16273,7 +16297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "applicableTypesFor()",
@@ -16281,7 +16305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L12",
       "id": "005_relation_engine_schema_spec_applicabletypesfor",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createBaseSchema()",
@@ -16289,7 +16313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L21",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 512
+      "community": 513
     },
     {
       "label": "createMemoryLinkTable()",
@@ -16297,7 +16321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L122",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 512
+      "community": 513
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -16393,7 +16417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -16401,7 +16425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 513
+      "community": 514
     },
     {
       "label": "createSchemaVersionTable()",
@@ -16409,7 +16433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 513
+      "community": 514
     },
     {
       "label": "getIndexNames()",
@@ -16417,7 +16441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 513
+      "community": 514
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -16425,7 +16449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createSchemaWith019()",
@@ -16433,7 +16457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 514
+      "community": 515
     },
     {
       "label": "tableExists()",
@@ -16441,7 +16465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 514
+      "community": 515
     },
     {
       "label": "columnExists()",
@@ -16449,7 +16473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 514
+      "community": 515
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -16609,7 +16633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_sqlite_agent_integration_repository_spec_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "createSession()",
@@ -16617,7 +16641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L27",
       "id": "sqlite_agent_integration_repository_spec_createsession",
-      "community": 656
+      "community": 657
     },
     {
       "label": "createObservation()",
@@ -16625,7 +16649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L59",
       "id": "sqlite_agent_integration_repository_spec_createobservation",
-      "community": 656
+      "community": 657
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -18409,7 +18433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -18417,7 +18441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 515
+      "community": 516
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -18425,7 +18449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 515
+      "community": 516
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -18433,7 +18457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 515
+      "community": 516
     },
     {
       "label": "health-checker.ts",
@@ -18521,7 +18545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "readRunDetails()",
@@ -18529,7 +18553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L15",
       "id": "memory_review_candidates_run_diagnostics_readrundetails",
-      "community": 657
+      "community": 658
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -18537,7 +18561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L46",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 657
+      "community": 658
     },
     {
       "label": "relation-validator-executor.ts",
@@ -18825,7 +18849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_timeout_resolver_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "isTripleExtractionQueueJob()",
@@ -18833,7 +18857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L5",
       "id": "batch_job_timeout_resolver_istripleextractionqueuejob",
-      "community": 516
+      "community": 517
     },
     {
       "label": "isJobTimeoutError()",
@@ -18841,7 +18865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L9",
       "id": "batch_job_timeout_resolver_isjobtimeouterror",
-      "community": 516
+      "community": 517
     },
     {
       "label": "resolveBatchJobTimeout()",
@@ -18849,7 +18873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L18",
       "id": "batch_job_timeout_resolver_resolvebatchjobtimeout",
-      "community": 516
+      "community": 517
     },
     {
       "label": "job-queue.ts",
@@ -19105,7 +19129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "createBaseSchema()",
@@ -19113,7 +19137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L12",
       "id": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
-      "community": 658
+      "community": 659
     },
     {
       "label": "createContext()",
@@ -19121,7 +19145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L41",
       "id": "batch_scheduler_review_meta_handlers_spec_createcontext",
-      "community": 658
+      "community": 659
     },
     {
       "label": "batch-scheduler-anchor-handlers.ts",
@@ -19145,7 +19169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_consolidation_relation_handlers_ts",
-      "community": 428
+      "community": 429
     },
     {
       "label": "runConsolidationScoreIncremental()",
@@ -19153,7 +19177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L5",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscoreincremental",
-      "community": 428
+      "community": 429
     },
     {
       "label": "runWeeklyRelationValidation()",
@@ -19161,7 +19185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L59",
       "id": "batch_scheduler_consolidation_relation_handlers_runweeklyrelationvalidation",
-      "community": 428
+      "community": 429
     },
     {
       "label": "runConsolidationScoreFullSweep()",
@@ -19169,7 +19193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L124",
       "id": "batch_scheduler_consolidation_relation_handlers_runconsolidationscorefullsweep",
-      "community": 428
+      "community": 429
     },
     {
       "label": "runLogRotation()",
@@ -19177,7 +19201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-consolidation-relation-handlers.ts",
       "source_location": "L179",
       "id": "batch_scheduler_consolidation_relation_handlers_runlogrotation",
-      "community": 428
+      "community": 429
     },
     {
       "label": "batch-scheduler-run-context.ts",
@@ -19193,7 +19217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -19201,7 +19225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 659
+      "community": 660
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -19209,7 +19233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 659
+      "community": 660
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -19217,7 +19241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -19225,7 +19249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 660
+      "community": 661
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -19233,7 +19257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 660
+      "community": 661
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -19241,7 +19265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -19249,7 +19273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L21",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 517
+      "community": 518
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -19257,7 +19281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L55",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 517
+      "community": 518
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -19265,7 +19289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L143",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 517
+      "community": 518
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -19273,7 +19297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_maintenance_handlers_ts",
-      "community": 429
+      "community": 430
     },
     {
       "label": "countMonitoringAlertBuckets()",
@@ -19281,7 +19305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L12",
       "id": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
-      "community": 429
+      "community": 430
     },
     {
       "label": "runMemoryCleanup()",
@@ -19289,7 +19313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_maintenance_handlers_runmemorycleanup",
-      "community": 429
+      "community": 430
     },
     {
       "label": "runMonitoring()",
@@ -19297,7 +19321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L61",
       "id": "batch_scheduler_maintenance_handlers_runmonitoring",
-      "community": 429
+      "community": 430
     },
     {
       "label": "runHealthCheck()",
@@ -19305,7 +19329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-maintenance-handlers.ts",
       "source_location": "L101",
       "id": "batch_scheduler_maintenance_handlers_runhealthcheck",
-      "community": 429
+      "community": 430
     },
     {
       "label": "file-logger.spec.ts",
@@ -19377,7 +19401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 430
+      "community": 431
     },
     {
       "label": "job()",
@@ -19385,7 +19409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 430
+      "community": 431
     },
     {
       "label": "job1()",
@@ -19393,7 +19417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 430
+      "community": 431
     },
     {
       "label": "job2()",
@@ -19401,7 +19425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 430
+      "community": 431
     },
     {
       "label": "job3()",
@@ -19409,7 +19433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 430
+      "community": 431
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -19609,7 +19633,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "TripleExtractionBatchJob",
@@ -19617,7 +19641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L31",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob",
-      "community": 518
+      "community": 519
     },
     {
       "label": ".constructor()",
@@ -19625,7 +19649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_constructor",
-      "community": 518
+      "community": 519
     },
     {
       "label": ".execute()",
@@ -19633,7 +19657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L58",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_execute",
-      "community": 518
+      "community": 519
     },
     {
       "label": "telemetry-cleanup-batch-job.spec.ts",
@@ -19649,7 +19673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -19657,7 +19681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 519
+      "community": 520
     },
     {
       "label": ".constructor()",
@@ -19665,7 +19689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 519
+      "community": 520
     },
     {
       "label": ".execute()",
@@ -19673,7 +19697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 519
+      "community": 520
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -19689,7 +19713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -19697,7 +19721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 520
+      "community": 521
     },
     {
       "label": ".constructor()",
@@ -19705,7 +19729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 520
+      "community": 521
     },
     {
       "label": ".execute()",
@@ -19713,7 +19737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 520
+      "community": 521
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -19721,7 +19745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -19729,7 +19753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 521
+      "community": 522
     },
     {
       "label": ".constructor()",
@@ -19737,7 +19761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 521
+      "community": 522
     },
     {
       "label": ".execute()",
@@ -19745,7 +19769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 521
+      "community": 522
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -19753,7 +19777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "generateId()",
@@ -19761,7 +19785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 661
+      "community": 662
     },
     {
       "label": "initializeTestDatabase()",
@@ -19769,7 +19793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 661
+      "community": 662
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -19793,7 +19817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "generateId()",
@@ -19801,7 +19825,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 662
+      "community": 663
     },
     {
       "label": "initializeTestDatabase()",
@@ -19809,7 +19833,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 662
+      "community": 663
     },
     {
       "label": "triple-extraction-batch-job-chunk.ts",
@@ -19817,7 +19841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_chunk_ts",
-      "community": 663
+      "community": 664
     },
     {
       "label": "splitTripleExtractionIntoChunks()",
@@ -19825,7 +19849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L25",
       "id": "triple_extraction_batch_job_chunk_splittripleextractionintochunks",
-      "community": 663
+      "community": 664
     },
     {
       "label": "processTripleExtractionChunk()",
@@ -19833,7 +19857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L42",
       "id": "triple_extraction_batch_job_chunk_processtripleextractionchunk",
-      "community": 663
+      "community": 664
     },
     {
       "label": "triple-extraction-batch-job.types.ts",
@@ -19857,7 +19881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_memory_status_ts",
-      "community": 664
+      "community": 665
     },
     {
       "label": "updateTripleExtractionMemoryStatus()",
@@ -19865,7 +19889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L8",
       "id": "triple_extraction_batch_job_memory_status_updatetripleextractionmemorystatus",
-      "community": 664
+      "community": 665
     },
     {
       "label": "calculateTripleExtractionAverageConfidence()",
@@ -19873,7 +19897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L43",
       "id": "triple_extraction_batch_job_memory_status_calculatetripleextractionaverageconfidence",
-      "community": 664
+      "community": 665
     },
     {
       "label": "triple-extraction-batch-job-retry.ts",
@@ -19881,7 +19905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_retry_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "getTripleExtractionRetryCount()",
@@ -19889,7 +19913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L12",
       "id": "triple_extraction_batch_job_retry_gettripleextractionretrycount",
-      "community": 522
+      "community": 523
     },
     {
       "label": "shouldRetryTripleExtraction()",
@@ -19897,7 +19921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L35",
       "id": "triple_extraction_batch_job_retry_shouldretrytripleextraction",
-      "community": 522
+      "community": 523
     },
     {
       "label": "getTripleExtractionTargetMemories()",
@@ -19905,7 +19929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L81",
       "id": "triple_extraction_batch_job_retry_gettripleextractiontargetmemories",
-      "community": 522
+      "community": 523
     },
     {
       "label": "batch-scheduler-job-control.ts",
@@ -19961,7 +19985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_context_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "createMutableJobRef()",
@@ -19969,7 +19993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L72",
       "id": "batch_scheduler_context_createmutablejobref",
-      "community": 523
+      "community": 524
     },
     {
       "label": "buildBatchSchedulerRunContext()",
@@ -19977,7 +20001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L86",
       "id": "batch_scheduler_context_buildbatchschedulerruncontext",
-      "community": 523
+      "community": 524
     },
     {
       "label": "buildBatchRecurringScheduleContext()",
@@ -19985,7 +20009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L124",
       "id": "batch_scheduler_context_buildbatchrecurringschedulecontext",
-      "community": 523
+      "community": 524
     },
     {
       "label": "batch-scheduler-diagnostics.ts",
@@ -19993,7 +20017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_diagnostics_ts",
-      "community": 665
+      "community": 666
     },
     {
       "label": "writeBatchSchedulerDiagnosticsEvent()",
@@ -20001,7 +20025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L6",
       "id": "batch_scheduler_diagnostics_writebatchschedulerdiagnosticsevent",
-      "community": 665
+      "community": 666
     },
     {
       "label": "emitMemoryReviewCandidatesRunRecord()",
@@ -20009,7 +20033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L28",
       "id": "batch_scheduler_diagnostics_emitmemoryreviewcandidatesrunrecord",
-      "community": 665
+      "community": 666
     },
     {
       "label": "batch-scheduler-job-processor.ts",
@@ -20081,7 +20105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_singleton_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "getBatchScheduler()",
@@ -20089,7 +20113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L6",
       "id": "batch_scheduler_singleton_getbatchscheduler",
-      "community": 524
+      "community": 525
     },
     {
       "label": "createBatchScheduler()",
@@ -20097,7 +20121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L13",
       "id": "batch_scheduler_singleton_createbatchscheduler",
-      "community": 524
+      "community": 525
     },
     {
       "label": "resetBatchScheduler()",
@@ -20105,7 +20129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L17",
       "id": "batch_scheduler_singleton_resetbatchscheduler",
-      "community": 524
+      "community": 525
     },
     {
       "label": "batch-scheduler-logging.ts",
@@ -20313,7 +20337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_lifecycle_ts",
-      "community": 666
+      "community": 667
     },
     {
       "label": "startBatchScheduler()",
@@ -20321,7 +20345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L30",
       "id": "batch_scheduler_lifecycle_startbatchscheduler",
-      "community": 666
+      "community": 667
     },
     {
       "label": "stopBatchScheduler()",
@@ -20329,7 +20353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L76",
       "id": "batch_scheduler_lifecycle_stopbatchscheduler",
-      "community": 666
+      "community": 667
     },
     {
       "label": "batch-scheduler-stats.ts",
@@ -20353,7 +20377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_interval_ts",
-      "community": 667
+      "community": 668
     },
     {
       "label": "scheduleBatchJob()",
@@ -20361,7 +20385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L16",
       "id": "batch_scheduler_interval_schedulebatchjob",
-      "community": 667
+      "community": 668
     },
     {
       "label": "waitForRunningBatchJobs()",
@@ -20369,7 +20393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L36",
       "id": "batch_scheduler_interval_waitforrunningbatchjobs",
-      "community": 667
+      "community": 668
     },
     {
       "label": "batch-scheduler-job-runners.ts",
@@ -20377,7 +20401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_job_runners_ts",
-      "community": 668
+      "community": 669
     },
     {
       "label": "createBatchSchedulerJobRunners()",
@@ -20385,7 +20409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L39",
       "id": "batch_scheduler_job_runners_createbatchschedulerjobrunners",
-      "community": 668
+      "community": 669
     },
     {
       "label": "runManualBatchSchedulerJob()",
@@ -20393,7 +20417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L61",
       "id": "batch_scheduler_job_runners_runmanualbatchschedulerjob",
-      "community": 668
+      "community": 669
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -20441,7 +20465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_external_api_retry_logging_ts",
-      "community": 669
+      "community": 670
     },
     {
       "label": "isTransientCapacityError()",
@@ -20449,7 +20473,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L21",
       "id": "external_api_retry_logging_istransientcapacityerror",
-      "community": 669
+      "community": 670
     },
     {
       "label": "logExternalApiRetry()",
@@ -20457,7 +20481,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L26",
       "id": "external_api_retry_logging_logexternalapiretry",
-      "community": 669
+      "community": 670
     },
     {
       "label": "stopwords.spec.ts",
@@ -20545,7 +20569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 670
+      "community": 671
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -20553,7 +20577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L39",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 670
+      "community": 671
     },
     {
       "label": ".extract()",
@@ -20561,7 +20585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L40",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 670
+      "community": 671
     },
     {
       "label": "sql-security-validator.ts",
@@ -20569,7 +20593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 671
+      "community": 672
     },
     {
       "label": "validateTableName()",
@@ -20577,7 +20601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 671
+      "community": 672
     },
     {
       "label": "getVectorTableName()",
@@ -20585,7 +20609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 671
+      "community": 672
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -20609,7 +20633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "isTestEnvironment()",
@@ -20617,7 +20641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 525
+      "community": 526
     },
     {
       "label": "isValidationDisabled()",
@@ -20625,7 +20649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 525
+      "community": 526
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -20633,7 +20657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 525
+      "community": 526
     },
     {
       "label": "db-path.spec.ts",
@@ -20713,7 +20737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 431
+      "community": 432
     },
     {
       "label": "toDbRelationType()",
@@ -20721,7 +20745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 431
+      "community": 432
     },
     {
       "label": "fromDbRelationType()",
@@ -20729,7 +20753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 431
+      "community": 432
     },
     {
       "label": "isValidDbRelationType()",
@@ -20737,7 +20761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 431
+      "community": 432
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -20745,7 +20769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 431
+      "community": 432
     },
     {
       "label": "memento-resource-uri.ts",
@@ -20753,7 +20777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_memento_resource_uri_ts",
-      "community": 432
+      "community": 433
     },
     {
       "label": "formatMementoResourceUri()",
@@ -20761,7 +20785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L21",
       "id": "memento_resource_uri_formatmementoresourceuri",
-      "community": 432
+      "community": 433
     },
     {
       "label": "parseMementoResourceUri()",
@@ -20769,7 +20793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L40",
       "id": "memento_resource_uri_parsemementoresourceuri",
-      "community": 432
+      "community": 433
     },
     {
       "label": "isMementoResourceKind()",
@@ -20777,7 +20801,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L68",
       "id": "memento_resource_uri_ismementoresourcekind",
-      "community": 432
+      "community": 433
     },
     {
       "label": "memoryItemResourceKind()",
@@ -20785,7 +20809,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L72",
       "id": "memento_resource_uri_memoryitemresourcekind",
-      "community": 432
+      "community": 433
     },
     {
       "label": "db-path.ts",
@@ -21417,7 +21441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 672
+      "community": 673
     },
     {
       "label": "issue()",
@@ -21425,7 +21449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L42",
       "id": "configuration_validator_issue",
-      "community": 672
+      "community": 673
     },
     {
       "label": "validateConfiguration()",
@@ -21433,7 +21457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L46",
       "id": "configuration_validator_validateconfiguration",
-      "community": 672
+      "community": 673
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -21505,7 +21529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 673
+      "community": 674
     },
     {
       "label": "transactionFn()",
@@ -21513,7 +21537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 673
+      "community": 674
     },
     {
       "label": "outerTransaction()",
@@ -21521,7 +21545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 673
+      "community": 674
     },
     {
       "label": "write-coalescing.ts",
@@ -21609,7 +21633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "validateReflectionNote()",
@@ -21617,7 +21641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 526
+      "community": 527
     },
     {
       "label": "validateReflectionNotes()",
@@ -21625,7 +21649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 526
+      "community": 527
     },
     {
       "label": "formatValidationErrors()",
@@ -21633,7 +21657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 526
+      "community": 527
     },
     {
       "label": "environment-check.spec.ts",
@@ -21969,7 +21993,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 674
+      "community": 675
     },
     {
       "label": "createValidReflectionNote()",
@@ -21977,7 +22001,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 674
+      "community": 675
     },
     {
       "label": "createLargeNote()",
@@ -21985,7 +22009,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 674
+      "community": 675
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -22233,7 +22257,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 433
+      "community": 434
     },
     {
       "label": "getStopWords()",
@@ -22241,7 +22265,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 433
+      "community": 434
     },
     {
       "label": "getEnglishStopWords()",
@@ -22249,7 +22273,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 433
+      "community": 434
     },
     {
       "label": "getKoreanStopWords()",
@@ -22257,7 +22281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 433
+      "community": 434
     },
     {
       "label": "isStopWord()",
@@ -22265,7 +22289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 433
+      "community": 434
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -22409,7 +22433,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_database_error_helpers_ts",
-      "community": 434
+      "community": 435
     },
     {
       "label": "log()",
@@ -22417,7 +22441,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L3",
       "id": "database_error_helpers_log",
-      "community": 434
+      "community": 435
     },
     {
       "label": "getSqliteErrorCode()",
@@ -22425,7 +22449,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L9",
       "id": "database_error_helpers_getsqliteerrorcode",
-      "community": 434
+      "community": 435
     },
     {
       "label": "getErrorMessage()",
@@ -22433,7 +22457,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L18",
       "id": "database_error_helpers_geterrormessage",
-      "community": 434
+      "community": 435
     },
     {
       "label": "getErrorName()",
@@ -22441,7 +22465,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L27",
       "id": "database_error_helpers_geterrorname",
-      "community": 434
+      "community": 435
     },
     {
       "label": "transaction-helpers.ts",
@@ -22497,7 +22521,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_query_helpers_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "runQuery()",
@@ -22505,7 +22529,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L5",
       "id": "query_helpers_runquery",
-      "community": 435
+      "community": 436
     },
     {
       "label": "getQuery()",
@@ -22513,7 +22537,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L36",
       "id": "query_helpers_getquery",
-      "community": 435
+      "community": 436
     },
     {
       "label": "allQuery()",
@@ -22521,7 +22545,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L67",
       "id": "query_helpers_allquery",
-      "community": 435
+      "community": 436
     },
     {
       "label": "execQuery()",
@@ -22529,7 +22553,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L98",
       "id": "query_helpers_execquery",
-      "community": 435
+      "community": 436
     },
     {
       "label": "wal-and-status.ts",
@@ -22537,7 +22561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_wal_and_status_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "isDatabaseOpen()",
@@ -22545,7 +22569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L7",
       "id": "wal_and_status_isdatabaseopen",
-      "community": 527
+      "community": 528
     },
     {
       "label": "checkpointWAL()",
@@ -22553,7 +22577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L23",
       "id": "wal_and_status_checkpointwal",
-      "community": 527
+      "community": 528
     },
     {
       "label": "getDatabaseStatus()",
@@ -22561,7 +22585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L33",
       "id": "wal_and_status_getdatabasestatus",
-      "community": 527
+      "community": 528
     },
     {
       "label": "schema-initialization.ts",
@@ -22689,7 +22713,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 675
+      "community": 676
     },
     {
       "label": "isMemoryItemType()",
@@ -22697,7 +22721,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 675
+      "community": 676
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -22705,7 +22729,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 675
+      "community": 676
     },
     {
       "label": "error-types.ts",
@@ -22737,7 +22761,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "isApplicableRelationType()",
@@ -22745,7 +22769,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L155",
       "id": "relation_isapplicablerelationtype",
-      "community": 528
+      "community": 529
     },
     {
       "label": "getRelationCategory()",
@@ -22753,7 +22777,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L165",
       "id": "relation_getrelationcategory",
-      "community": 528
+      "community": 529
     },
     {
       "label": "getRelationBoost()",
@@ -22761,7 +22785,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L172",
       "id": "relation_getrelationboost",
-      "community": 528
+      "community": 529
     },
     {
       "label": "search.types.ts",
@@ -22993,7 +23017,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_llm_model_resolver_ts",
-      "community": 676
+      "community": 677
     },
     {
       "label": "resolveProviderDefaultModel()",
@@ -23001,7 +23025,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L28",
       "id": "llm_model_resolver_resolveproviderdefaultmodel",
-      "community": 676
+      "community": 677
     },
     {
       "label": "resolveLlmModel()",
@@ -23009,7 +23033,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L51",
       "id": "llm_model_resolver_resolvellmmodel",
-      "community": 676
+      "community": 677
     },
     {
       "label": "index.ts",
@@ -23337,7 +23361,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "LLMClientInitializer",
@@ -23345,7 +23369,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L32",
       "id": "llm_client_initializer_llmclientinitializer",
-      "community": 436
+      "community": 437
     },
     {
       "label": ".constructor()",
@@ -23353,7 +23377,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L39",
       "id": "llm_client_initializer_llmclientinitializer_constructor",
-      "community": 436
+      "community": 437
     },
     {
       "label": ".initialize()",
@@ -23361,7 +23385,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L60",
       "id": "llm_client_initializer_llmclientinitializer_initialize",
-      "community": 436
+      "community": 437
     },
     {
       "label": ".validateApiKeys()",
@@ -23369,7 +23393,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L106",
       "id": "llm_client_initializer_llmclientinitializer_validateapikeys",
-      "community": 436
+      "community": 437
     },
     {
       "label": "llm-client-initializer.test-setup.ts",
@@ -23377,7 +23401,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 677
+      "community": 678
     },
     {
       "label": "getMockMementoConfig()",
@@ -23385,7 +23409,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L21",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 677
+      "community": 678
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -23393,7 +23417,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L50",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 677
+      "community": 678
     },
     {
       "label": "initialize.spec.ts",
@@ -23609,7 +23633,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_ollama_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "handleOllamaResponse()",
@@ -23617,7 +23641,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L12",
       "id": "ollama_handleollamaresponse",
-      "community": 437
+      "community": 438
     },
     {
       "label": "shouldRetryOllamaConnection()",
@@ -23625,7 +23649,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L57",
       "id": "ollama_shouldretryollamaconnection",
-      "community": 437
+      "community": 438
     },
     {
       "label": "getOllamaErrorMessage()",
@@ -23633,7 +23657,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L76",
       "id": "ollama_getollamaerrormessage",
-      "community": 437
+      "community": 438
     },
     {
       "label": "testOllamaConnection()",
@@ -23641,7 +23665,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L94",
       "id": "ollama_testollamaconnection",
-      "community": 437
+      "community": 438
     },
     {
       "label": "openai.ts",
@@ -23689,7 +23713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "SearchLocalTool",
@@ -23697,7 +23721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 529
+      "community": 530
     },
     {
       "label": ".constructor()",
@@ -23705,7 +23729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 529
+      "community": 530
     },
     {
       "label": ".handle()",
@@ -23713,7 +23737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 529
+      "community": 530
     },
     {
       "label": "get-anchor-tool.ts",
@@ -23721,7 +23745,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "GetAnchorTool",
@@ -23729,7 +23753,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 530
+      "community": 531
     },
     {
       "label": ".constructor()",
@@ -23737,7 +23761,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 530
+      "community": 531
     },
     {
       "label": ".handle()",
@@ -23745,7 +23769,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 530
+      "community": 531
     },
     {
       "label": "set-anchor-tool.ts",
@@ -23753,7 +23777,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "SetAnchorTool",
@@ -23761,7 +23785,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 531
+      "community": 532
     },
     {
       "label": ".constructor()",
@@ -23769,7 +23793,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 531
+      "community": 532
     },
     {
       "label": ".handle()",
@@ -23777,7 +23801,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 531
+      "community": 532
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -23785,7 +23809,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "ClearAnchorTool",
@@ -23793,7 +23817,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 532
+      "community": 533
     },
     {
       "label": ".constructor()",
@@ -23801,7 +23825,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 532
+      "community": 533
     },
     {
       "label": ".handle()",
@@ -23809,7 +23833,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 532
+      "community": 533
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -23817,7 +23841,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "RestoreAnchorsTool",
@@ -23825,7 +23849,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 533
+      "community": 534
     },
     {
       "label": ".constructor()",
@@ -23833,7 +23857,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 533
+      "community": 534
     },
     {
       "label": ".handle()",
@@ -23841,7 +23865,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 533
+      "community": 534
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -23849,7 +23873,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "initializeTestDatabase()",
@@ -23857,7 +23881,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMockEmbeddingService()",
@@ -23865,7 +23889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -23873,7 +23897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 438
+      "community": 439
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -23881,7 +23905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 438
+      "community": 439
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -23889,7 +23913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "initializeTestDatabase()",
@@ -23897,7 +23921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMockEmbeddingService()",
@@ -23905,7 +23929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -23913,7 +23937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 439
+      "community": 440
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -23921,7 +23945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 439
+      "community": 440
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -23929,7 +23953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "initializeTestDatabase()",
@@ -23937,7 +23961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createMockEmbeddingService()",
@@ -23945,7 +23969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -23953,7 +23977,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 440
+      "community": 441
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -23961,7 +23985,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 440
+      "community": 441
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -24009,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "QueryFilterStrategy",
@@ -24017,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".constructor()",
@@ -24025,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".filter()",
@@ -24033,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".execute()",
@@ -24041,7 +24065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 441
+      "community": 442
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -24377,7 +24401,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "NHopSearchStrategy",
@@ -24385,7 +24409,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 442
+      "community": 443
     },
     {
       "label": ".constructor()",
@@ -24393,7 +24417,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 442
+      "community": 443
     },
     {
       "label": ".search()",
@@ -24401,7 +24425,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 442
+      "community": 443
     },
     {
       "label": ".execute()",
@@ -24409,7 +24433,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 442
+      "community": 443
     },
     {
       "label": "query-filter-service.ts",
@@ -24561,7 +24585,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "FallbackSearchService",
@@ -24569,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 443
+      "community": 444
     },
     {
       "label": ".setDatabase()",
@@ -24577,7 +24601,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 443
+      "community": 444
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -24585,7 +24609,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 443
+      "community": 444
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -24593,7 +24617,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 443
+      "community": 444
     },
     {
       "label": "index.ts",
@@ -24609,7 +24633,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "FallbackStrategy",
@@ -24617,7 +24641,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 444
+      "community": 445
     },
     {
       "label": ".constructor()",
@@ -24625,7 +24649,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 444
+      "community": 445
     },
     {
       "label": ".fallback()",
@@ -24633,7 +24657,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 444
+      "community": 445
     },
     {
       "label": ".execute()",
@@ -24641,7 +24665,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 444
+      "community": 445
     },
     {
       "label": "anchor-search-service.ts",
@@ -25073,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_store_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "key()",
@@ -25081,7 +25105,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L13",
       "id": "store_key",
-      "community": 534
+      "community": 535
     },
     {
       "label": "buildSnapshotsFromFixture()",
@@ -25089,7 +25113,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L38",
       "id": "store_buildsnapshotsfromfixture",
-      "community": 534
+      "community": 535
     },
     {
       "label": "getFixtureSnapshot()",
@@ -25097,7 +25121,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L172",
       "id": "store_getfixturesnapshot",
-      "community": 534
+      "community": 535
     },
     {
       "label": "types.ts",
@@ -25121,7 +25145,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_getters_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "EvolutionDemoNotFoundError",
@@ -25129,7 +25153,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L44",
       "id": "getters_evolutiondemonotfounderror",
-      "community": 445
+      "community": 446
     },
     {
       "label": ".constructor()",
@@ -25137,7 +25161,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L45",
       "id": "getters_evolutiondemonotfounderror_constructor",
-      "community": 445
+      "community": 446
     },
     {
       "label": "listEvolutionDemoScenarios()",
@@ -25145,7 +25169,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L55",
       "id": "getters_listevolutiondemoscenarios",
-      "community": 445
+      "community": 446
     },
     {
       "label": "getEvolutionDemoSnapshot()",
@@ -25153,7 +25177,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L61",
       "id": "getters_getevolutiondemosnapshot",
-      "community": 445
+      "community": 446
     },
     {
       "label": "spec.ts",
@@ -25329,7 +25353,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "SearchResultCombiner",
@@ -25337,7 +25361,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L24",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 535
+      "community": 536
     },
     {
       "label": ".combine()",
@@ -25345,7 +25369,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L36",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 535
+      "community": 536
     },
     {
       "label": ".generateHybridReason()",
@@ -25353,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L109",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 535
+      "community": 536
     },
     {
       "label": "hybrid-result-ranker.ts",
@@ -25601,7 +25625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_adaptive_weight_calculator_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "AdaptiveWeightCalculator",
@@ -25609,7 +25633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L4",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".calculateWeights()",
@@ -25617,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L7",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_calculateweights",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".analyzeQuery()",
@@ -25625,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L57",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_analyzequery",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".normalizeQuery()",
@@ -25633,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L71",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_normalizequery",
-      "community": 446
+      "community": 447
     },
     {
       "label": "hybrid-vector-search-executor.ts",
@@ -25777,7 +25801,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -25785,7 +25809,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 536
+      "community": 537
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -25793,7 +25817,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 536
+      "community": 537
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -25801,7 +25825,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 536
+      "community": 537
     },
     {
       "label": "search-ranking.ts",
@@ -26289,7 +26313,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_error_ts",
-      "community": 678
+      "community": 679
     },
     {
       "label": "SearchError",
@@ -26297,7 +26321,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L11",
       "id": "search_error_searcherror",
-      "community": 678
+      "community": 679
     },
     {
       "label": ".constructor()",
@@ -26305,7 +26329,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L12",
       "id": "search_error_searcherror_constructor",
-      "community": 678
+      "community": 679
     },
     {
       "label": "search-logger.ts",
@@ -26433,7 +26457,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "normalize()",
@@ -26441,7 +26465,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 537
+      "community": 538
     },
     {
       "label": "toSet()",
@@ -26449,7 +26473,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 537
+      "community": 538
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -26457,7 +26481,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 537
+      "community": 538
     },
     {
       "label": "search-ranking.types.ts",
@@ -26745,7 +26769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 679
+      "community": 680
     },
     {
       "label": "initializeTestDatabase()",
@@ -26753,7 +26777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 679
+      "community": 680
     },
     {
       "label": "createValidReflectionNote()",
@@ -26761,7 +26785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 679
+      "community": 680
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -26857,7 +26881,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createCountingSearchDb()",
@@ -26865,7 +26889,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -26873,7 +26897,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 538
+      "community": 539
     },
     {
       "label": "createSearchRows()",
@@ -26881,7 +26905,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 538
+      "community": 539
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -26897,7 +26921,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_ranking_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "attachBreakdownToDisplayTotal()",
@@ -26905,7 +26929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L12",
       "id": "search_engine_ranking_attachbreakdowntodisplaytotal",
-      "community": 447
+      "community": 448
     },
     {
       "label": "calculateFactMetadataBoost()",
@@ -26913,7 +26937,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L29",
       "id": "search_engine_ranking_calculatefactmetadataboost",
-      "community": 447
+      "community": 448
     },
     {
       "label": "generateRecallReason()",
@@ -26921,7 +26945,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L38",
       "id": "search_engine_ranking_generaterecallreason",
-      "community": 447
+      "community": 448
     },
     {
       "label": "applyRanking()",
@@ -26929,7 +26953,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L66",
       "id": "search_engine_ranking_applyranking",
-      "community": 447
+      "community": 448
     },
     {
       "label": "search-engine-fts-query.ts",
@@ -26937,7 +26961,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_fts_query_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "buildFTSQuery()",
@@ -26945,7 +26969,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L9",
       "id": "search_engine_fts_query_buildftsquery",
-      "community": 539
+      "community": 540
     },
     {
       "label": "preprocessQuery()",
@@ -26953,7 +26977,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L38",
       "id": "search_engine_fts_query_preprocessquery",
-      "community": 539
+      "community": 540
     },
     {
       "label": "makeFTSSafe()",
@@ -26961,7 +26985,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L53",
       "id": "search_engine_fts_query_makeftssafe",
-      "community": 539
+      "community": 540
     },
     {
       "label": "search-engine.types.ts",
@@ -27265,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_result_mapper_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "safeParseTags()",
@@ -27273,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L10",
       "id": "vector_search_result_mapper_safeparsetags",
-      "community": 540
+      "community": 541
     },
     {
       "label": "mapKnnResults()",
@@ -27281,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L25",
       "id": "vector_search_result_mapper_mapknnresults",
-      "community": 540
+      "community": 541
     },
     {
       "label": "mapHybridResults()",
@@ -27289,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.ts",
       "source_location": "L53",
       "id": "vector_search_result_mapper_maphybridresults",
-      "community": 540
+      "community": 541
     },
     {
       "label": "vector-search-knn-query.ts",
@@ -27297,7 +27321,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_knn_query_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "buildScopeParams()",
@@ -27305,7 +27329,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L25",
       "id": "vector_search_knn_query_buildscopeparams",
-      "community": 541
+      "community": 542
     },
     {
       "label": "buildOuterWhereSql()",
@@ -27313,7 +27337,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L38",
       "id": "vector_search_knn_query_buildouterwheresql",
-      "community": 541
+      "community": 542
     },
     {
       "label": "executeKnnQuery()",
@@ -27321,7 +27345,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L54",
       "id": "vector_search_knn_query_executeknnquery",
-      "community": 541
+      "community": 542
     },
     {
       "label": "vector-search-runtime-context.ts",
@@ -27393,7 +27417,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_availability_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "isVecTableRegistered()",
@@ -27401,7 +27425,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L11",
       "id": "vector_search_availability_isvectableregistered",
-      "community": 448
+      "community": 449
     },
     {
       "label": "checkVecAvailability()",
@@ -27409,7 +27433,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L26",
       "id": "vector_search_availability_checkvecavailability",
-      "community": 448
+      "community": 449
     },
     {
       "label": "getIndexStatus()",
@@ -27417,7 +27441,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L104",
       "id": "vector_search_availability_getindexstatus",
-      "community": 448
+      "community": 449
     },
     {
       "label": "rebuildIndex()",
@@ -27425,7 +27449,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L162",
       "id": "vector_search_availability_rebuildindex",
-      "community": 448
+      "community": 449
     },
     {
       "label": "vector-search-scope.ts",
@@ -27449,7 +27473,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_hybrid_query_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "buildScopeParams()",
@@ -27457,7 +27481,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L26",
       "id": "vector_search_hybrid_query_buildscopeparams",
-      "community": 449
+      "community": 450
     },
     {
       "label": "buildItemScopeClause()",
@@ -27465,7 +27489,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L39",
       "id": "vector_search_hybrid_query_builditemscopeclause",
-      "community": 449
+      "community": 450
     },
     {
       "label": "buildItemWhereSql()",
@@ -27473,7 +27497,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L52",
       "id": "vector_search_hybrid_query_builditemwheresql",
-      "community": 449
+      "community": 450
     },
     {
       "label": "executeHybridQuery()",
@@ -27481,7 +27505,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L68",
       "id": "vector_search_hybrid_query_executehybridquery",
-      "community": 449
+      "community": 450
     },
     {
       "label": "vector-search.service.ts",
@@ -27921,7 +27945,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "selectScore()",
@@ -27929,7 +27953,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 450
+      "community": 451
     },
     {
       "label": "computeNormalizationRange()",
@@ -27937,7 +27961,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 450
+      "community": 451
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -27945,7 +27969,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 450
+      "community": 451
     },
     {
       "label": ".normalize()",
@@ -27953,7 +27977,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 450
+      "community": 451
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -28585,7 +28609,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "ForgettingStatsTool",
@@ -28593,7 +28617,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 542
+      "community": 543
     },
     {
       "label": ".constructor()",
@@ -28601,7 +28625,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 542
+      "community": 543
     },
     {
       "label": ".handle()",
@@ -28609,7 +28633,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 542
+      "community": 543
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -29761,7 +29785,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_system_metrics_query_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "toolBucketFromEvents()",
@@ -29769,7 +29793,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L15",
       "id": "telemetry_system_metrics_query_toolbucketfromevents",
-      "community": 543
+      "community": 544
     },
     {
       "label": "mapJob()",
@@ -29777,7 +29801,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L65",
       "id": "telemetry_system_metrics_query_mapjob",
-      "community": 543
+      "community": 544
     },
     {
       "label": "querySystemMetrics()",
@@ -29785,7 +29809,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L81",
       "id": "telemetry_system_metrics_query_querysystemmetrics",
-      "community": 543
+      "community": 544
     },
     {
       "label": "telemetry-feedback-quality-query.ts",
@@ -29833,7 +29857,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_search_quality_query_ts",
-      "community": 680
+      "community": 681
     },
     {
       "label": "avgCandidateCountForPeriod()",
@@ -29841,7 +29865,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L11",
       "id": "telemetry_search_quality_query_avgcandidatecountforperiod",
-      "community": 680
+      "community": 681
     },
     {
       "label": "querySearchQuality()",
@@ -29849,7 +29873,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L37",
       "id": "telemetry_search_quality_query_querysearchquality",
-      "community": 680
+      "community": 681
     },
     {
       "label": "telemetry-repository.ts",
@@ -29977,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_utils_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "periodCutoffIso()",
@@ -29985,7 +30009,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L3",
       "id": "telemetry_repository_utils_periodcutoffiso",
-      "community": 544
+      "community": 545
     },
     {
       "label": "rolling24hCutoffIso()",
@@ -29993,7 +30017,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L15",
       "id": "telemetry_repository_utils_rolling24hcutoffiso",
-      "community": 544
+      "community": 545
     },
     {
       "label": "percentile95Sorted()",
@@ -30001,7 +30025,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L22",
       "id": "telemetry_repository_utils_percentile95sorted",
-      "community": 544
+      "community": 545
     },
     {
       "label": "telemetry-memory-quality-query.ts",
@@ -30009,7 +30033,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_memory_quality_query_ts",
-      "community": 681
+      "community": 682
     },
     {
       "label": "queryMemoryQuality()",
@@ -30017,7 +30041,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L8",
       "id": "telemetry_memory_quality_query_querymemoryquality",
-      "community": 681
+      "community": 682
     },
     {
       "label": "queryConsolidationQuality()",
@@ -30025,7 +30049,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L82",
       "id": "telemetry_memory_quality_query_queryconsolidationquality",
-      "community": 681
+      "community": 682
     },
     {
       "label": "get-telemetry-summary-tool.spec.ts",
@@ -30081,7 +30105,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -30089,7 +30113,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 545
+      "community": 546
     },
     {
       "label": ".constructor()",
@@ -30097,7 +30121,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 545
+      "community": 546
     },
     {
       "label": ".handle()",
@@ -30105,7 +30129,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 545
+      "community": 546
     },
     {
       "label": "audit-hash-chain-service.ts",
@@ -30497,7 +30521,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "baseTags()",
@@ -30505,7 +30529,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 546
+      "community": 547
     },
     {
       "label": "pushUnique()",
@@ -30513,7 +30537,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 546
+      "community": 547
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -30521,7 +30545,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 546
+      "community": 547
     },
     {
       "label": "personal-agent-llm-error.ts",
@@ -30529,7 +30553,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "PersonalAgentLlmError",
@@ -30537,7 +30561,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L12",
       "id": "personal_agent_llm_error_personalagentllmerror",
-      "community": 547
+      "community": 548
     },
     {
       "label": ".constructor()",
@@ -30545,7 +30569,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L15",
       "id": "personal_agent_llm_error_personalagentllmerror_constructor",
-      "community": 547
+      "community": 548
     },
     {
       "label": "isPersonalAgentLlmError()",
@@ -30553,7 +30577,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L22",
       "id": "personal_agent_llm_error_ispersonalagentllmerror",
-      "community": 547
+      "community": 548
     },
     {
       "label": "personal-agent-llm-error.spec.ts",
@@ -30601,7 +30625,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 682
+      "community": 683
     },
     {
       "label": "readProviderToken()",
@@ -30609,7 +30633,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 682
+      "community": 683
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -30617,7 +30641,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 682
+      "community": 683
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -30641,7 +30665,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "parseRememberSuccess()",
@@ -30649,7 +30673,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 451
+      "community": 452
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -30657,7 +30681,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 451
+      "community": 452
     },
     {
       "label": ".constructor()",
@@ -30665,7 +30689,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 451
+      "community": 452
     },
     {
       "label": ".persistApproved()",
@@ -30673,7 +30697,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 451
+      "community": 452
     },
     {
       "label": "openai-chat-llm-adapter.ts",
@@ -30681,7 +30705,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "OpenAiChatLlmAdapter",
@@ -30689,7 +30713,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "openai_chat_llm_adapter_openaichatllmadapter",
-      "community": 548
+      "community": 549
     },
     {
       "label": ".constructor()",
@@ -30697,7 +30721,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
-      "community": 548
+      "community": 549
     },
     {
       "label": ".complete()",
@@ -30705,7 +30729,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_complete",
-      "community": 548
+      "community": 549
     },
     {
       "label": "openai-chat-llm-adapter.spec.ts",
@@ -30721,7 +30745,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "OllamaChatLlmAdapter",
@@ -30729,7 +30753,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter",
-      "community": 549
+      "community": 550
     },
     {
       "label": ".constructor()",
@@ -30737,7 +30761,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
-      "community": 549
+      "community": 550
     },
     {
       "label": ".complete()",
@@ -30745,7 +30769,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L27",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
-      "community": 549
+      "community": 550
     },
     {
       "label": "gemini-chat-llm-adapter.ts",
@@ -30753,7 +30777,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "GeminiChatLlmAdapter",
@@ -30761,7 +30785,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L10",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter",
-      "community": 550
+      "community": 551
     },
     {
       "label": ".constructor()",
@@ -30769,7 +30793,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L14",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
-      "community": 550
+      "community": 551
     },
     {
       "label": ".complete()",
@@ -30777,7 +30801,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L19",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
-      "community": 550
+      "community": 551
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -30785,7 +30809,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -30793,7 +30817,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 452
+      "community": 453
     },
     {
       "label": ".constructor()",
@@ -30801,7 +30825,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 452
+      "community": 453
     },
     {
       "label": ".buildContext()",
@@ -30809,7 +30833,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 452
+      "community": 453
     },
     {
       "label": ".proposeCandidates()",
@@ -30817,7 +30841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 452
+      "community": 453
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -30825,7 +30849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -30833,7 +30857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 453
+      "community": 454
     },
     {
       "label": ".constructor()",
@@ -30841,7 +30865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 453
+      "community": 454
     },
     {
       "label": ".complete()",
@@ -30849,7 +30873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 453
+      "community": 454
     },
     {
       "label": ".createRequestId()",
@@ -30857,7 +30881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 453
+      "community": 454
     },
     {
       "label": "gemini-chat-llm-adapter.spec.ts",
@@ -30905,7 +30929,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "normalizeOwnerId()",
@@ -30913,7 +30937,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 454
+      "community": 455
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -30921,7 +30945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 454
+      "community": 455
     },
     {
       "label": "assertUnreachable()",
@@ -30929,7 +30953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 454
+      "community": 455
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -30937,7 +30961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 454
+      "community": 455
     },
     {
       "label": "create-personal-agent-llm-port.spec.ts",
@@ -30969,7 +30993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -30977,7 +31001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 455
+      "community": 456
     },
     {
       "label": ".constructor()",
@@ -30985,7 +31009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 455
+      "community": 456
     },
     {
       "label": ".runOneTurn()",
@@ -30993,7 +31017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 455
+      "community": 456
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -31001,7 +31025,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 455
+      "community": 456
     },
     {
       "label": "create-personal-agent-llm-port.ts",
@@ -31177,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_memory_item_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "buildSimilarityWarning()",
@@ -31185,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L39",
       "id": "remember_tool_memory_item_buildsimilaritywarning",
-      "community": 551
+      "community": 552
     },
     {
       "label": "persistMemoryItem()",
@@ -31193,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L71",
       "id": "remember_tool_memory_item_persistmemoryitem",
-      "community": 551
+      "community": 552
     },
     {
       "label": "handleMemoryItem()",
@@ -31201,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L195",
       "id": "remember_tool_memory_item_handlememoryitem",
-      "community": 551
+      "community": 552
     },
     {
       "label": "recall-tool-definition.ts",
@@ -31225,7 +31249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_reflection_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "validateReflectionNotesJson()",
@@ -31233,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L19",
       "id": "remember_tool_reflection_validatereflectionnotesjson",
-      "community": 456
+      "community": 457
     },
     {
       "label": "parseReflectionNotes()",
@@ -31241,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L27",
       "id": "remember_tool_reflection_parsereflectionnotes",
-      "community": 456
+      "community": 457
     },
     {
       "label": "getExistingReflectionNotes()",
@@ -31249,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L53",
       "id": "remember_tool_reflection_getexistingreflectionnotes",
-      "community": 456
+      "community": 457
     },
     {
       "label": "prepareReflectionNotes()",
@@ -31257,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L82",
       "id": "remember_tool_reflection_preparereflectionnotes",
-      "community": 456
+      "community": 457
     },
     {
       "label": "remember-tool.ts",
@@ -31265,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "RememberTool",
@@ -31273,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L27",
       "id": "remember_tool_remembertool",
-      "community": 552
+      "community": 553
     },
     {
       "label": ".constructor()",
@@ -31281,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L28",
       "id": "remember_tool_remembertool_constructor",
-      "community": 552
+      "community": 553
     },
     {
       "label": ".handle()",
@@ -31289,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L129",
       "id": "remember_tool_remembertool_handle",
-      "community": 552
+      "community": 553
     },
     {
       "label": "remember-tool-vault.ts",
@@ -31313,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 683
+      "community": 684
     },
     {
       "label": "validateRecallQuery()",
@@ -31321,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 683
+      "community": 684
     },
     {
       "label": "validateRecallFilters()",
@@ -31329,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 683
+      "community": 684
     },
     {
       "label": "recall-tool-schema.ts",
@@ -31353,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_db_helpers_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "findExistingProceduralMemory()",
@@ -31361,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L11",
       "id": "remember_tool_db_helpers_findexistingproceduralmemory",
-      "community": 553
+      "community": 554
     },
     {
       "label": "getExistingMemoriesForRelationExtraction()",
@@ -31369,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L78",
       "id": "remember_tool_db_helpers_getexistingmemoriesforrelationextraction",
-      "community": 553
+      "community": 554
     },
     {
       "label": "getMemoryById()",
@@ -31377,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L119",
       "id": "remember_tool_db_helpers_getmemorybyid",
-      "community": 553
+      "community": 554
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -31385,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -31393,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L30",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".constructor()",
@@ -31401,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L31",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".handle()",
@@ -31409,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L84",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 554
+      "community": 555
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -31417,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -31425,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".constructor()",
@@ -31433,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".handle()",
@@ -31441,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 555
+      "community": 556
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -31449,7 +31473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "ProceduralRollbackTool",
@@ -31457,7 +31481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 556
+      "community": 557
     },
     {
       "label": ".constructor()",
@@ -31465,7 +31489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 556
+      "community": 557
     },
     {
       "label": ".handle()",
@@ -31473,7 +31497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 556
+      "community": 557
     },
     {
       "label": "feedback-tool.ts",
@@ -31537,7 +31561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "CleanupMemoryTool",
@@ -31545,7 +31569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".constructor()",
@@ -31553,7 +31577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".handle()",
@@ -31561,7 +31585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 557
+      "community": 558
     },
     {
       "label": "recall-tool-filters.ts",
@@ -31569,7 +31593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 684
+      "community": 685
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -31577,7 +31601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 684
+      "community": 685
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -31585,7 +31609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 684
+      "community": 685
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -31913,7 +31937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "ProceduralDiffTool",
@@ -31921,7 +31945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 558
+      "community": 559
     },
     {
       "label": ".constructor()",
@@ -31929,7 +31953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 558
+      "community": 559
     },
     {
       "label": ".handle()",
@@ -31937,7 +31961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 558
+      "community": 559
     },
     {
       "label": "remember-tool-types.ts",
@@ -31953,7 +31977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_direct_ts",
-      "community": 685
+      "community": 686
     },
     {
       "label": "recallCoreMemoryDirect()",
@@ -31961,7 +31985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L13",
       "id": "recall_tool_direct_recallcorememorydirect",
-      "community": 685
+      "community": 686
     },
     {
       "label": "recallVaultMemoryDirect()",
@@ -31969,7 +31993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L67",
       "id": "recall_tool_direct_recallvaultmemorydirect",
-      "community": 685
+      "community": 686
     },
     {
       "label": "unpin-tool.ts",
@@ -32161,7 +32185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -32169,7 +32193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".constructor()",
@@ -32177,7 +32201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".handle()",
@@ -32185,7 +32209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 559
+      "community": 560
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -32193,7 +32217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "RememberProcedureTool",
@@ -32201,7 +32225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 560
+      "community": 561
     },
     {
       "label": ".constructor()",
@@ -32209,7 +32233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 560
+      "community": 561
     },
     {
       "label": ".handle()",
@@ -32217,7 +32241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 560
+      "community": 561
     },
     {
       "label": "recall-tool-envelope.ts",
@@ -32225,7 +32249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 686
+      "community": 687
     },
     {
       "label": "getMetaStatsForResults()",
@@ -32233,7 +32257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L35",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 686
+      "community": 687
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -32241,7 +32265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L79",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 686
+      "community": 687
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -32249,7 +32273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -32257,7 +32281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 457
+      "community": 458
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -32265,7 +32289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 457
+      "community": 458
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -32273,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 457
+      "community": 458
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -32281,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 457
+      "community": 458
     },
     {
       "label": "export-memories-tool.ts",
@@ -32641,7 +32665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 687
+      "community": 688
     },
     {
       "label": "initializeTestDatabase()",
@@ -32649,7 +32673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 687
+      "community": 688
     },
     {
       "label": "createValidReflectionNote()",
@@ -32657,7 +32681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L848",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 687
+      "community": 688
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -32705,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "generateId()",
@@ -32713,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 561
+      "community": 562
     },
     {
       "label": "initializeTestDatabase()",
@@ -32721,7 +32745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 561
+      "community": 562
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -32729,7 +32753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 561
+      "community": 562
     },
     {
       "label": "forget-tool.spec.ts",
@@ -32793,7 +32817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 688
+      "community": 689
     },
     {
       "label": "initializeTestDatabase()",
@@ -32801,7 +32825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 688
+      "community": 689
     },
     {
       "label": "createValidReflectionNote()",
@@ -32809,7 +32833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1508",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 688
+      "community": 689
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -32825,7 +32849,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
-      "community": 689
+      "community": 690
     },
     {
       "label": "initializeProductionLikeSchema()",
@@ -32833,7 +32857,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L15",
       "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
-      "community": 689
+      "community": 690
     },
     {
       "label": "createHost()",
@@ -32841,7 +32865,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L33",
       "id": "remember_tool_relation_load_spec_createhost",
-      "community": 689
+      "community": 690
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -32985,7 +33009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "fieldDiff()",
@@ -32993,7 +33017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 562
+      "community": 563
     },
     {
       "label": "parseStepsJson()",
@@ -33001,7 +33025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 562
+      "community": 563
     },
     {
       "label": "computeProceduralDiff()",
@@ -33009,7 +33033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 562
+      "community": 563
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -33017,7 +33041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -33025,7 +33049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".constructor()",
@@ -33033,7 +33057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".notFound()",
@@ -33041,7 +33065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".notActionable()",
@@ -33049,7 +33073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 458
+      "community": 459
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -33209,7 +33233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "getVersionChain()",
@@ -33217,7 +33241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 563
+      "community": 564
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -33225,7 +33249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 563
+      "community": 564
     },
     {
       "label": "getNextVersionNumber()",
@@ -33233,7 +33257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 563
+      "community": 564
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -33241,7 +33265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 690
+      "community": 691
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -33249,7 +33273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 690
+      "community": 691
     },
     {
       "label": ".runScan()",
@@ -33257,7 +33281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 690
+      "community": 691
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -33265,7 +33289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 691
+      "community": 692
     },
     {
       "label": "generateMemoryId()",
@@ -33273,7 +33297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 691
+      "community": 692
     },
     {
       "label": "rollbackToVersion()",
@@ -33281,7 +33305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 691
+      "community": 692
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -33353,7 +33377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 692
+      "community": 693
     },
     {
       "label": "selectionWindowLimit()",
@@ -33361,7 +33385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 692
+      "community": 693
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -33369,7 +33393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 692
+      "community": 693
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -33377,7 +33401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "IntrospectionScanCache",
@@ -33385,7 +33409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 459
+      "community": 460
     },
     {
       "label": ".set()",
@@ -33393,7 +33417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 459
+      "community": 460
     },
     {
       "label": ".get()",
@@ -33401,7 +33425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 459
+      "community": 460
     },
     {
       "label": ".clear()",
@@ -33409,7 +33433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 459
+      "community": 460
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -34489,7 +34513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 693
+      "community": 694
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -34497,7 +34521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 693
+      "community": 694
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -34505,7 +34529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 693
+      "community": 694
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -35025,7 +35049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_crud_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "SemanticMemoryCrud",
@@ -35033,7 +35057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L16",
       "id": "semantic_memory_crud_semanticmemorycrud",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".constructor()",
@@ -35041,7 +35065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L17",
       "id": "semantic_memory_crud_semanticmemorycrud_constructor",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".createSemanticMemory()",
@@ -35049,7 +35073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L23",
       "id": "semantic_memory_crud_semanticmemorycrud_createsemanticmemory",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".updateExistingSemanticMemory()",
@@ -35057,7 +35081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L79",
       "id": "semantic_memory_crud_semanticmemorycrud_updateexistingsemanticmemory",
-      "community": 460
+      "community": 461
     },
     {
       "label": "semantic-memory-update-pipeline.ts",
@@ -35697,7 +35721,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "ConsolidationOutboxWorker",
@@ -35705,7 +35729,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L19",
       "id": "consolidation_outbox_worker_consolidationoutboxworker",
-      "community": 461
+      "community": 462
     },
     {
       "label": ".constructor()",
@@ -35713,7 +35737,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L22",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_constructor",
-      "community": 461
+      "community": 462
     },
     {
       "label": ".publish()",
@@ -35721,7 +35745,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L26",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_publish",
-      "community": 461
+      "community": 462
     },
     {
       "label": ".handled()",
@@ -35729,7 +35753,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L38",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_handled",
-      "community": 461
+      "community": 462
     },
     {
       "label": "summarization-service.ts",
@@ -35785,7 +35809,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "insertEpisodic()",
@@ -35793,7 +35817,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 462
+      "community": 463
     },
     {
       "label": "insertEmbedding()",
@@ -35801,7 +35825,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 462
+      "community": 463
     },
     {
       "label": "FailingRepo",
@@ -35809,7 +35833,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 462
+      "community": 463
     },
     {
       "label": ".insertSemanticMemory()",
@@ -35817,7 +35841,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 462
+      "community": 463
     },
     {
       "label": "consolidation-outbox-worker.spec.ts",
@@ -35825,7 +35849,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
-      "community": 694
+      "community": 695
     },
     {
       "label": "insertEpisodic()",
@@ -35833,7 +35857,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L10",
       "id": "consolidation_outbox_worker_spec_insertepisodic",
-      "community": 694
+      "community": 695
     },
     {
       "label": "insertEmbedding()",
@@ -35841,7 +35865,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L18",
       "id": "consolidation_outbox_worker_spec_insertembedding",
-      "community": 694
+      "community": 695
     },
     {
       "label": "clustering-service.spec.ts",
@@ -35945,7 +35969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "VisualizeRelationsTool",
@@ -35953,7 +35977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".constructor()",
@@ -35961,7 +35985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".handle()",
@@ -35969,7 +35993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 564
+      "community": 565
     },
     {
       "label": "remove-relation-tool.ts",
@@ -35977,7 +36001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "RemoveRelationTool",
@@ -35985,7 +36009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".constructor()",
@@ -35993,7 +36017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".handle()",
@@ -36001,7 +36025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 565
+      "community": 566
     },
     {
       "label": "extract-relations-tool.ts",
@@ -36009,7 +36033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "ExtractRelationsTool",
@@ -36017,7 +36041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 566
+      "community": 567
     },
     {
       "label": ".constructor()",
@@ -36025,7 +36049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 566
+      "community": 567
     },
     {
       "label": ".handle()",
@@ -36033,7 +36057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 566
+      "community": 567
     },
     {
       "label": "add-relation-tool.ts",
@@ -36041,7 +36065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "memoryItemHasOwnerIdColumn()",
@@ -36049,7 +36073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L16",
       "id": "add_relation_tool_memoryitemhasowneridcolumn",
-      "community": 463
+      "community": 464
     },
     {
       "label": "AddRelationTool",
@@ -36057,7 +36081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L28",
       "id": "add_relation_tool_addrelationtool",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".constructor()",
@@ -36065,7 +36089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L29",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".handle()",
@@ -36073,7 +36097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L67",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 463
+      "community": 464
     },
     {
       "label": "extract-triples-tool.ts",
@@ -36137,7 +36161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 695
+      "community": 696
     },
     {
       "label": "createBaseSchema()",
@@ -36145,7 +36169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 695
+      "community": 696
     },
     {
       "label": "createTestMemory()",
@@ -36153,7 +36177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L53",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 695
+      "community": 696
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -36161,7 +36185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createBaseSchema()",
@@ -36169,7 +36193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 696
+      "community": 697
     },
     {
       "label": "createTestMemory()",
@@ -36177,7 +36201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 696
+      "community": 697
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -36185,7 +36209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 697
+      "community": 698
     },
     {
       "label": "createBaseSchema()",
@@ -36193,7 +36217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 697
+      "community": 698
     },
     {
       "label": "createTestMemory()",
@@ -36201,7 +36225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 697
+      "community": 698
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -36225,7 +36249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 698
+      "community": 699
     },
     {
       "label": "createBaseSchema()",
@@ -36233,7 +36257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 698
+      "community": 699
     },
     {
       "label": "createTestMemory()",
@@ -36241,7 +36265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L53",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 698
+      "community": 699
     },
     {
       "label": "relation-retry-manager.ts",
@@ -36249,7 +36273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "RelationRetryManager",
@@ -36257,7 +36281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 567
+      "community": 568
     },
     {
       "label": ".constructor()",
@@ -36265,7 +36289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 567
+      "community": 568
     },
     {
       "label": ".retry()",
@@ -36273,7 +36297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 567
+      "community": 568
     },
     {
       "label": "relation-errors.ts",
@@ -36481,7 +36505,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_query_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "RelationGraphQuery",
@@ -36489,7 +36513,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L16",
       "id": "relation_graph_query_relationgraphquery",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".constructor()",
@@ -36497,7 +36521,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L17",
       "id": "relation_graph_query_relationgraphquery_constructor",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".getRelations()",
@@ -36505,7 +36529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L25",
       "id": "relation_graph_query_relationgraphquery_getrelations",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".getRelationsBatch()",
@@ -36513,7 +36537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L99",
       "id": "relation_graph_query_relationgraphquery_getrelationsbatch",
-      "community": 464
+      "community": 465
     },
     {
       "label": "relation-graph-row-utils.ts",
@@ -36521,7 +36545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_row_utils_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "mapRelationRowToMemoryRelation()",
@@ -36529,7 +36553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L13",
       "id": "relation_graph_row_utils_maprelationrowtomemoryrelation",
-      "community": 568
+      "community": 569
     },
     {
       "label": "filterRelationRows()",
@@ -36537,7 +36561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L29",
       "id": "relation_graph_row_utils_filterrelationrows",
-      "community": 568
+      "community": 569
     },
     {
       "label": "filterRelationRowsWithWarning()",
@@ -36545,7 +36569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L36",
       "id": "relation_graph_row_utils_filterrelationrowswithwarning",
-      "community": 568
+      "community": 569
     },
     {
       "label": "relation-graph-cycle-detector.ts",
@@ -36553,7 +36577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_cycle_detector_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "RelationGraphCycleDetector",
@@ -36561,7 +36585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L11",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".constructor()",
@@ -36569,7 +36593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L12",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_constructor",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".detectCycleInternal()",
@@ -36577,7 +36601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L17",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycleinternal",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".detectCycle()",
@@ -36585,7 +36609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L89",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycle",
-      "community": 465
+      "community": 466
     },
     {
       "label": "relation-graph.ts",
@@ -36857,7 +36881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_traversal_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "RelationGraphTraversal",
@@ -36865,7 +36889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L24",
       "id": "relation_graph_traversal_relationgraphtraversal",
-      "community": 569
+      "community": 570
     },
     {
       "label": ".constructor()",
@@ -36873,7 +36897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L25",
       "id": "relation_graph_traversal_relationgraphtraversal_constructor",
-      "community": 569
+      "community": 570
     },
     {
       "label": ".getRelatedMemories()",
@@ -36881,7 +36905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L30",
       "id": "relation_graph_traversal_relationgraphtraversal_getrelatedmemories",
-      "community": 569
+      "community": 570
     },
     {
       "label": "llm-based-relation-extractor.ts",
@@ -37257,7 +37281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "loadTestDataset()",
@@ -37265,7 +37289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createBaseSchema()",
@@ -37273,7 +37297,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 570
+      "community": 571
     },
     {
       "label": "createTestMemory()",
@@ -37281,7 +37305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 570
+      "community": 571
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -37297,7 +37321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 699
+      "community": 700
     },
     {
       "label": "createBaseSchema()",
@@ -37305,7 +37329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 699
+      "community": 700
     },
     {
       "label": "createTestMemory()",
@@ -37313,7 +37337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 699
+      "community": 700
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -37337,7 +37361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createBaseSchema()",
@@ -37345,7 +37369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createTestMemory()",
@@ -37353,7 +37377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 571
+      "community": 572
     },
     {
       "label": "createBulkMemories()",
@@ -37361,7 +37385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 571
+      "community": 572
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -37457,7 +37481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 700
+      "community": 701
     },
     {
       "label": "getMockMementoConfig()",
@@ -37465,7 +37489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 700
+      "community": 701
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -37473,7 +37497,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 700
+      "community": 701
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -37513,7 +37537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -37521,7 +37545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".constructor()",
@@ -37529,7 +37553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".consume()",
@@ -37537,7 +37561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".refill()",
@@ -37545,7 +37569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 466
+      "community": 467
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -37553,7 +37577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -37561,7 +37585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 572
+      "community": 573
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -37569,7 +37593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 572
+      "community": 573
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -37577,7 +37601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 572
+      "community": 573
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -37841,7 +37865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 701
+      "community": 702
     },
     {
       "label": "tripleDedupeKey()",
@@ -37849,7 +37873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 701
+      "community": 702
     },
     {
       "label": "mergeTripleLists()",
@@ -37857,7 +37881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 701
+      "community": 702
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -38241,7 +38265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "TripleNormalizer",
@@ -38249,7 +38273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 573
+      "community": 574
     },
     {
       "label": ".constructor()",
@@ -38257,7 +38281,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 573
+      "community": 574
     },
     {
       "label": ".normalize()",
@@ -38265,7 +38289,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 573
+      "community": 574
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -38281,7 +38305,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -38289,7 +38313,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 574
+      "community": 575
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -38297,7 +38321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 574
+      "community": 575
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -38305,7 +38329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 574
+      "community": 575
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -38321,7 +38345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "TripleParser",
@@ -38329,7 +38353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 467
+      "community": 468
     },
     {
       "label": ".parse()",
@@ -38337,7 +38361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 467
+      "community": 468
     },
     {
       "label": ".extractJSON()",
@@ -38345,7 +38369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 467
+      "community": 468
     },
     {
       "label": ".isValidTriple()",
@@ -38353,7 +38377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 467
+      "community": 468
     },
     {
       "label": "triple-text-chunker.ts",
@@ -38553,7 +38577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "checkOllamaModel()",
@@ -38561,7 +38585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 575
+      "community": 576
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -38569,7 +38593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 575
+      "community": 576
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -38577,7 +38601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 575
+      "community": 576
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -38601,7 +38625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 702
+      "community": 703
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -38609,7 +38633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 702
+      "community": 703
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -38617,7 +38641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 702
+      "community": 703
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -38641,7 +38665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -38649,7 +38673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 468
+      "community": 469
     },
     {
       "label": "trimToValidJsonObject()",
@@ -38657,7 +38681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 468
+      "community": 469
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -38665,7 +38689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 468
+      "community": 469
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -38673,7 +38697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 468
+      "community": 469
     },
     {
       "label": "types.ts",
@@ -38689,7 +38713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_analysis_rules_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "calculateConfusionMatrix()",
@@ -38697,7 +38721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L12",
       "id": "analysis_rules_calculateconfusionmatrix",
-      "community": 576
+      "community": 577
     },
     {
       "label": "analyzeRelationType()",
@@ -38705,7 +38729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L56",
       "id": "analysis_rules_analyzerelationtype",
-      "community": 576
+      "community": 577
     },
     {
       "label": "analyzeAllRelationTypes()",
@@ -38713,7 +38737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L127",
       "id": "analysis_rules_analyzeallrelationtypes",
-      "community": 576
+      "community": 577
     },
     {
       "label": "metric-rules.ts",
@@ -38769,7 +38793,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_quality_metrics_rules_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "emptyTypeMetric()",
@@ -38777,7 +38801,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L20",
       "id": "quality_metrics_rules_emptytypemetric",
-      "community": 469
+      "community": 470
     },
     {
       "label": "calculateQualityMetrics()",
@@ -38785,7 +38809,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L31",
       "id": "quality_metrics_rules_calculatequalitymetrics",
-      "community": 469
+      "community": 470
     },
     {
       "label": "validateThresholds()",
@@ -38793,7 +38817,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L79",
       "id": "quality_metrics_rules_validatethresholds",
-      "community": 469
+      "community": 470
     },
     {
       "label": "calculateQualityMetricsWithAnalysis()",
@@ -38801,7 +38825,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L122",
       "id": "quality_metrics_rules_calculatequalitymetricswithanalysis",
-      "community": 469
+      "community": 470
     },
     {
       "label": "matching-rules.ts",
@@ -38841,7 +38865,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 703
+      "community": 704
     },
     {
       "label": "candidate()",
@@ -38849,7 +38873,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 703
+      "community": 704
     },
     {
       "label": "source()",
@@ -38857,7 +38881,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 703
+      "community": 704
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -38873,7 +38897,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 704
+      "community": 705
     },
     {
       "label": "AgentIntegrationError",
@@ -38881,7 +38905,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 704
+      "community": 705
     },
     {
       "label": ".constructor()",
@@ -38889,7 +38913,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 704
+      "community": 705
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -38905,7 +38929,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 705
+      "community": 706
     },
     {
       "label": "createSession()",
@@ -38913,7 +38937,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 705
+      "community": 706
     },
     {
       "label": "addObservation()",
@@ -38921,7 +38945,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 705
+      "community": 706
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -39489,7 +39513,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 706
+      "community": 707
     },
     {
       "label": "addObservation()",
@@ -39497,7 +39521,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 706
+      "community": 707
     },
     {
       "label": "finishAndSummarize()",
@@ -39505,7 +39529,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 706
+      "community": 707
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -39897,7 +39921,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "createMockService()",
@@ -39905,7 +39929,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 577
+      "community": 578
     },
     {
       "label": "resolver()",
@@ -39913,7 +39937,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 577
+      "community": 578
     },
     {
       "label": "priority()",
@@ -39921,7 +39945,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 577
+      "community": 578
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -40961,7 +40985,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 707
+      "community": 708
     },
     {
       "label": "createSchema()",
@@ -40969,7 +40993,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 707
+      "community": 708
     },
     {
       "label": "seedMemoryItem()",
@@ -40977,7 +41001,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 707
+      "community": 708
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -41017,7 +41041,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_execution_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "safeParseEmbedding()",
@@ -41025,7 +41049,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L24",
       "id": "migration_execution_safeparseembedding",
-      "community": 470
+      "community": 471
     },
     {
       "label": "processMigrationRow()",
@@ -41033,7 +41057,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L38",
       "id": "migration_execution_processmigrationrow",
-      "community": 470
+      "community": 471
     },
     {
       "label": "runMigrationBatchLoop()",
@@ -41041,7 +41065,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L143",
       "id": "migration_execution_runmigrationbatchloop",
-      "community": 470
+      "community": 471
     },
     {
       "label": "finalizeMigrationExecution()",
@@ -41049,7 +41073,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L169",
       "id": "migration_execution_finalizemigrationexecution",
-      "community": 470
+      "community": 471
     },
     {
       "label": "migration-progress.ts",
@@ -41121,7 +41145,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_rollback_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "rollback()",
@@ -41129,7 +41153,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L6",
       "id": "migration_rollback_rollback",
-      "community": 578
+      "community": 579
     },
     {
       "label": "applyRollbackDelete()",
@@ -41137,7 +41161,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L53",
       "id": "migration_rollback_applyrollbackdelete",
-      "community": 578
+      "community": 579
     },
     {
       "label": "applyRollbackRestore()",
@@ -41145,7 +41169,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L57",
       "id": "migration_rollback_applyrollbackrestore",
-      "community": 578
+      "community": 579
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -41153,7 +41177,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -41161,7 +41185,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 579
+      "community": 580
     },
     {
       "label": ".constructor()",
@@ -41169,7 +41193,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 579
+      "community": 580
     },
     {
       "label": ".handle()",
@@ -41177,7 +41201,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 579
+      "community": 580
     },
     {
       "label": "performance-alerts.ts",
@@ -41233,7 +41257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "PerformanceStatsTool",
@@ -41241,7 +41265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 580
+      "community": 581
     },
     {
       "label": ".constructor()",
@@ -41249,7 +41273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 580
+      "community": 581
     },
     {
       "label": ".handle()",
@@ -41257,7 +41281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 580
+      "community": 581
     },
     {
       "label": "resolve-error.ts",
@@ -41817,7 +41841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_database_metrics_reader_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "DatabaseMetricsReader",
@@ -41825,7 +41849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L15",
       "id": "database_metrics_reader_databasemetricsreader",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".setDatabase()",
@@ -41833,7 +41857,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L18",
       "id": "database_metrics_reader_databasemetricsreader_setdatabase",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".getDatabaseMetrics()",
@@ -41841,7 +41865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L22",
       "id": "database_metrics_reader_databasemetricsreader_getdatabasemetrics",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".optimizeDatabase()",
@@ -41849,7 +41873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L70",
       "id": "database_metrics_reader_databasemetricsreader_optimizedatabase",
-      "community": 471
+      "community": 472
     },
     {
       "label": "performance-alert-service.ts",
@@ -42265,7 +42289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_cpu_usage_tracker_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "CpuUsageTracker",
@@ -42273,7 +42297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L14",
       "id": "cpu_usage_tracker_cpuusagetracker",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".seed()",
@@ -42281,7 +42305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L18",
       "id": "cpu_usage_tracker_cpuusagetracker_seed",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".getLatestSnapshot()",
@@ -42289,7 +42313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L28",
       "id": "cpu_usage_tracker_cpuusagetracker_getlatestsnapshot",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".calculateUsage()",
@@ -42297,7 +42321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L40",
       "id": "cpu_usage_tracker_cpuusagetracker_calculateusage",
-      "community": 472
+      "community": 473
     },
     {
       "label": "runtime-diagnostics-logger.ts",
@@ -42473,7 +42497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_memory_pressure_utils_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "getMemoryPressureDenominatorBytes()",
@@ -42481,7 +42505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L12",
       "id": "memory_pressure_utils_getmemorypressuredenominatorbytes",
-      "community": 581
+      "community": 582
     },
     {
       "label": "memoryRatioToPercent()",
@@ -42489,7 +42513,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L27",
       "id": "memory_pressure_utils_memoryratiotopercent",
-      "community": 581
+      "community": 582
     },
     {
       "label": "formatBytes()",
@@ -42497,7 +42521,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L38",
       "id": "memory_pressure_utils_formatbytes",
-      "community": 581
+      "community": 582
     },
     {
       "label": "performance-analytics.ts",
@@ -42505,7 +42529,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_analytics_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "analyzeTrend()",
@@ -42513,7 +42537,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L54",
       "id": "performance_analytics_analyzetrend",
-      "community": 473
+      "community": 474
     },
     {
       "label": "generateRecommendations()",
@@ -42521,7 +42545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L72",
       "id": "performance_analytics_generaterecommendations",
-      "community": 473
+      "community": 474
     },
     {
       "label": "getPerformanceSummary()",
@@ -42529,7 +42553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L101",
       "id": "performance_analytics_getperformancesummary",
-      "community": 473
+      "community": 474
     },
     {
       "label": "getMetricsAnalytics()",
@@ -42537,7 +42561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L130",
       "id": "performance_analytics_getmetricsanalytics",
-      "community": 473
+      "community": 474
     },
     {
       "label": "failure-detector.spec.ts",
@@ -42577,7 +42601,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "toBytes()",
@@ -42585,7 +42609,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L8",
       "id": "performance_monitor_spec_tobytes",
-      "community": 474
+      "community": 475
     },
     {
       "label": "createMetrics()",
@@ -42593,7 +42617,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L10",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 474
+      "community": 475
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -42601,7 +42625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L261",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 474
+      "community": 475
     },
     {
       "label": "makeMonitor()",
@@ -42609,7 +42633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L268",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 474
+      "community": 475
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -42633,7 +42657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -42641,7 +42665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createQualityMetricsTable()",
@@ -42649,7 +42673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -42657,7 +42681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 582
+      "community": 583
     },
     {
       "label": "relation-metrics-collector.ts",
@@ -42665,7 +42689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_relation_metrics_collector_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "isRelationType()",
@@ -42673,7 +42697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L9",
       "id": "relation_metrics_collector_isrelationtype",
-      "community": 475
+      "community": 476
     },
     {
       "label": "RelationMetricsCollector",
@@ -42681,7 +42705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L13",
       "id": "relation_metrics_collector_relationmetricscollector",
-      "community": 475
+      "community": 476
     },
     {
       "label": ".constructor()",
@@ -42689,7 +42713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L14",
       "id": "relation_metrics_collector_relationmetricscollector_constructor",
-      "community": 475
+      "community": 476
     },
     {
       "label": ".collect()",
@@ -42697,7 +42721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L16",
       "id": "relation_metrics_collector_relationmetricscollector_collect",
-      "community": 475
+      "community": 476
     },
     {
       "label": "quality-recorder.ts",
@@ -42873,7 +42897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_category_quality_aggregator_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "CategoryQualityAggregator",
@@ -42881,7 +42905,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L23",
       "id": "category_quality_aggregator_categoryqualityaggregator",
-      "community": 583
+      "community": 584
     },
     {
       "label": ".constructor()",
@@ -42889,7 +42913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L24",
       "id": "category_quality_aggregator_categoryqualityaggregator_constructor",
-      "community": 583
+      "community": 584
     },
     {
       "label": ".collect()",
@@ -42897,7 +42921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L26",
       "id": "category_quality_aggregator_categoryqualityaggregator_collect",
-      "community": 583
+      "community": 584
     },
     {
       "label": "consolidation-metrics-collector.ts",
@@ -42905,7 +42929,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_consolidation_metrics_collector_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "ConsolidationMetricsCollector",
@@ -42913,7 +42937,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L14",
       "id": "consolidation_metrics_collector_consolidationmetricscollector",
-      "community": 584
+      "community": 585
     },
     {
       "label": ".constructor()",
@@ -42921,7 +42945,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L15",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_constructor",
-      "community": 584
+      "community": 585
     },
     {
       "label": ".collect()",
@@ -42929,7 +42953,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L17",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_collect",
-      "community": 584
+      "community": 585
     },
     {
       "label": "quality-report-renderers.ts",
@@ -43049,7 +43073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -43057,7 +43081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 585
+      "community": 586
     },
     {
       "label": "createQualityMetricsTable()",
@@ -43065,7 +43089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 585
+      "community": 586
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43073,7 +43097,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 585
+      "community": 586
     },
     {
       "label": "storage-metrics-collector.ts",
@@ -43081,7 +43105,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_storage_metrics_collector_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "StorageMetricsCollector",
@@ -43089,7 +43113,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L5",
       "id": "storage_metrics_collector_storagemetricscollector",
-      "community": 586
+      "community": 587
     },
     {
       "label": ".constructor()",
@@ -43097,7 +43121,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L6",
       "id": "storage_metrics_collector_storagemetricscollector_constructor",
-      "community": 586
+      "community": 587
     },
     {
       "label": ".collect()",
@@ -43105,7 +43129,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L8",
       "id": "storage_metrics_collector_storagemetricscollector_collect",
-      "community": 586
+      "community": 587
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -43313,7 +43337,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_search_metrics_collector_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "calculateMRR()",
@@ -43321,7 +43345,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L31",
       "id": "search_metrics_collector_calculatemrr",
-      "community": 476
+      "community": 477
     },
     {
       "label": "SearchMetricsCollector",
@@ -43329,7 +43353,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L64",
       "id": "search_metrics_collector_searchmetricscollector",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".constructor()",
@@ -43337,7 +43361,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L65",
       "id": "search_metrics_collector_searchmetricscollector_constructor",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".collect()",
@@ -43345,7 +43369,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L67",
       "id": "search_metrics_collector_searchmetricscollector_collect",
-      "community": 476
+      "community": 477
     },
     {
       "label": "quality-evaluator.ts",
@@ -43433,7 +43457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -43441,7 +43465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityMetricsTable()",
@@ -43449,7 +43473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43457,7 +43481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -43993,7 +44017,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 708
+      "community": 709
     },
     {
       "label": "compareToolResults()",
@@ -44001,7 +44025,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 708
+      "community": 709
     },
     {
       "label": "testToolConsistency()",
@@ -44009,7 +44033,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 708
+      "community": 709
     },
     {
       "label": "test-quality-assurance.ts",
@@ -44017,7 +44041,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 709
+      "community": 710
     },
     {
       "label": "createQualityTables()",
@@ -44025,7 +44049,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 709
+      "community": 710
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -44033,7 +44057,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 709
+      "community": 710
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -44041,7 +44065,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "PerformanceBenchmark",
@@ -44049,7 +44073,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".measureOperation()",
@@ -44057,7 +44081,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".getResults()",
@@ -44065,7 +44089,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".getSummary()",
@@ -44073,7 +44097,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 477
+      "community": 478
     },
     {
       "label": "test-search.ts",
@@ -44177,7 +44201,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 710
+      "community": 711
     },
     {
       "label": "setupResourceHandlers()",
@@ -44185,7 +44209,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 710
+      "community": 711
     },
     {
       "label": "createTestMemories()",
@@ -44193,7 +44217,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 710
+      "community": 711
     },
     {
       "label": "test-regression.ts",
@@ -44729,7 +44753,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "telemetryDb()",
@@ -44737,7 +44761,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 588
+      "community": 589
     },
     {
       "label": "percentile95()",
@@ -44745,7 +44769,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 588
+      "community": 589
     },
     {
       "label": "run()",
@@ -44753,7 +44777,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 588
+      "community": 589
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -44817,7 +44841,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 711
+      "community": 712
     },
     {
       "label": "readSource()",
@@ -44825,7 +44849,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 711
+      "community": 712
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -44833,7 +44857,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 711
+      "community": 712
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -44841,7 +44865,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -44849,7 +44873,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 589
+      "community": 590
     },
     {
       "label": "normalizeTags()",
@@ -44857,7 +44881,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 589
+      "community": 590
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -44865,7 +44889,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 589
+      "community": 590
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -45041,7 +45065,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "mulberry32()",
@@ -45049,7 +45073,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L22",
       "id": "benchmark_search_database_mulberry32",
-      "community": 478
+      "community": 479
     },
     {
       "label": "normalizeMemoryType()",
@@ -45057,7 +45081,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L33",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 478
+      "community": 479
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -45065,7 +45089,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L50",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 478
+      "community": 479
     },
     {
       "label": "seedOneCorpusRow()",
@@ -45073,7 +45097,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L134",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 478
+      "community": 479
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -45137,7 +45161,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 712
+      "community": 713
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -45145,7 +45169,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 712
+      "community": 713
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -45153,7 +45177,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 712
+      "community": 713
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -45377,7 +45401,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "extractQueryType()",
@@ -45385,7 +45409,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 590
+      "community": 591
     },
     {
       "label": "isExcluded()",
@@ -45393,7 +45417,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createQueryCounter()",
@@ -45401,7 +45425,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 590
+      "community": 591
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -45489,7 +45513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spearman_ts",
-      "community": 713
+      "community": 714
     },
     {
       "label": "calculateSpearmanRho()",
@@ -45497,7 +45521,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L27",
       "id": "spearman_calculatespearmanrho",
-      "community": 713
+      "community": 714
     },
     {
       "label": "calculateRanks()",
@@ -45505,7 +45529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L81",
       "id": "spearman_calculateranks",
-      "community": 713
+      "community": 714
     },
     {
       "label": "report-comparison.ts",
@@ -45945,7 +45969,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 714
+      "community": 715
     },
     {
       "label": "readStaticFile()",
@@ -45953,7 +45977,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 714
+      "community": 715
     },
     {
       "label": "getFunctionMetrics()",
@@ -45961,7 +45985,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L9",
       "id": "static_design_contracts_spec_getfunctionmetrics",
-      "community": 714
+      "community": 715
     },
     {
       "label": "anchor-map.e2e.ts",
@@ -46121,7 +46145,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "parseArgs()",
@@ -46129,7 +46153,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 591
+      "community": 592
     },
     {
       "label": "printHelp()",
@@ -46137,7 +46161,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 591
+      "community": 592
     },
     {
       "label": "main()",
@@ -46145,7 +46169,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 591
+      "community": 592
     },
     {
       "label": "check-magic-numbers.ts",
@@ -46249,7 +46273,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 715
+      "community": 716
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -46257,7 +46281,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 715
+      "community": 716
     },
     {
       "label": "readTarString()",
@@ -46265,7 +46289,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 715
+      "community": 716
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -46561,7 +46585,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "parseArgs()",
@@ -46569,7 +46593,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 592
+      "community": 593
     },
     {
       "label": "printHelp()",
@@ -46577,7 +46601,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 592
+      "community": 593
     },
     {
       "label": "main()",
@@ -46585,7 +46609,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 592
+      "community": 593
     },
     {
       "label": "check-path-traversal.ts",
@@ -46785,7 +46809,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "buildLongMemEvalDatasetUrl()",
@@ -46793,7 +46817,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L19",
       "id": "acquire_longmemeval_buildlongmemevaldataseturl",
-      "community": 593
+      "community": 594
     },
     {
       "label": "acquireLongMemEval()",
@@ -46801,7 +46825,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L29",
       "id": "acquire_longmemeval_acquirelongmemeval",
-      "community": 593
+      "community": 594
     },
     {
       "label": "main()",
@@ -46809,7 +46833,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L65",
       "id": "acquire_longmemeval_main",
-      "community": 593
+      "community": 594
     },
     {
       "label": "agent-memory-benchmark.ts",
@@ -47097,7 +47121,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "parseArgs()",
@@ -47105,7 +47129,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 479
+      "community": 480
     },
     {
       "label": "printHelp()",
@@ -47113,7 +47137,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 479
+      "community": 480
     },
     {
       "label": "printThresholds()",
@@ -47121,7 +47145,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 479
+      "community": 480
     },
     {
       "label": "main()",
@@ -47129,7 +47153,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 479
+      "community": 480
     },
     {
       "label": "simple-update.js",
@@ -47153,7 +47177,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L1",
       "id": "scripts_memory_export_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "parseArgs()",
@@ -47161,7 +47185,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L20",
       "id": "memory_export_parseargs",
-      "community": 594
+      "community": 595
     },
     {
       "label": "printHelp()",
@@ -47169,7 +47193,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L47",
       "id": "memory_export_printhelp",
-      "community": 594
+      "community": 595
     },
     {
       "label": "main()",
@@ -47177,7 +47201,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L65",
       "id": "memory_export_main",
-      "community": 594
+      "community": 595
     },
     {
       "label": "agent-smoke-matrix.spec.ts",
@@ -47185,7 +47209,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 716
+      "community": 717
     },
     {
       "label": "temporaryRoot()",
@@ -47193,7 +47217,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 716
+      "community": 717
     },
     {
       "label": "dependencies()",
@@ -47201,7 +47225,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 716
+      "community": 717
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -47297,7 +47321,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L1",
       "id": "scripts_reindex_embeddings_ts",
-      "community": 717
+      "community": 718
     },
     {
       "label": "option()",
@@ -47305,7 +47329,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L3",
       "id": "reindex_embeddings_option",
-      "community": 717
+      "community": 718
     },
     {
       "label": "main()",
@@ -47313,7 +47337,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L8",
       "id": "reindex_embeddings_main",
-      "community": 717
+      "community": 718
     },
     {
       "label": "check-pii-masking.ts",
@@ -47409,7 +47433,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 718
+      "community": 719
     },
     {
       "label": "fetchJson()",
@@ -47417,7 +47441,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L7",
       "id": "test_docker_fetchjson",
-      "community": 718
+      "community": 719
     },
     {
       "label": "testDockerServer()",
@@ -47425,7 +47449,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L23",
       "id": "test_docker_testdockerserver",
-      "community": 718
+      "community": 719
     },
     {
       "label": "pack-with-restore.js",
@@ -47801,7 +47825,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_integration_release_gate_spec_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "createDatabase()",
@@ -47809,7 +47833,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L8",
       "id": "agent_integration_release_gate_spec_createdatabase",
-      "community": 595
+      "community": 596
     },
     {
       "label": "passingEvidence()",
@@ -47817,7 +47841,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L49",
       "id": "agent_integration_release_gate_spec_passingevidence",
-      "community": 595
+      "community": 596
     },
     {
       "label": "seedPassingDatabase()",
@@ -47825,7 +47849,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L64",
       "id": "agent_integration_release_gate_spec_seedpassingdatabase",
-      "community": 595
+      "community": 596
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -47833,7 +47857,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "parseArgs()",
@@ -47841,7 +47865,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 596
+      "community": 597
     },
     {
       "label": "printHelp()",
@@ -47849,7 +47873,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 596
+      "community": 597
     },
     {
       "label": "main()",
@@ -47857,7 +47881,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 596
+      "community": 597
     },
     {
       "label": "check-debt-markers.ts",
@@ -47921,7 +47945,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L1",
       "id": "scripts_forgetting_events_query_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "parseArgs()",
@@ -47929,7 +47953,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L20",
       "id": "forgetting_events_query_parseargs",
-      "community": 597
+      "community": 598
     },
     {
       "label": "printHelp()",
@@ -47937,7 +47961,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L49",
       "id": "forgetting_events_query_printhelp",
-      "community": 597
+      "community": 598
     },
     {
       "label": "main()",
@@ -47945,7 +47969,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L65",
       "id": "forgetting_events_query_main",
-      "community": 597
+      "community": 598
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -47961,7 +47985,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "getTriggerInfo()",
@@ -47969,7 +47993,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 480
+      "community": 481
     },
     {
       "label": "fixTriggers()",
@@ -47977,7 +48001,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 480
+      "community": 481
     },
     {
       "label": "checkMigrationVersion()",
@@ -47985,7 +48009,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 480
+      "community": 481
     },
     {
       "label": "main()",
@@ -47993,7 +48017,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 480
+      "community": 481
     },
     {
       "label": "simple-migrate.js",
@@ -48017,7 +48041,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L1",
       "id": "scripts_memory_import_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "parseArgs()",
@@ -48025,7 +48049,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L27",
       "id": "memory_import_parseargs",
-      "community": 598
+      "community": 599
     },
     {
       "label": "printHelp()",
@@ -48033,7 +48057,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L60",
       "id": "memory_import_printhelp",
-      "community": 598
+      "community": 599
     },
     {
       "label": "main()",
@@ -48041,7 +48065,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L79",
       "id": "memory_import_main",
-      "community": 598
+      "community": 599
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -48065,7 +48089,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "formatCategoryReportLine()",
@@ -48073,7 +48097,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 599
+      "community": 600
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -48081,7 +48105,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 599
+      "community": 600
     },
     {
       "label": "main()",
@@ -48089,7 +48113,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 599
+      "community": 600
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -48097,7 +48121,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 719
+      "community": 720
     },
     {
       "label": "loadVecExtension()",
@@ -48105,7 +48129,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 719
+      "community": 720
     },
     {
       "label": "fixTfidfDimensions()",
@@ -48113,7 +48137,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 719
+      "community": 720
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -48145,7 +48169,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 720
+      "community": 721
     },
     {
       "label": "reappearanceRate()",
@@ -48153,7 +48177,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 720
+      "community": 721
     },
     {
       "label": "main()",
@@ -48161,7 +48185,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 720
+      "community": 721
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -48537,7 +48561,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 600
+      "community": 601
     },
     {
       "label": "log()",
@@ -48545,7 +48569,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 600
+      "community": 601
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -48553,7 +48577,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 600
+      "community": 601
     },
     {
       "label": "main()",
@@ -48561,7 +48585,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 600
+      "community": 601
     },
     {
       "label": "agent-smoke-matrix.ts",
@@ -48745,7 +48769,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L1",
       "id": "scripts_tune_report_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "parseReportArgs()",
@@ -48753,7 +48777,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L10",
       "id": "tune_report_parsereportargs",
-      "community": 601
+      "community": 602
     },
     {
       "label": "findLatestRunDir()",
@@ -48761,7 +48785,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L20",
       "id": "tune_report_findlatestrundir",
-      "community": 601
+      "community": 602
     },
     {
       "label": "main()",
@@ -48769,7 +48793,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L61",
       "id": "tune_report_main",
-      "community": 601
+      "community": 602
     },
     {
       "label": "mcp-http-client.js",
@@ -49385,7 +49409,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 721
+      "community": 722
     },
     {
       "label": "createBackup()",
@@ -49393,7 +49417,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 721
+      "community": 722
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -49401,7 +49425,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 721
+      "community": 722
     },
     {
       "label": "restore-legacy.ps1",
@@ -49737,7 +49761,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "startMarker()",
@@ -49745,7 +49769,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 602
+      "community": 603
     },
     {
       "label": "renderManagedIssueBody()",
@@ -49753,7 +49777,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 602
+      "community": 603
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -49761,7 +49785,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 602
+      "community": 603
     },
     {
       "label": "fingerprint.ts",
@@ -49769,7 +49793,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 722
+      "community": 723
     },
     {
       "label": "normalizeMessage()",
@@ -49777,7 +49801,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 722
+      "community": 723
     },
     {
       "label": "createFingerprint()",
@@ -49785,7 +49809,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 722
+      "community": 723
     },
     {
       "label": "sanitizer.ts",
@@ -49793,7 +49817,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 723
+      "community": 724
     },
     {
       "label": "limitUtf8Bytes()",
@@ -49801,7 +49825,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 723
+      "community": 724
     },
     {
       "label": "sanitizeExcerpt()",
@@ -49809,7 +49833,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 723
+      "community": 724
     },
     {
       "label": "parsers.ts",
@@ -49817,7 +49841,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "inferLevel()",
@@ -49825,7 +49849,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 603
+      "community": 604
     },
     {
       "label": "parseAppLogLine()",
@@ -49833,7 +49857,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 603
+      "community": 604
     },
     {
       "label": "parseJsonlRecord()",
@@ -49841,7 +49865,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 603
+      "community": 604
     },
     {
       "label": "index.ts",
@@ -49849,7 +49873,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -49857,7 +49881,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 604
+      "community": 605
     },
     {
       "label": "createMonitorRuntime()",
@@ -49865,7 +49889,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 604
+      "community": 605
     },
     {
       "label": "runForever()",
@@ -49873,7 +49897,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 604
+      "community": 605
     },
     {
       "label": "promotion.ts",
@@ -50273,7 +50297,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "main()",
@@ -50281,7 +50305,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 605
+      "community": 606
     },
     {
       "label": "index.ts",
@@ -50289,7 +50313,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 605
+      "community": 606
     },
     {
       "label": "runExample()",
@@ -50297,7 +50321,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 605
+      "community": 606
     },
     {
       "label": "index.spec.ts",
@@ -50401,7 +50425,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_js",
-      "community": 606
+      "community": 607
     },
     {
       "label": "initializeMap()",
@@ -50409,7 +50433,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L14",
       "id": "anchor_map_initializemap",
-      "community": 606
+      "community": 607
     },
     {
       "label": "onSearchResultClick()",
@@ -50417,7 +50441,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L52",
       "id": "anchor_map_onsearchresultclick",
-      "community": 606
+      "community": 607
     },
     {
       "label": "setupEventListeners()",
@@ -50425,7 +50449,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L68",
       "id": "anchor_map_setupeventlisteners",
-      "community": 606
+      "community": 607
     },
     {
       "label": "dashboard-auth-error.js",
@@ -50441,7 +50465,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_js",
-      "community": 724
+      "community": 725
     },
     {
       "label": "buildEmbeddingMapQuery()",
@@ -50449,7 +50473,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L12",
       "id": "embedding_map_fetch_buildembeddingmapquery",
-      "community": 724
+      "community": 725
     },
     {
       "label": "handleEmbeddingMapResponse()",
@@ -50457,7 +50481,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_handleembeddingmapresponse",
-      "community": 724
+      "community": 725
     },
     {
       "label": "review-candidates-panel-poll.js",
@@ -50489,7 +50513,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L1",
       "id": "static_js_graph_detail_js",
-      "community": 607
+      "community": 608
     },
     {
       "label": "getTypeBadgeClass()",
@@ -50497,7 +50521,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L12",
       "id": "graph_detail_gettypebadgeclass",
-      "community": 607
+      "community": 608
     },
     {
       "label": "buildTagsHtml()",
@@ -50505,7 +50529,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L19",
       "id": "graph_detail_buildtagshtml",
-      "community": 607
+      "community": 608
     },
     {
       "label": "buildDetailRows()",
@@ -50513,7 +50537,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L26",
       "id": "graph_detail_builddetailrows",
-      "community": 607
+      "community": 608
     },
     {
       "label": "review-candidates-panel-render-actions.js",
@@ -50521,7 +50545,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_actions_js",
-      "community": 608
+      "community": 609
     },
     {
       "label": "showActionToast()",
@@ -50529,7 +50553,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L16",
       "id": "review_candidates_panel_render_actions_showactiontoast",
-      "community": 608
+      "community": 609
     },
     {
       "label": "showError()",
@@ -50537,7 +50561,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L33",
       "id": "review_candidates_panel_render_actions_showerror",
-      "community": 608
+      "community": 609
     },
     {
       "label": "postCandidateAction()",
@@ -50545,7 +50569,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L41",
       "id": "review_candidates_panel_render_actions_postcandidateaction",
-      "community": 608
+      "community": 609
     },
     {
       "label": "dashboard-auth-render-message.js",
@@ -50577,7 +50601,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_fetch_js",
-      "community": 725
+      "community": 726
     },
     {
       "label": "loadBatchRunHistory()",
@@ -50585,7 +50609,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L15",
       "id": "review_candidates_panel_health_fetch_loadbatchrunhistory",
-      "community": 725
+      "community": 726
     },
     {
       "label": "loadHealthMetrics()",
@@ -50593,7 +50617,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L61",
       "id": "review_candidates_panel_health_fetch_loadhealthmetrics",
-      "community": 725
+      "community": 726
     },
     {
       "label": "graph.js",
@@ -50681,7 +50705,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_state_js",
-      "community": 481
+      "community": 482
     },
     {
       "label": "createSessionGate()",
@@ -50689,7 +50713,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L16",
       "id": "dashboard_auth_state_createsessiongate",
-      "community": 481
+      "community": 482
     },
     {
       "label": "ensureSessionGate()",
@@ -50697,7 +50721,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L22",
       "id": "dashboard_auth_state_ensuresessiongate",
-      "community": 481
+      "community": 482
     },
     {
       "label": "unlockSessionGate()",
@@ -50705,7 +50729,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L25",
       "id": "dashboard_auth_state_unlocksessiongate",
-      "community": 481
+      "community": 482
     },
     {
       "label": "resetSessionGate()",
@@ -50713,7 +50737,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L31",
       "id": "dashboard_auth_state_resetsessiongate",
-      "community": 481
+      "community": 482
     },
     {
       "label": "embedding-map-chart-setup.js",
@@ -50721,7 +50745,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_setup_js",
-      "community": 609
+      "community": 610
     },
     {
       "label": "readContainerSize()",
@@ -50729,7 +50753,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L12",
       "id": "embedding_map_chart_setup_readcontainersize",
-      "community": 609
+      "community": 610
     },
     {
       "label": "appendPlotLayers()",
@@ -50737,7 +50761,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L24",
       "id": "embedding_map_chart_setup_appendplotlayers",
-      "community": 609
+      "community": 610
     },
     {
       "label": "appendBackgroundClickHandler()",
@@ -50745,7 +50769,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L32",
       "id": "embedding_map_chart_setup_appendbackgroundclickhandler",
-      "community": 609
+      "community": 610
     },
     {
       "label": "memory-evolution-demo-shell-render-timeline.js",
@@ -50753,7 +50777,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_timeline_js",
-      "community": 482
+      "community": 483
     },
     {
       "label": "buildComparisonHintMarkup()",
@@ -50761,7 +50785,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_timeline_buildcomparisonhintmarkup",
-      "community": 482
+      "community": 483
     },
     {
       "label": "updateComparisonHint()",
@@ -50769,7 +50793,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L36",
       "id": "memory_evolution_demo_shell_render_timeline_updatecomparisonhint",
-      "community": 482
+      "community": 483
     },
     {
       "label": "syncSegmentSelection()",
@@ -50777,7 +50801,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L51",
       "id": "memory_evolution_demo_shell_render_timeline_syncsegmentselection",
-      "community": 482
+      "community": 483
     },
     {
       "label": "renderPointSegment()",
@@ -50785,7 +50809,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L66",
       "id": "memory_evolution_demo_shell_render_timeline_renderpointsegment",
-      "community": 482
+      "community": 483
     },
     {
       "label": "embedding-map-fetch-status.js",
@@ -50793,7 +50817,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_status_js",
-      "community": 610
+      "community": 611
     },
     {
       "label": "setLoading()",
@@ -50801,7 +50825,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_status_setloading",
-      "community": 610
+      "community": 611
     },
     {
       "label": "setError()",
@@ -50809,7 +50833,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L30",
       "id": "embedding_map_fetch_status_seterror",
-      "community": 610
+      "community": 611
     },
     {
       "label": "updateCacheInfo()",
@@ -50817,7 +50841,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L58",
       "id": "embedding_map_fetch_status_updatecacheinfo",
-      "community": 610
+      "community": 611
     },
     {
       "label": "agent-sessions-panel-data.js",
@@ -51185,7 +51209,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_config_js",
-      "community": 483
+      "community": 484
     },
     {
       "label": "getReviewQueueBoot()",
@@ -51193,7 +51217,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L12",
       "id": "review_candidates_panel_poll_config_getreviewqueueboot",
-      "community": 483
+      "community": 484
     },
     {
       "label": "clearPollTimer()",
@@ -51201,7 +51225,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L23",
       "id": "review_candidates_panel_poll_config_clearpolltimer",
-      "community": 483
+      "community": 484
     },
     {
       "label": "schedulePollAfterMs()",
@@ -51209,7 +51233,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L30",
       "id": "review_candidates_panel_poll_config_schedulepollafterms",
-      "community": 483
+      "community": 484
     },
     {
       "label": "schedulePollAfterMsUnlessSse()",
@@ -51217,7 +51241,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L41",
       "id": "review_candidates_panel_poll_config_schedulepollaftermsunlesssse",
-      "community": 483
+      "community": 484
     },
     {
       "label": "agent-sessions-panel-shared.js",
@@ -51241,7 +51265,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_tooltip_js",
-      "community": 611
+      "community": 612
     },
     {
       "label": "ensureTooltip()",
@@ -51249,7 +51273,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L12",
       "id": "embedding_map_tooltip_ensuretooltip",
-      "community": 611
+      "community": 612
     },
     {
       "label": "showTooltip()",
@@ -51257,7 +51281,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L23",
       "id": "embedding_map_tooltip_showtooltip",
-      "community": 611
+      "community": 612
     },
     {
       "label": "hideTooltip()",
@@ -51265,7 +51289,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L40",
       "id": "embedding_map_tooltip_hidetooltip",
-      "community": 611
+      "community": 612
     },
     {
       "label": "review-candidates-panel-render-preview.js",
@@ -51473,7 +51497,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_js",
-      "community": 612
+      "community": 613
     },
     {
       "label": "on()",
@@ -51481,7 +51505,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_on",
-      "community": 612
+      "community": 613
     },
     {
       "label": "wirePanel()",
@@ -51489,7 +51513,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L19",
       "id": "agent_sessions_panel_wirepanel",
-      "community": 612
+      "community": 613
     },
     {
       "label": "initAgentSessionsPanel()",
@@ -51497,7 +51521,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L71",
       "id": "agent_sessions_panel_initagentsessionspanel",
-      "community": 612
+      "community": 613
     },
     {
       "label": "agent-sessions-panel-render-injections.js",
@@ -51649,7 +51673,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_consolidation_js",
-      "community": 484
+      "community": 485
     },
     {
       "label": "renderEpisodicSources()",
@@ -51657,7 +51681,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_consolidation_renderepisodicsources",
-      "community": 484
+      "community": 485
     },
     {
       "label": "renderSemanticResult()",
@@ -51665,7 +51689,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersemanticresult",
-      "community": 484
+      "community": 485
     },
     {
       "label": "renderSearchComparison()",
@@ -51673,7 +51697,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L110",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersearchcomparison",
-      "community": 484
+      "community": 485
     },
     {
       "label": "renderConsolidationPanel()",
@@ -51681,7 +51705,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L128",
       "id": "memory_evolution_demo_shell_render_consolidation_renderconsolidationpanel",
-      "community": 484
+      "community": 485
     },
     {
       "label": "memory-evolution-demo-shell.js",
@@ -51777,7 +51801,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_prompt_js",
-      "community": 726
+      "community": 727
     },
     {
       "label": "isReviewNotifyPromptDismissed()",
@@ -51785,7 +51809,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_prompt_isreviewnotifypromptdismissed",
-      "community": 726
+      "community": 727
     },
     {
       "label": "dismissReviewNotifyPrompt()",
@@ -51793,7 +51817,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L18",
       "id": "review_candidates_panel_poll_prompt_dismissreviewnotifyprompt",
-      "community": 726
+      "community": 727
     },
     {
       "label": "dashboard-auth-dom.js",
@@ -51801,7 +51825,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_dom_js",
-      "community": 727
+      "community": 728
     },
     {
       "label": "selectFirst()",
@@ -51809,7 +51833,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L12",
       "id": "dashboard_auth_dom_selectfirst",
-      "community": 727
+      "community": 728
     },
     {
       "label": "getElementByIdFallback()",
@@ -51817,7 +51841,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L20",
       "id": "dashboard_auth_dom_getelementbyidfallback",
-      "community": 727
+      "community": 728
     },
     {
       "label": "graph-search.js",
@@ -51889,7 +51913,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 728
+      "community": 729
     },
     {
       "label": "refreshChartIfActive()",
@@ -51897,7 +51921,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L13",
       "id": "embedding_map_refreshchartifactive",
-      "community": 728
+      "community": 729
     },
     {
       "label": "initEmbeddingMap()",
@@ -51905,7 +51929,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_initembeddingmap",
-      "community": 728
+      "community": 729
     },
     {
       "label": "anchor-map-search.js",
@@ -51969,7 +51993,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_data_js",
-      "community": 613
+      "community": 614
     },
     {
       "label": "getSelectedAgentId()",
@@ -51977,7 +52001,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L12",
       "id": "anchor_map_data_getselectedagentid",
-      "community": 613
+      "community": 614
     },
     {
       "label": "loadAgentIdOptions()",
@@ -51985,7 +52009,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L17",
       "id": "anchor_map_data_loadagentidoptions",
-      "community": 613
+      "community": 614
     },
     {
       "label": "loadMapData()",
@@ -51993,7 +52017,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L66",
       "id": "anchor_map_data_loadmapdata",
-      "community": 613
+      "community": 614
     },
     {
       "label": "agent-sessions-panel-render-timeline.js",
@@ -52377,7 +52401,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_snapshot_js",
-      "community": 614
+      "community": 615
     },
     {
       "label": "renderMemoryGroups()",
@@ -52385,7 +52409,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorygroups",
-      "community": 614
+      "community": 615
     },
     {
       "label": "renderMemoryStats()",
@@ -52393,7 +52417,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorystats",
-      "community": 614
+      "community": 615
     },
     {
       "label": "renderSnapshot()",
@@ -52401,7 +52425,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L92",
       "id": "memory_evolution_demo_shell_render_snapshot_rendersnapshot",
-      "community": 614
+      "community": 615
     },
     {
       "label": "dashboard-auth-requests.js",
@@ -52417,7 +52441,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 485
+      "community": 486
     },
     {
       "label": "getTabButtons()",
@@ -52425,7 +52449,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 485
+      "community": 486
     },
     {
       "label": "setRovingTabindex()",
@@ -52433,7 +52457,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L22",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 485
+      "community": 486
     },
     {
       "label": "focusActiveTabButton()",
@@ -52441,7 +52465,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L28",
       "id": "dashboard_tabs_focusactivetabbutton",
-      "community": 485
+      "community": 486
     },
     {
       "label": "activateTab()",
@@ -52449,7 +52473,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L37",
       "id": "dashboard_tabs_activatetab",
-      "community": 485
+      "community": 486
     },
     {
       "label": "review-candidates-panel-health-render.js",
@@ -52521,7 +52545,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_panels_js",
-      "community": 615
+      "community": 616
     },
     {
       "label": "getPanel()",
@@ -52529,7 +52553,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L16",
       "id": "dashboard_tabs_panels_getpanel",
-      "community": 615
+      "community": 616
     },
     {
       "label": "setTabButtonsActive()",
@@ -52537,7 +52561,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L23",
       "id": "dashboard_tabs_panels_settabbuttonsactive",
-      "community": 615
+      "community": 616
     },
     {
       "label": "setPanelVisibility()",
@@ -52545,7 +52569,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L31",
       "id": "dashboard_tabs_panels_setpanelvisibility",
-      "community": 615
+      "community": 616
     },
     {
       "label": "dashboard-auth-ui.js",
@@ -52681,7 +52705,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L1",
       "id": "static_js_graph_fetch_js",
-      "community": 729
+      "community": 730
     },
     {
       "label": "resetGraphState()",
@@ -52689,7 +52713,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L48",
       "id": "graph_fetch_resetgraphstate",
-      "community": 729
+      "community": 730
     },
     {
       "label": "handleGraphPayload()",
@@ -52697,7 +52721,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L62",
       "id": "graph_fetch_handlegraphpayload",
-      "community": 729
+      "community": 730
     },
     {
       "label": "embedding-map-panel.js",
@@ -52705,7 +52729,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_panel_js",
-      "community": 616
+      "community": 617
     },
     {
       "label": "appendLabeledLine()",
@@ -52713,7 +52737,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L12",
       "id": "embedding_map_panel_appendlabeledline",
-      "community": 616
+      "community": 617
     },
     {
       "label": "closeSidePanel()",
@@ -52721,7 +52745,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L21",
       "id": "embedding_map_panel_closesidepanel",
-      "community": 616
+      "community": 617
     },
     {
       "label": "openSidePanel()",
@@ -52729,7 +52753,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L29",
       "id": "embedding_map_panel_opensidepanel",
-      "community": 616
+      "community": 617
     }
   ],
   "links": [
@@ -58209,12 +58233,48 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
       "_tgt": "anchor_map_handler_spec_createanchorschema",
       "source": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
       "target": "anchor_map_handler_spec_createanchorschema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L72",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "_tgt": "anchor_map_handler_spec_creatememoryitemschema",
+      "source": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "target": "anchor_map_handler_spec_creatememoryitemschema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L94",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "_tgt": "anchor_map_handler_spec_buildfakeanchormanager",
+      "source": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "target": "anchor_map_handler_spec_buildfakeanchormanager",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts",
+      "source_location": "L123",
+      "weight": 1.0,
+      "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "_tgt": "anchor_map_handler_spec_insertmemory",
+      "source": "packages_memento_server_src_server_handlers_anchor_map_handler_spec_ts",
+      "target": "anchor_map_handler_spec_insertmemory",
       "confidence_score": 1.0
     },
     {
@@ -58245,7 +58305,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L128",
+      "source_location": "L129",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
       "_tgt": "anchor_map_handler_buildnetworknodesandlinks",
@@ -58257,12 +58317,12 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L238",
+      "source_location": "L246",
       "weight": 1.0,
       "_src": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "_tgt": "anchor_map_handler_buildnetworklinks",
+      "_tgt": "anchor_map_handler_buildrelationlinks",
       "source": "packages_memento_server_src_server_handlers_anchor_map_handler_ts",
-      "target": "anchor_map_handler_buildnetworklinks",
+      "target": "anchor_map_handler_buildrelationlinks",
       "confidence_score": 1.0
     },
     {
@@ -58317,12 +58377,12 @@
       "relation": "calls",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-server/src/server/handlers/anchor-map.handler.ts",
-      "source_location": "L229",
+      "source_location": "L235",
       "weight": 1.0,
       "_src": "anchor_map_handler_buildnetworknodesandlinks",
-      "_tgt": "anchor_map_handler_buildnetworklinks",
+      "_tgt": "anchor_map_handler_buildrelationlinks",
       "source": "anchor_map_handler_buildnetworknodesandlinks",
-      "target": "anchor_map_handler_buildnetworklinks",
+      "target": "anchor_map_handler_buildrelationlinks",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/shared/types/relation-graph.ts
+++ b/packages/memento-core/src/shared/types/relation-graph.ts
@@ -190,6 +190,18 @@ export interface IRelationGraph {
   ): Promise<MemoryRelation[]>;
 
   /**
+   * 여러 기억에 대한 관계 일괄 조회 (N+1 완화)
+   *
+   * @param memoryIds 기억 ID 목록
+   * @param options 조회 옵션
+   * @returns 기억 ID별 관계 목록 맵
+   */
+  getRelationsBatch(
+    memoryIds: string[],
+    options?: GetRelationsOptions
+  ): Promise<Map<string, MemoryRelation[]>>;
+
+  /**
    * 관련 기억 조회 (N-hop 관계 탐색)
    * 
    * @param memoryId 시작 기억 ID

--- a/packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts
+++ b/packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 
-import { listAnchorAgentIds } from './anchor-map.handler.js';
+import { listAnchorAgentIds, buildAnchorMapData } from './anchor-map.handler.js';
+import type { ServerServices } from '../bootstrap.js';
 
 function createAnchorSchema(db: Database.Database): void {
   db.exec(`
@@ -65,5 +66,173 @@ describe('listAnchorAgentIds', () => {
       'middle',
       'zebra',
     ]);
+  });
+});
+
+function createMemoryItemSchema(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE memory_item (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL,
+      type TEXT NOT NULL,
+      importance REAL NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+type FakeSearchItem = {
+  id: string;
+  content: string;
+  type: string;
+  similarity?: number;
+  hop_distance?: number;
+  importance?: number;
+  created_at?: string;
+};
+
+function buildFakeAnchorManager(
+  anchors: Array<{ agent_id: string; slot: string; memory_id: string | null; created_at: string; updated_at: string }>,
+  searchResultsBySlot: Record<string, FakeSearchItem[]>
+): ServerServices['anchorManager'] {
+  return {
+    getAnchor: vi.fn().mockResolvedValue(anchors),
+    getSlotConfig: vi.fn().mockReturnValue({ hop_limit: 1, vector_threshold: 0.5 }),
+    searchLocal: vi.fn().mockImplementation(async (_agentId: string, slot: string) => ({
+      items: searchResultsBySlot[slot] ?? [],
+      total_count: (searchResultsBySlot[slot] ?? []).length,
+      local_results_count: (searchResultsBySlot[slot] ?? []).length,
+      fallback_used: false,
+      query_time: 0,
+    })),
+  } as unknown as ServerServices['anchorManager'];
+}
+
+describe('buildAnchorMapData - anchor map network edges (#709)', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    createMemoryItemSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function insertMemory(id: string, content = `content-${id}`): void {
+    db.prepare(
+      `INSERT INTO memory_item (id, content, type, importance, created_at) VALUES (?, ?, 'episodic', 0.5, datetime('now'))`
+    ).run(id, content);
+  }
+
+  it('same memory found by slot A and slot B search produces 1 node and 2 slot edges', async () => {
+    insertMemory('anchor-a');
+    insertMemory('anchor-b');
+    insertMemory('mem-shared');
+
+    const anchorManager = buildFakeAnchorManager(
+      [
+        { agent_id: 'default', slot: 'A', memory_id: 'anchor-a', created_at: 'now', updated_at: 'now' },
+        { agent_id: 'default', slot: 'B', memory_id: 'anchor-b', created_at: 'now', updated_at: 'now' },
+      ],
+      {
+        A: [{ id: 'mem-shared', content: 'shared', type: 'episodic', hop_distance: 1, similarity: 0.8 }],
+        B: [{ id: 'mem-shared', content: 'shared', type: 'episodic', hop_distance: 1, similarity: 0.6 }],
+      }
+    );
+
+    const relationGraph = {
+      getRelationsBatch: vi.fn().mockResolvedValue(new Map()),
+    } as unknown as ServerServices['relationGraph'];
+
+    const serverServices = { anchorManager, relationGraph } as unknown as ServerServices;
+
+    const result = await buildAnchorMapData(db, serverServices, 'default');
+
+    const sharedNodes = result.nodes.filter(n => n.id === 'mem-shared');
+    expect(sharedNodes).toHaveLength(1);
+
+    const slotEdges = result.links.filter(l => l.type === 'hop' && l.target === 'mem-shared');
+    expect(slotEdges).toHaveLength(2);
+    expect(slotEdges.map(l => l.source).sort()).toEqual(['anchor-a', 'anchor-b']);
+  });
+
+  it('builds relation-based edges via RelationGraph.getRelationsBatch with confidence as weight (memory_link not queried)', async () => {
+    insertMemory('anchor-a');
+    insertMemory('mem-neighbor');
+
+    const anchorManager = buildFakeAnchorManager(
+      [{ agent_id: 'default', slot: 'A', memory_id: 'anchor-a', created_at: 'now', updated_at: 'now' }],
+      { A: [{ id: 'mem-neighbor', content: 'neighbor', type: 'episodic', hop_distance: 1, similarity: 0.7 }] }
+    );
+
+    const relationRow = {
+      id: 1,
+      source_id: 'anchor-a',
+      target_id: 'mem-neighbor',
+      relation_type: 'REFERENCES',
+      confidence: 0.42,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    const getRelationsBatch = vi.fn().mockResolvedValue(
+      new Map([
+        ['anchor-a', [relationRow]],
+        ['mem-neighbor', [relationRow]],
+      ])
+    );
+    const relationGraph = { getRelationsBatch } as unknown as ServerServices['relationGraph'];
+
+    const serverServices = { anchorManager, relationGraph } as unknown as ServerServices;
+
+    const result = await buildAnchorMapData(db, serverServices, 'default');
+
+    expect(getRelationsBatch).toHaveBeenCalledWith(
+      expect.arrayContaining(['anchor-a', 'mem-neighbor']),
+      { direction: 'both' }
+    );
+
+    const relationLinks = result.links.filter(l => l.type === 'link');
+    expect(relationLinks).toHaveLength(1);
+    expect(relationLinks[0]).toMatchObject({
+      source: 'anchor-a',
+      target: 'mem-neighbor',
+      similarity: 0.42,
+    });
+  });
+
+  it('ignores relations pointing to memories that are not part of the current node set (floating hop>=2 excluded)', async () => {
+    insertMemory('anchor-a');
+    insertMemory('mem-neighbor');
+
+    const anchorManager = buildFakeAnchorManager(
+      [{ agent_id: 'default', slot: 'A', memory_id: 'anchor-a', created_at: 'now', updated_at: 'now' }],
+      { A: [{ id: 'mem-neighbor', content: 'neighbor', type: 'episodic', hop_distance: 1, similarity: 0.7 }] }
+    );
+
+    const relationToOutsideNode = {
+      id: 2,
+      source_id: 'anchor-a',
+      target_id: 'mem-not-on-map',
+      relation_type: 'REFERENCES',
+      confidence: 0.9,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+    const getRelationsBatch = vi.fn().mockResolvedValue(
+      new Map([
+        ['anchor-a', [relationToOutsideNode]],
+        ['mem-neighbor', []],
+      ])
+    );
+    const relationGraph = { getRelationsBatch } as unknown as ServerServices['relationGraph'];
+
+    const serverServices = { anchorManager, relationGraph } as unknown as ServerServices;
+
+    const result = await buildAnchorMapData(db, serverServices, 'default');
+
+    expect(result.links.filter(l => l.type === 'link')).toHaveLength(0);
+    expect(result.nodes.find(n => n.id === 'mem-not-on-map')).toBeUndefined();
   });
 });

--- a/packages/memento-server/src/server/handlers/anchor-map.handler.ts
+++ b/packages/memento-server/src/server/handlers/anchor-map.handler.ts
@@ -110,7 +110,8 @@ export async function buildAnchorMapData(
     db,
     anchorManager,
     agentId,
-    anchorList
+    anchorList,
+    serverServices.relationGraph
   );
 
   return {
@@ -135,11 +136,14 @@ async function buildNetworkNodesAndLinks(
     memory_id: string | null;
     created_at: string;
     updated_at: string;
-  }>
+  }>,
+  relationGraph: ServerServices['relationGraph']
 ): Promise<{ nodes: AnchorMapNode[]; links: AnchorMapLink[] }> {
   const nodes: AnchorMapNode[] = [];
   const links: AnchorMapLink[] = [];
-  const processedMemoryIds = new Set<string>();
+  // 노드 dedup(메모리 id당 1개)과 별개로, slot→memory 엣지는 슬롯마다 생성한다
+  // (같은 메모리가 slot A/B에 모두 잡히면 노드는 1개, 엣지는 2개)
+  const nodeIds = new Set<string>();
 
   // 각 앵커에 대해 처리
   for (const anchor of anchorList) {
@@ -159,15 +163,17 @@ async function buildNetworkNodesAndLinks(
     } | undefined;
 
     if (anchorMemory) {
-      nodes.push({
-        id: anchor.memory_id,
-        type: 'anchor',
-        slot: anchor.slot,
-        content: anchorMemory.content.substring(0, 100),
-        importance: anchorMemory.importance,
-        created_at: anchorMemory.created_at
-      });
-      processedMemoryIds.add(anchor.memory_id);
+      if (!nodeIds.has(anchor.memory_id)) {
+        nodes.push({
+          id: anchor.memory_id,
+          type: 'anchor',
+          slot: anchor.slot,
+          content: anchorMemory.content.substring(0, 100),
+          importance: anchorMemory.importance,
+          created_at: anchorMemory.created_at
+        });
+        nodeIds.add(anchor.memory_id);
+      }
 
       // 앵커 주변 메모리 검색
       try {
@@ -182,20 +188,20 @@ async function buildNetworkNodesAndLinks(
 
         // 검색 결과를 노드와 링크로 변환
         for (const item of searchResult.items) {
-          if (processedMemoryIds.has(item.id)) continue;
+          if (!nodeIds.has(item.id)) {
+            nodes.push({
+              id: item.id,
+              type: 'memory',
+              content: item.content.substring(0, 100),
+              hop_distance: item.hop_distance || 0,
+              similarity: item.similarity,
+              importance: item.importance,
+              created_at: item.created_at
+            });
+            nodeIds.add(item.id);
+          }
 
-          nodes.push({
-            id: item.id,
-            type: 'memory',
-            content: item.content.substring(0, 100),
-            hop_distance: item.hop_distance || 0,
-            similarity: item.similarity,
-            importance: item.importance,
-            created_at: item.created_at
-          });
-          processedMemoryIds.add(item.id);
-
-          // 링크 추가 (앵커에서 메모리로)
+          // 링크 추가 (앵커에서 메모리로) - 슬롯마다 별도 엣지로 추가
           if (item.hop_distance === 1) {
             links.push({
               source: anchor.memory_id,
@@ -225,56 +231,50 @@ async function buildNetworkNodesAndLinks(
     }
   }
 
-  // memory_link 테이블을 활용한 직접 연결 정보 추가
-  const memoryLinks = buildNetworkLinks(db, nodes, processedMemoryIds);
-  links.push(...memoryLinks);
+  // memory_relation 테이블(RelationGraph)을 활용한 직접 연결 정보 추가
+  const relationLinks = await buildRelationLinks(relationGraph, nodeIds);
+  links.push(...relationLinks);
 
   return { nodes, links };
 }
 
 /**
- * memory_link 테이블을 활용한 네트워크 링크 생성
+ * RelationGraph(memory_relation)를 활용한 네트워크 링크 생성.
+ * 노드로 등록된 메모리끼리의 관계만 엣지로 반영하며, confidence를 가중치로 사용한다.
+ * hop 2/3 경로 엣지는 범위 밖(#715)이므로 다루지 않는다.
  */
-function buildNetworkLinks(
-  db: Database.Database,
-  nodes: AnchorMapNode[],
-  processedMemoryIds: Set<string>
-): AnchorMapLink[] {
+async function buildRelationLinks(
+  relationGraph: ServerServices['relationGraph'],
+  nodeIds: Set<string>
+): Promise<AnchorMapLink[]> {
   const links: AnchorMapLink[] = [];
+  if (nodeIds.size === 0) return links;
 
-  for (const node of nodes) {
-    if (node.type === 'anchor') continue;
+  const memoryIds = Array.from(nodeIds);
 
-    // memory_link 테이블 조회
-    const linkedMemories = db.prepare(`
-      SELECT target_id, relation_type, created_at
-      FROM memory_link
-      WHERE source_id = ?
-      UNION
-      SELECT source_id, relation_type, created_at
-      FROM memory_link
-      WHERE target_id = ?
-    `).all(node.id, node.id) as Array<{
-      target_id?: string;
-      source_id?: string;
-      relation_type: string;
-      created_at: string;
-    }>;
+  try {
+    const relationsByMemory = await relationGraph.getRelationsBatch(memoryIds, { direction: 'both' });
 
-    for (const link of linkedMemories) {
-      const linkedId = link.target_id || link.source_id;
-      if (linkedId && processedMemoryIds.has(linkedId)) {
-        // relation_type을 기반으로 similarity 추정
-        const similarity = link.relation_type === 'derived_from' ? 0.9 :
-                          link.relation_type === 'cause_of' ? 0.8 : 0.7;
+    const seenRelationIds = new Set<number>();
+    for (const memoryId of memoryIds) {
+      for (const relation of relationsByMemory.get(memoryId) ?? []) {
+        if (seenRelationIds.has(relation.id)) continue;
+        const otherId = relation.source_id === memoryId ? relation.target_id : relation.source_id;
+        if (otherId === memoryId || !nodeIds.has(otherId)) continue;
+
+        seenRelationIds.add(relation.id);
         links.push({
-          source: node.id,
-          target: linkedId,
+          source: relation.source_id,
+          target: relation.target_id,
           type: 'link',
-          similarity: similarity
+          similarity: relation.confidence
         });
       }
     }
+  } catch (error) {
+    logger.error('Relation link lookup failed', {
+      error: error instanceof Error ? error.message : String(error)
+    });
   }
 
   return links;


### PR DESCRIPTION
## Summary
- `buildAnchorMapData`/`buildNetworkNodesAndLinks`: 노드 dedup(메모리 id당 1개)과 slot→memory 엣지 생성을 분리. 같은 메모리가 slot A/B 검색 모두에서 발견되면 노드는 1개만 생기지만, 슬롯마다 `hop` 엣지가 각각 생성됨(기존에는 전역 `processedMemoryIds`로 두 번째 슬롯의 엣지가 통째로 스킵됨).
- `buildNetworkLinks`(→ `buildRelationLinks`로 교체): 프로덕션에서 항상 비어있는 `memory_link` 테이블 대신 `RelationGraph.getRelationsBatch(memoryIds, { direction: 'both' })`로 `memory_relation` 데이터를 조회. relation `id` 기준으로 dedup하고, 두 노드가 모두 현재 맵에 존재할 때만 엣지로 반영. 엣지 가중치는 relation의 `confidence`를 그대로 사용(기존의 `relation_type → 임의 similarity` 매핑 제거).
- `IRelationGraph` 포트 인터페이스에 `getRelationsBatch` 시그니처 추가. `RelationGraph` 클래스는 이미 이 메서드를 구현하고 있었지만 포트 타입 선언에는 누락되어 있어 핸들러에서 타입 에러가 발생했음(다른 곳에서는 각자 로컬 타입으로 우회 중이었음).

## Scope
- hop 2/3 경로 엣지는 범위 밖 (#715로 분리)
- hop≥2 floating 노드(엣지 없이 노드만 있는 상태)는 이번 PR에서 허용

## Test plan
- [x] TDD RED: 신규 테스트를 fix 이전 코드(`git show HEAD~1:...anchor-map.handler.ts`)에 대입 실행 → `no such table: memory_link`로 3개 실패 확인
- [x] TDD GREEN: 수정 후 `npx vitest run packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts` → 6/6 통과
  - 같은 메모리가 slot A/B에서 모두 발견 → 노드 1개, `hop` 엣지 2개(소스: `anchor-a`, `anchor-b`)
  - `RelationGraph.getRelationsBatch(ids, { direction: 'both' })` 호출 확인, 반환된 relation의 `confidence`가 엣지 `similarity`로 그대로 반영됨(memory_link 테이블 없이도 동작)
  - 맵에 없는 메모리를 가리키는 relation은 엣지로 반영되지 않음(floating hop≥2 노드 허용과 일관)
- [x] `npx vitest run packages/memento-server/src/server/handlers/anchor-map.handler.spec.ts packages/memento-server/src/test/integration/anchor-map-search-highlight.spec.ts packages/memento-core/src/domains/relation` → 34 files / 398 tests 통과
- [x] `npm run type-check` (전 워크스페이스) 통과
- [x] `npx eslint` (변경 파일) 통과
- [x] `npm run build` 통과
- [x] graphify 재빌드 완료 (`graphify-out/graph.json`, `GRAPH_REPORT.md` 갱신)

Closes #709
Parent: #707

Made with [Cursor](https://cursor.com)