### PR TITLE
feat(anchor): auto-refresh 후보 스코어링에 relation/embedding 반영 (고립 slot 방지)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .  (2026-08-01)
 
 ## Corpus Check
-- 1436 files · ~1,576,974 words
+- 1437 files · ~1,578,460 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6634 nodes · 7573 edges · 1428 communities detected
+- 6640 nodes · 7579 edges · 1429 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1438,6 +1438,7 @@
 - [[_COMMUNITY_Community 1425|Community 1425]]
 - [[_COMMUNITY_Community 1426|Community 1426]]
 - [[_COMMUNITY_Community 1427|Community 1427]]
+- [[_COMMUNITY_Community 1428|Community 1428]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `BatchScheduler` - 47 edges
@@ -3214,16 +3215,16 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 437 - "Community 437"
+Cohesion: 0.4
+Nodes (0): 
+
+### Community 438 - "Community 438"
 Cohesion: 0.6
 Nodes (3): formatMementoResourceUri(), isMementoResourceKind(), parseMementoResourceUri()
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.5
 Nodes (2): getStopWords(), isStopWord()
-
-### Community 439 - "Community 439"
-Cohesion: 0.4
-Nodes (0): 
 
 ### Community 440 - "Community 440"
 Cohesion: 0.4
@@ -3231,15 +3232,15 @@ Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.4
-Nodes (1): LLMClientInitializer
+Nodes (0): 
 
 ### Community 442 - "Community 442"
-Cohesion: 0.6
-Nodes (3): getOllamaErrorMessage(), handleOllamaResponse(), testOllamaConnection()
+Cohesion: 0.4
+Nodes (1): LLMClientInitializer
 
 ### Community 443 - "Community 443"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.6
+Nodes (3): getOllamaErrorMessage(), handleOllamaResponse(), testOllamaConnection()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.4
@@ -3250,200 +3251,200 @@ Cohesion: 0.4
 Nodes (0): 
 
 ### Community 446 - "Community 446"
-Cohesion: 0.5
-Nodes (1): QueryFilterStrategy
+Cohesion: 0.4
+Nodes (0): 
 
 ### Community 447 - "Community 447"
 Cohesion: 0.5
-Nodes (1): NHopSearchStrategy
+Nodes (1): QueryFilterStrategy
 
 ### Community 448 - "Community 448"
+Cohesion: 0.5
+Nodes (1): NHopSearchStrategy
+
+### Community 449 - "Community 449"
 Cohesion: 0.4
 Nodes (1): FallbackSearchService
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (1): FallbackStrategy
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.4
 Nodes (1): EvolutionDemoNotFoundError
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.6
 Nodes (1): AdaptiveWeightCalculator
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.4
 Nodes (0): 
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (2): checkVecAvailability(), isVecTableRegistered()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.7
 Nodes (4): buildItemScopeClause(), buildItemWhereSql(), buildScopeParams(), executeHybridQuery()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.6
 Nodes (3): computeNormalizationRange(), selectScore(), VectorSearchResultNormalizer
 
-### Community 456 - "Community 456"
+### Community 457 - "Community 457"
 Cohesion: 0.5
 Nodes (2): parseRememberSuccess(), ToolContextRememberPersistenceAdapter
 
-### Community 457 - "Community 457"
+### Community 458 - "Community 458"
 Cohesion: 0.4
 Nodes (1): ToolContextKnowledgeContextAdapter
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (1): DeterministicMockLlmAdapter
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.7
 Nodes (4): assertUnreachable(), buildProceduralStepsJson(), mapKnowledgeCandidateToRememberParams(), normalizeOwnerId()
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.4
 Nodes (1): PersonalKnowledgeAgentService
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.6
 Nodes (3): getExistingReflectionNotes(), parseReflectionNotes(), prepareReflectionNotes()
 
-### Community 462 - "Community 462"
-Cohesion: 0.4
-Nodes (0): 
-
 ### Community 463 - "Community 463"
 Cohesion: 0.4
-Nodes (1): MemoryReviewCandidateError
+Nodes (0): 
 
 ### Community 464 - "Community 464"
 Cohesion: 0.4
-Nodes (1): IntrospectionScanCache
+Nodes (1): MemoryReviewCandidateError
 
 ### Community 465 - "Community 465"
 Cohesion: 0.4
-Nodes (1): SemanticMemoryCrud
+Nodes (1): IntrospectionScanCache
 
 ### Community 466 - "Community 466"
 Cohesion: 0.4
-Nodes (1): ConsolidationOutboxWorker
+Nodes (1): SemanticMemoryCrud
 
 ### Community 467 - "Community 467"
 Cohesion: 0.4
-Nodes (1): FailingRepo
+Nodes (1): ConsolidationOutboxWorker
 
 ### Community 468 - "Community 468"
+Cohesion: 0.4
+Nodes (1): FailingRepo
+
+### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (2): AddRelationTool, memoryItemHasOwnerIdColumn()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.4
 Nodes (1): RelationGraphQuery
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.5
 Nodes (1): RelationGraphCycleDetector
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.4
 Nodes (1): TokenBucketRateLimiter
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.6
 Nodes (1): TripleParser
 
-### Community 473 - "Community 473"
+### Community 474 - "Community 474"
 Cohesion: 0.7
 Nodes (4): extractJsonObjectFromLlmText(), parseLlmRelationsResponse(), prepareOllamaRelationJsonContent(), trimToValidJsonObject()
 
-### Community 474 - "Community 474"
+### Community 475 - "Community 475"
 Cohesion: 0.5
 Nodes (2): calculateQualityMetrics(), calculateQualityMetricsWithAnalysis()
 
-### Community 475 - "Community 475"
+### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (2): processMigrationRow(), safeParseEmbedding()
 
-### Community 476 - "Community 476"
+### Community 477 - "Community 477"
 Cohesion: 0.4
 Nodes (1): DatabaseMetricsReader
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.4
 Nodes (1): CpuUsageTracker
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.5
 Nodes (2): analyzeTrend(), getPerformanceSummary()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.5
 Nodes (2): createMetrics(), toBytes()
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.4
 Nodes (1): RelationMetricsCollector
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (2): calculateMRR(), SearchMetricsCollector
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.4
 Nodes (1): PerformanceBenchmark
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.7
 Nodes (4): createSeededBenchmarkDatabase(), mulberry32(), normalizeMemoryType(), seedOneCorpusRow()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.7
 Nodes (4): main(), parseArgs(), printHelp(), printThresholds()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.7
 Nodes (4): checkMigrationVersion(), fixTriggers(), getTriggerInfo(), main()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.7
 Nodes (4): createSessionGate(), ensureSessionGate(), resetSessionGate(), unlockSessionGate()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.6
 Nodes (4): buildComparisonHintMarkup(), renderPointSegment(), syncSegmentSelection(), updateComparisonHint()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.7
 Nodes (4): clearPollTimer(), getReviewQueueBoot(), schedulePollAfterMs(), schedulePollAfterMsUnlessSse()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.7
 Nodes (4): renderConsolidationPanel(), renderEpisodicSources(), renderSearchComparison(), renderSemanticResult()
 
-### Community 490 - "Community 490"
+### Community 491 - "Community 491"
 Cohesion: 0.7
 Nodes (4): activateTab(), focusActiveTabButton(), getTabButtons(), setRovingTabindex()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.83
 Nodes (3): findFreePort(), startTestHttpServer(), waitForHealth()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (2): collectEnvKeys(), expectNoDuplicateKeys()
-
-### Community 494 - "Community 494"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 495 - "Community 495"
 Cohesion: 0.5
@@ -3454,20 +3455,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 497 - "Community 497"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 498 - "Community 498"
 Cohesion: 0.83
 Nodes (3): createOwnerScopeMiddleware(), hasOwnerIdInBody(), isOwnerScopedToolRequest()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 499 - "Community 499"
-Cohesion: 0.67
-Nodes (2): handlePostPersonalRun(), parsePersonalRunBody()
 
 ### Community 500 - "Community 500"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): handlePostPersonalRun(), parsePersonalRunBody()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.5
@@ -3479,23 +3480,23 @@ Nodes (0):
 
 ### Community 503 - "Community 503"
 Cohesion: 0.5
-Nodes (1): BraveSearchProvider
+Nodes (0): 
 
 ### Community 504 - "Community 504"
-Cohesion: 0.83
-Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
+Cohesion: 0.5
+Nodes (1): BraveSearchProvider
 
 ### Community 505 - "Community 505"
 Cohesion: 0.83
-Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
+Nodes (3): canonicalize(), normalizeAgentEvent(), normalizeJson()
 
 ### Community 506 - "Community 506"
-Cohesion: 0.67
-Nodes (2): fixture(), fixtureUrl()
+Cohesion: 0.83
+Nodes (3): diagnoseClaudeCode(), parseVersion(), versionAtLeast()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.67
+Nodes (2): fixture(), fixtureUrl()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.5
@@ -3506,32 +3507,32 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 510 - "Community 510"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 511 - "Community 511"
 Cohesion: 0.83
 Nodes (3): createServerContext(), createToolContext(), createToolContextFromServerContext()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 512 - "Community 512"
+### Community 513 - "Community 513"
 Cohesion: 0.67
 Nodes (2): attemptRestart(), performHealthCheck()
 
-### Community 513 - "Community 513"
+### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (1): DatabaseOptimizeTool
 
-### Community 514 - "Community 514"
+### Community 515 - "Community 515"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 515 - "Community 515"
-Cohesion: 0.83
-Nodes (3): isDuplicateColumnError(), loadVecExtension(), migrateDatabase()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): isDuplicateColumnError(), loadVecExtension(), migrateDatabase()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.5
@@ -3554,52 +3555,52 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
+Nodes (2): isTripleExtractionQueueJob(), resolveBatchJobTimeout()
 
 ### Community 524 - "Community 524"
-Cohesion: 0.5
-Nodes (1): TripleExtractionBatchJob
+Cohesion: 0.67
+Nodes (2): buildMemoryReviewCandidateUpsertInputs(), runMemoryReviewCandidatesJob()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.5
-Nodes (1): QualityMeasurementBatchJob
+Nodes (1): TripleExtractionBatchJob
 
 ### Community 526 - "Community 526"
 Cohesion: 0.5
-Nodes (1): SleepConsolidationBatchJob
+Nodes (1): QualityMeasurementBatchJob
 
 ### Community 527 - "Community 527"
 Cohesion: 0.5
-Nodes (1): TelemetryCleanupBatchJob
+Nodes (1): SleepConsolidationBatchJob
 
 ### Community 528 - "Community 528"
-Cohesion: 0.67
-Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
+Cohesion: 0.5
+Nodes (1): TelemetryCleanupBatchJob
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
-Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
+Nodes (2): getTripleExtractionRetryCount(), shouldRetryTripleExtraction()
 
 ### Community 530 - "Community 530"
+Cohesion: 0.67
+Nodes (2): buildBatchSchedulerRunContext(), createMutableJobRef()
+
+### Community 531 - "Community 531"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 531 - "Community 531"
+### Community 532 - "Community 532"
 Cohesion: 0.83
 Nodes (3): isTestEnvironment(), isValidationDisabled(), isValidConfigurationEnvironment()
 
-### Community 532 - "Community 532"
+### Community 533 - "Community 533"
 Cohesion: 0.67
 Nodes (2): validateReflectionNote(), validateReflectionNotes()
-
-### Community 533 - "Community 533"
-Cohesion: 0.5
-Nodes (0): 
 
 ### Community 534 - "Community 534"
 Cohesion: 0.5
@@ -3607,183 +3608,183 @@ Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.5
-Nodes (1): SearchLocalTool
+Nodes (0): 
 
 ### Community 536 - "Community 536"
 Cohesion: 0.5
-Nodes (1): GetAnchorTool
+Nodes (1): SearchLocalTool
 
 ### Community 537 - "Community 537"
 Cohesion: 0.5
-Nodes (1): SetAnchorTool
+Nodes (1): GetAnchorTool
 
 ### Community 538 - "Community 538"
 Cohesion: 0.5
-Nodes (1): ClearAnchorTool
+Nodes (1): SetAnchorTool
 
 ### Community 539 - "Community 539"
 Cohesion: 0.5
-Nodes (1): RestoreAnchorsTool
+Nodes (1): ClearAnchorTool
 
 ### Community 540 - "Community 540"
+Cohesion: 0.5
+Nodes (1): RestoreAnchorsTool
+
+### Community 541 - "Community 541"
 Cohesion: 0.83
 Nodes (3): buildSnapshotsFromFixture(), getFixtureSnapshot(), key()
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.5
 Nodes (1): SearchResultCombiner
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.67
 Nodes (2): createProviderVectorSearchTask(), runSingleProviderVectorSearch()
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.67
 Nodes (2): computeProcessAttributeFit(), toSet()
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 545 - "Community 545"
-Cohesion: 0.83
-Nodes (3): buildFTSQuery(), makeFTSSafe(), preprocessQuery()
 
 ### Community 546 - "Community 546"
 Cohesion: 0.83
-Nodes (3): buildOuterWhereSql(), buildScopeParams(), executeKnnQuery()
+Nodes (3): buildFTSQuery(), makeFTSSafe(), preprocessQuery()
 
 ### Community 547 - "Community 547"
+Cohesion: 0.83
+Nodes (3): buildOuterWhereSql(), buildScopeParams(), executeKnnQuery()
+
+### Community 548 - "Community 548"
 Cohesion: 0.5
 Nodes (1): ForgettingStatsTool
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.83
 Nodes (3): mapJob(), querySystemMetrics(), toolBucketFromEvents()
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.5
 Nodes (1): GetTelemetrySummaryTool
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.83
 Nodes (3): baseTags(), extractKnowledgeCandidates(), pushUnique()
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.5
 Nodes (1): PersonalAgentLlmError
 
-### Community 553 - "Community 553"
+### Community 554 - "Community 554"
 Cohesion: 0.5
 Nodes (1): OpenAiChatLlmAdapter
 
-### Community 554 - "Community 554"
+### Community 555 - "Community 555"
 Cohesion: 0.5
 Nodes (1): OllamaChatLlmAdapter
 
-### Community 555 - "Community 555"
+### Community 556 - "Community 556"
 Cohesion: 0.5
 Nodes (1): GeminiChatLlmAdapter
 
-### Community 556 - "Community 556"
+### Community 557 - "Community 557"
 Cohesion: 0.83
 Nodes (3): buildSimilarityWarning(), handleMemoryItem(), persistMemoryItem()
 
-### Community 557 - "Community 557"
+### Community 558 - "Community 558"
 Cohesion: 0.5
 Nodes (1): RememberTool
 
-### Community 558 - "Community 558"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 559 - "Community 559"
 Cohesion: 0.5
-Nodes (1): MemoryInjectionPrompt
+Nodes (0): 
 
 ### Community 560 - "Community 560"
 Cohesion: 0.5
-Nodes (1): GetMemoryNeighborsTool
+Nodes (1): MemoryInjectionPrompt
 
 ### Community 561 - "Community 561"
 Cohesion: 0.5
-Nodes (1): ProceduralRollbackTool
+Nodes (1): GetMemoryNeighborsTool
 
 ### Community 562 - "Community 562"
 Cohesion: 0.5
-Nodes (1): CleanupMemoryTool
+Nodes (1): ProceduralRollbackTool
 
 ### Community 563 - "Community 563"
 Cohesion: 0.5
-Nodes (1): ProceduralDiffTool
+Nodes (1): CleanupMemoryTool
 
 ### Community 564 - "Community 564"
 Cohesion: 0.5
-Nodes (1): GetIntrospectionSummaryTool
+Nodes (1): ProceduralDiffTool
 
 ### Community 565 - "Community 565"
 Cohesion: 0.5
-Nodes (1): RememberProcedureTool
+Nodes (1): GetIntrospectionSummaryTool
 
 ### Community 566 - "Community 566"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): RememberProcedureTool
 
 ### Community 567 - "Community 567"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 568 - "Community 568"
 Cohesion: 0.83
 Nodes (3): computeProceduralDiff(), fieldDiff(), parseStepsJson()
 
-### Community 568 - "Community 568"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 569 - "Community 569"
 Cohesion: 0.5
-Nodes (1): VisualizeRelationsTool
+Nodes (0): 
 
 ### Community 570 - "Community 570"
 Cohesion: 0.5
-Nodes (1): RemoveRelationTool
+Nodes (1): VisualizeRelationsTool
 
 ### Community 571 - "Community 571"
 Cohesion: 0.5
-Nodes (1): ExtractRelationsTool
+Nodes (1): RemoveRelationTool
 
 ### Community 572 - "Community 572"
 Cohesion: 0.5
-Nodes (1): RelationRetryManager
+Nodes (1): ExtractRelationsTool
 
 ### Community 573 - "Community 573"
+Cohesion: 0.5
+Nodes (1): RelationRetryManager
+
+### Community 574 - "Community 574"
 Cohesion: 0.67
 Nodes (2): filterRelationRows(), filterRelationRowsWithWarning()
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.5
 Nodes (1): RelationGraphTraversal
 
-### Community 575 - "Community 575"
+### Community 576 - "Community 576"
 Cohesion: 0.5
 Nodes (0): 
 
-### Community 576 - "Community 576"
+### Community 577 - "Community 577"
 Cohesion: 0.67
 Nodes (2): createBulkMemories(), createTestMemory()
 
-### Community 577 - "Community 577"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 578 - "Community 578"
 Cohesion: 0.5
-Nodes (1): TripleNormalizer
+Nodes (0): 
 
 ### Community 579 - "Community 579"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): TripleNormalizer
 
 ### Community 580 - "Community 580"
 Cohesion: 0.5
@@ -3798,20 +3799,20 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 583 - "Community 583"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 584 - "Community 584"
 Cohesion: 0.83
 Nodes (3): applyRollbackDelete(), applyRollbackRestore(), rollback()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.5
 Nodes (1): GetMetaMemoryStatsTool
 
-### Community 585 - "Community 585"
-Cohesion: 0.5
-Nodes (1): PerformanceStatsTool
-
 ### Community 586 - "Community 586"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): PerformanceStatsTool
 
 ### Community 587 - "Community 587"
 Cohesion: 0.5
@@ -3819,39 +3820,39 @@ Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 0.5
-Nodes (1): CategoryQualityAggregator
+Nodes (0): 
 
 ### Community 589 - "Community 589"
 Cohesion: 0.5
-Nodes (1): ConsolidationMetricsCollector
+Nodes (1): CategoryQualityAggregator
 
 ### Community 590 - "Community 590"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): ConsolidationMetricsCollector
 
 ### Community 591 - "Community 591"
 Cohesion: 0.5
-Nodes (1): StorageMetricsCollector
+Nodes (0): 
 
 ### Community 592 - "Community 592"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (1): StorageMetricsCollector
 
 ### Community 593 - "Community 593"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 594 - "Community 594"
-Cohesion: 0.67
-Nodes (2): buildBenchmarkCorpus(), normalizeTags()
-
-### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 595 - "Community 595"
+Cohesion: 0.67
+Nodes (2): buildBenchmarkCorpus(), normalizeTags()
+
 ### Community 596 - "Community 596"
-Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 597 - "Community 597"
 Cohesion: 0.83
@@ -3859,19 +3860,19 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 598 - "Community 598"
 Cohesion: 0.83
-Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 599 - "Community 599"
 Cohesion: 0.83
-Nodes (3): main(), parseArgs(), printHelp()
+Nodes (3): acquireLongMemEval(), buildLongMemEvalDatasetUrl(), main()
 
 ### Community 600 - "Community 600"
-Cohesion: 0.5
-Nodes (0): 
-
-### Community 601 - "Community 601"
 Cohesion: 0.83
 Nodes (3): main(), parseArgs(), printHelp()
+
+### Community 601 - "Community 601"
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 602 - "Community 602"
 Cohesion: 0.83
@@ -3883,111 +3884,111 @@ Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.83
-Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+Nodes (3): main(), parseArgs(), printHelp()
 
 ### Community 605 - "Community 605"
+Cohesion: 0.83
+Nodes (3): anyCategoryFailsMrrGate(), formatCategoryReportLine(), main()
+
+### Community 606 - "Community 606"
 Cohesion: 1.0
 Nodes (3): checkDatabaseIntegrity(), log(), main()
 
-### Community 606 - "Community 606"
+### Community 607 - "Community 607"
 Cohesion: 0.83
 Nodes (3): findLatestRunDir(), main(), parseReportArgs()
 
-### Community 607 - "Community 607"
+### Community 608 - "Community 608"
 Cohesion: 1.0
 Nodes (3): renderManagedIssueBody(), startMarker(), upsertManagedIssueBody()
 
-### Community 608 - "Community 608"
+### Community 609 - "Community 609"
 Cohesion: 0.67
 Nodes (2): inferLevel(), parseAppLogLine()
 
-### Community 609 - "Community 609"
+### Community 610 - "Community 610"
 Cohesion: 0.67
 Nodes (2): createMonitorRuntime(), runForever()
 
-### Community 610 - "Community 610"
+### Community 611 - "Community 611"
 Cohesion: 0.67
 Nodes (2): main(), runExample()
 
-### Community 611 - "Community 611"
+### Community 612 - "Community 612"
 Cohesion: 0.5
 Nodes (0): 
-
-### Community 612 - "Community 612"
-Cohesion: 0.83
-Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
 
 ### Community 613 - "Community 613"
 Cohesion: 0.83
-Nodes (3): postCandidateAction(), showActionToast(), showError()
+Nodes (3): buildDetailRows(), buildTagsHtml(), getTypeBadgeClass()
 
 ### Community 614 - "Community 614"
-Cohesion: 0.5
-Nodes (0): 
+Cohesion: 0.83
+Nodes (3): postCandidateAction(), showActionToast(), showError()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.5
 Nodes (0): 
 
 ### Community 616 - "Community 616"
-Cohesion: 0.67
-Nodes (2): ensureTooltip(), showTooltip()
-
-### Community 617 - "Community 617"
-Cohesion: 0.83
-Nodes (3): initAgentSessionsPanel(), on(), wirePanel()
-
-### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (3): getSelectedAgentId(), loadAgentIdOptions(), loadMapData()
-
-### Community 619 - "Community 619"
-Cohesion: 0.83
-Nodes (3): renderMemoryGroups(), renderMemoryStats(), renderSnapshot()
-
-### Community 620 - "Community 620"
 Cohesion: 0.5
 Nodes (0): 
 
+### Community 617 - "Community 617"
+Cohesion: 0.67
+Nodes (2): ensureTooltip(), showTooltip()
+
+### Community 618 - "Community 618"
+Cohesion: 0.83
+Nodes (3): initAgentSessionsPanel(), on(), wirePanel()
+
+### Community 619 - "Community 619"
+Cohesion: 1.0
+Nodes (3): getSelectedAgentId(), loadAgentIdOptions(), loadMapData()
+
+### Community 620 - "Community 620"
+Cohesion: 0.83
+Nodes (3): renderMemoryGroups(), renderMemoryStats(), renderSnapshot()
+
 ### Community 621 - "Community 621"
+Cohesion: 0.5
+Nodes (0): 
+
+### Community 622 - "Community 622"
 Cohesion: 0.83
 Nodes (3): appendLabeledLine(), closeSidePanel(), openSidePanel()
 
-### Community 622 - "Community 622"
+### Community 623 - "Community 623"
 Cohesion: 0.67
 Nodes (1): SlowTransport
 
-### Community 623 - "Community 623"
+### Community 624 - "Community 624"
 Cohesion: 1.0
 Nodes (2): beforeUserTurn(), withTimeout()
 
-### Community 624 - "Community 624"
+### Community 625 - "Community 625"
 Cohesion: 0.67
 Nodes (0): 
-
-### Community 625 - "Community 625"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), sendOptions()
 
 ### Community 626 - "Community 626"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createMockResponse(), sendOptions()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 628 - "Community 628"
-Cohesion: 1.0
-Nodes (2): createMockResponse(), runAdminAuthProbe()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
+Nodes (2): createMockResponse(), runAdminAuthProbe()
 
 ### Community 630 - "Community 630"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): buildMcpManualCorsHeaders(), resolveCorsAllowOrigin()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
@@ -4014,12 +4015,12 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 637 - "Community 637"
-Cohesion: 1.0
-Nodes (2): loadEnv(), resolveEnvPath()
-
-### Community 638 - "Community 638"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 638 - "Community 638"
+Cohesion: 1.0
+Nodes (2): loadEnv(), resolveEnvPath()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
@@ -4034,40 +4035,40 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 642 - "Community 642"
-Cohesion: 1.0
-Nodes (2): compareServices(), testServerSynchronization()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 643 - "Community 643"
 Cohesion: 1.0
-Nodes (2): assert(), testMementoClient()
+Nodes (2): compareServices(), testServerSynchronization()
 
 ### Community 644 - "Community 644"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): assert(), testMementoClient()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (1): NoopSearchProvider
+Nodes (0): 
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (1): git()
+Nodes (1): NoopSearchProvider
 
 ### Community 647 - "Community 647"
-Cohesion: 1.0
-Nodes (2): invalid(), runClaudeCodeHook()
+Cohesion: 0.67
+Nodes (1): git()
 
 ### Community 648 - "Community 648"
 Cohesion: 1.0
-Nodes (2): log(), shouldLog()
+Nodes (2): invalid(), runClaudeCodeHook()
 
 ### Community 649 - "Community 649"
 Cohesion: 1.0
-Nodes (2): hybridSearch(), recall()
+Nodes (2): log(), shouldLog()
 
 ### Community 650 - "Community 650"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): hybridSearch(), recall()
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
@@ -4078,24 +4079,24 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 653 - "Community 653"
-Cohesion: 1.0
-Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 654 - "Community 654"
 Cohesion: 1.0
-Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
+Nodes (2): getIntegratedMetrics(), getReflexionMetrics()
 
 ### Community 655 - "Community 655"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): mergeProceduralSteps(), updateProceduralMemoryIncremental()
 
 ### Community 656 - "Community 656"
-Cohesion: 1.0
-Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
-
-### Community 657 - "Community 657"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 657 - "Community 657"
+Cohesion: 1.0
+Nodes (2): addMissingColumn(), ensureMemoryItemTripleExtractionColumns()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
@@ -4110,20 +4111,20 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 661 - "Community 661"
-Cohesion: 1.0
-Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
-
-### Community 662 - "Community 662"
 Cohesion: 0.67
 Nodes (0): 
+
+### Community 662 - "Community 662"
+Cohesion: 1.0
+Nodes (2): buildMemoryReviewCandidatesRunDiagnosticsPayload(), readRunDetails()
 
 ### Community 663 - "Community 663"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 664 - "Community 664"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): isIsolatedCandidate(), runAnchorAutoRefresh()
 
 ### Community 665 - "Community 665"
 Cohesion: 0.67
@@ -4158,52 +4159,52 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 673 - "Community 673"
-Cohesion: 1.0
-Nodes (2): isTransientCapacityError(), logExternalApiRetry()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (1): RuleBasedProceduralExtractor
+Nodes (0): 
 
 ### Community 675 - "Community 675"
 Cohesion: 1.0
-Nodes (2): getVectorTableName(), validateTableName()
+Nodes (2): isTransientCapacityError(), logExternalApiRetry()
 
 ### Community 676 - "Community 676"
-Cohesion: 1.0
-Nodes (2): issue(), validateConfiguration()
+Cohesion: 0.67
+Nodes (1): RuleBasedProceduralExtractor
 
 ### Community 677 - "Community 677"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): getVectorTableName(), validateTableName()
 
 ### Community 678 - "Community 678"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): issue(), validateConfiguration()
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 680 - "Community 680"
-Cohesion: 1.0
-Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 681 - "Community 681"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 682 - "Community 682"
-Cohesion: 0.67
-Nodes (1): SearchError
+Cohesion: 1.0
+Nodes (2): resolveLlmModel(), resolveProviderDefaultModel()
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 684 - "Community 684"
-Cohesion: 1.0
-Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
+Cohesion: 0.67
+Nodes (1): SearchError
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
@@ -4211,31 +4212,31 @@ Nodes (0):
 
 ### Community 686 - "Community 686"
 Cohesion: 1.0
-Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
+Nodes (2): avgCandidateCountForPeriod(), querySearchQuality()
 
 ### Community 687 - "Community 687"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 688 - "Community 688"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): parsePersonalAgentLlmEnv(), readProviderToken()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 690 - "Community 690"
-Cohesion: 1.0
-Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 691 - "Community 691"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 692 - "Community 692"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): finalizeMemoryItemRecallEnvelope(), getMetaStatsForResults()
 
 ### Community 693 - "Community 693"
 Cohesion: 0.67
@@ -4247,23 +4248,23 @@ Nodes (0):
 
 ### Community 695 - "Community 695"
 Cohesion: 0.67
-Nodes (1): MetaMemoryIntrospectionService
+Nodes (0): 
 
 ### Community 696 - "Community 696"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 697 - "Community 697"
+Cohesion: 0.67
+Nodes (1): MetaMemoryIntrospectionService
+
+### Community 698 - "Community 698"
 Cohesion: 1.0
 Nodes (2): generateMemoryId(), rollbackToVersion()
 
-### Community 697 - "Community 697"
+### Community 699 - "Community 699"
 Cohesion: 1.0
 Nodes (2): selectionWindowLimit(), selectMemoryReviewCandidates()
-
-### Community 698 - "Community 698"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 699 - "Community 699"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 700 - "Community 700"
 Cohesion: 0.67
@@ -4290,20 +4291,20 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 706 - "Community 706"
-Cohesion: 1.0
-Nodes (2): mergeTripleLists(), tripleDedupeKey()
-
-### Community 707 - "Community 707"
-Cohesion: 1.0
-Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
-
-### Community 708 - "Community 708"
 Cohesion: 0.67
 Nodes (0): 
 
-### Community 709 - "Community 709"
+### Community 707 - "Community 707"
 Cohesion: 0.67
-Nodes (1): AgentIntegrationError
+Nodes (0): 
+
+### Community 708 - "Community 708"
+Cohesion: 1.0
+Nodes (2): mergeTripleLists(), tripleDedupeKey()
+
+### Community 709 - "Community 709"
+Cohesion: 1.0
+Nodes (2): determineRelationLlmProvider(), isOllamaPreferredSlotAvailable()
 
 ### Community 710 - "Community 710"
 Cohesion: 0.67
@@ -4311,35 +4312,35 @@ Nodes (0):
 
 ### Community 711 - "Community 711"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (1): AgentIntegrationError
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 713 - "Community 713"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 714 - "Community 714"
+Cohesion: 0.67
+Nodes (0): 
+
+### Community 715 - "Community 715"
 Cohesion: 1.0
 Nodes (2): compareToolResults(), testToolConsistency()
 
-### Community 714 - "Community 714"
+### Community 716 - "Community 716"
 Cohesion: 1.0
 Nodes (2): createQualityTables(), testQualityAssuranceE2E()
-
-### Community 715 - "Community 715"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 716 - "Community 716"
-Cohesion: 0.67
-Nodes (0): 
 
 ### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0): 
 
 ### Community 718 - "Community 718"
-Cohesion: 1.0
-Nodes (2): calculateRanks(), calculateSpearmanRho()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 719 - "Community 719"
 Cohesion: 0.67
@@ -4347,7 +4348,7 @@ Nodes (0):
 
 ### Community 720 - "Community 720"
 Cohesion: 1.0
-Nodes (2): listUstarGzipEntryPaths(), readTarString()
+Nodes (2): calculateRanks(), calculateSpearmanRho()
 
 ### Community 721 - "Community 721"
 Cohesion: 0.67
@@ -4355,39 +4356,39 @@ Nodes (0):
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (2): main(), option()
+Nodes (2): listUstarGzipEntryPaths(), readTarString()
 
 ### Community 723 - "Community 723"
-Cohesion: 1.0
-Nodes (2): fetchJson(), testDockerServer()
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): fixTfidfDimensions(), loadVecExtension()
+Nodes (2): main(), option()
 
 ### Community 725 - "Community 725"
 Cohesion: 1.0
-Nodes (2): main(), reappearanceRate()
+Nodes (2): fetchJson(), testDockerServer()
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
-Nodes (2): createBackup(), removeBenchmarkTestData()
+Nodes (2): fixTfidfDimensions(), loadVecExtension()
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (2): createFingerprint(), normalizeMessage()
+Nodes (2): main(), reappearanceRate()
 
 ### Community 728 - "Community 728"
 Cohesion: 1.0
-Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
+Nodes (2): createBackup(), removeBenchmarkTestData()
 
 ### Community 729 - "Community 729"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): createFingerprint(), normalizeMessage()
 
 ### Community 730 - "Community 730"
-Cohesion: 0.67
-Nodes (0): 
+Cohesion: 1.0
+Nodes (2): limitUtf8Bytes(), sanitizeExcerpt()
 
 ### Community 731 - "Community 731"
 Cohesion: 0.67
@@ -4406,11 +4407,11 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 735 - "Community 735"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 736 - "Community 736"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0): 
 
 ### Community 737 - "Community 737"
@@ -7177,1394 +7178,1396 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0): 
 
+### Community 1428 - "Community 1428"
+Cohesion: 1.0
+Nodes (0): 
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `TimeoutError`, `InjectionTimeoutError`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 735`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
+- **Thin community `Community 737`** (2 nodes): `afterAssistantTurn()`, `after-assistant-turn.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
+- **Thin community `Community 738`** (2 nodes): `shouldAutoRecall()`, `auto-recall-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
+- **Thin community `Community 739`** (2 nodes): `rememberDispatch()`, `auto-remember-policy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
+- **Thin community `Community 740`** (2 nodes): `createTransportFromEnv()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
+- **Thin community `Community 741`** (2 nodes): `test-basic.js`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
+- **Thin community `Community 742`** (2 nodes): `basicUsageExample()`, `basic-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
+- **Thin community `Community 743`** (2 nodes): `advancedUsageExample()`, `advanced-usage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
+- **Thin community `Community 744`** (2 nodes): `telemetry-cli.spec.ts`, `makeNullRunner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
+- **Thin community `Community 745`** (2 nodes): `readShellSources()`, `dashboard-memory-evolution-demo-shell.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `server-factory.ts`, `createServerFactory()`
+- **Thin community `Community 746`** (2 nodes): `server-factory.ts`, `createServerFactory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
+- **Thin community `Community 747`** (2 nodes): `setupWebSocketServer()`, `http-server-websocket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
+- **Thin community `Community 748`** (2 nodes): `stdio-server-impl.ts`, `startStdioServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
+- **Thin community `Community 749`** (2 nodes): `simple-mcp-server.ts`, `startSimpleMcpServer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
+- **Thin community `Community 750`** (2 nodes): `mapToolExecutionErrorToJsonRpc()`, `mcp-tool-call-error.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
+- **Thin community `Community 751`** (2 nodes): `tool-result.utils.ts`, `extractToolResultPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
+- **Thin community `Community 752`** (2 nodes): `getRequest()`, `http-rate-limit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
+- **Thin community `Community 753`** (2 nodes): `tool-context.middleware.ts`, `createToolContextMiddleware()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
+- **Thin community `Community 754`** (2 nodes): `session-auth.middleware.spec.ts`, `createMockResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
+- **Thin community `Community 755`** (2 nodes): `createMockResponse()`, `http-audit.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
+- **Thin community `Community 756`** (2 nodes): `service-injector.middleware.ts`, `createServiceInjector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
+- **Thin community `Community 757`** (2 nodes): `createAdminAuthMiddleware()`, `admin-auth.middleware.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
+- **Thin community `Community 758`** (2 nodes): `runMiddleware()`, `owner-scope.middleware.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `session-store.ts`, `createSessionStore()`
+- **Thin community `Community 759`** (2 nodes): `session-store.ts`, `createSessionStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
+- **Thin community `Community 760`** (2 nodes): `createAgentRouter()`, `agent.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
+- **Thin community `Community 761`** (2 nodes): `request()`, `maintenance.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
+- **Thin community `Community 762`** (2 nodes): `invoke()`, `agent-personal.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
+- **Thin community `Community 763`** (2 nodes): `prepareEvent()`, `agent.routes.events.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
+- **Thin community `Community 764`** (2 nodes): `createAdminRouter()`, `admin.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
+- **Thin community `Community 765`** (2 nodes): `createMcpRouter()`, `mcp.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
+- **Thin community `Community 766`** (2 nodes): `tools.routes.ts`, `createToolsRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `request()`, `audit.routes.spec.ts`
+- **Thin community `Community 767`** (2 nodes): `request()`, `audit.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `createApiRouter()`, `api.routes.ts`
+- **Thin community `Community 768`** (2 nodes): `createApiRouter()`, `api.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
+- **Thin community `Community 769`** (2 nodes): `quality.routes.ts`, `createQualityRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
+- **Thin community `Community 770`** (2 nodes): `registerAdminEvolutionDemoRoutes()`, `admin-evolution-demo.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
+- **Thin community `Community 771`** (2 nodes): `registerAdminStatsAndHealthRoutes()`, `admin-stats-and-health.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
+- **Thin community `Community 772`** (2 nodes): `buildGraphResponse()`, `admin-graph-response.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
+- **Thin community `Community 773`** (2 nodes): `registerAdminToolRoutes()`, `admin-tools.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
+- **Thin community `Community 774`** (2 nodes): `registerAdminBatchRoutes()`, `admin-batch.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
+- **Thin community `Community 775`** (2 nodes): `registerAdminForgettingRoutes()`, `admin-forgetting.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
+- **Thin community `Community 776`** (2 nodes): `registerAdminGraphRoute()`, `admin-graph.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
+- **Thin community `Community 777`** (2 nodes): `registerAdminRuntimePerformanceRoutes()`, `admin-runtime-performance.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
+- **Thin community `Community 778`** (2 nodes): `registerAdminTelemetryRoutes()`, `admin-telemetry.routes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
+- **Thin community `Community 779`** (2 nodes): `effectiveTelemetryPeriod()`, `admin-telemetry-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `argv()`, `agent-ask.spec.ts`
+- **Thin community `Community 780`** (2 nodes): `argv()`, `agent-ask.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
+- **Thin community `Community 781`** (2 nodes): `runDemo()`, `agent-ops-demo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
+- **Thin community `Community 782`** (2 nodes): `event()`, `claude-code-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `event()`, `codex-hook.spec.ts`
+- **Thin community `Community 783`** (2 nodes): `event()`, `codex-hook.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
+- **Thin community `Community 784`** (2 nodes): `promptApproveInteractive()`, `approval.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `agentAskHelpText()`, `help.ts`
+- **Thin community `Community 785`** (2 nodes): `agentAskHelpText()`, `help.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
+- **Thin community `Community 786`** (2 nodes): `test-simple-alerts.ts`, `testSimpleAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
+- **Thin community `Community 787`** (2 nodes): `test-http-server-v2-simple.ts`, `testBasicFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
+- **Thin community `Community 788`** (2 nodes): `test-performance-monitoring.ts`, `testPerformanceMonitoring()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
+- **Thin community `Community 789`** (2 nodes): `test-error-logging.ts`, `testErrorLogging()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
+- **Thin community `Community 790`** (2 nodes): `testFetch()`, `debug-http-v2.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 791`** (2 nodes): `test-reflexion-error-cases.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
+- **Thin community `Community 792`** (2 nodes): `test-reflexion-e2e.spec.ts`, `testReflexionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
+- **Thin community `Community 793`** (2 nodes): `test-alerts-direct.ts`, `testAlertsDirect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
+- **Thin community `Community 794`** (2 nodes): `test-performance-alerts.ts`, `testPerformanceAlerts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
+- **Thin community `Community 795`** (2 nodes): `test-security-path-traversal.ts`, `testPathTraversalE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
+- **Thin community `Community 796`** (2 nodes): `test-security-sql-injection.ts`, `testSqlInjectionE2E()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
+- **Thin community `Community 797`** (2 nodes): `search-factory.ts`, `createSearchProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `types.ts`, `loadAgentConfig()`
+- **Thin community `Community 798`** (2 nodes): `types.ts`, `loadAgentConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
+- **Thin community `Community 799`** (2 nodes): `queue-runtime.spec.ts`, `transport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
+- **Thin community `Community 800`** (2 nodes): `test-fixtures.ts`, `eventFixture()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
+- **Thin community `Community 801`** (2 nodes): `diagnoseCodex()`, `diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `runner.ts`, `runCodexHook()`
+- **Thin community `Community 802`** (2 nodes): `runner.ts`, `runCodexHook()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `utils.spec.ts`, `buildMemory()`
+- **Thin community `Community 803`** (2 nodes): `utils.spec.ts`, `buildMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createMementoClient()`, `factory.ts`
+- **Thin community `Community 804`** (2 nodes): `createMementoClient()`, `factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `initializeServices()`, `bootstrap.ts`
+- **Thin community `Community 805`** (2 nodes): `initializeServices()`, `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
+- **Thin community `Community 806`** (2 nodes): `write-and-meta.ts`, `createWriteCoalescingMetaAndScore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
+- **Thin community `Community 807`** (2 nodes): `createBatchTelemetryRelationAndSleep()`, `batch-telemetry-relation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
+- **Thin community `Community 808`** (2 nodes): `createAnchorStack()`, `anchor-stack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
+- **Thin community `Community 809`** (2 nodes): `startFailureAndReflexion()`, `failure-reflexion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
+- **Thin community `Community 810`** (2 nodes): `search-and-embedding.ts`, `createSearchEmbeddingAndOptimizerServices()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
+- **Thin community `Community 811`** (2 nodes): `createMonitoringAndSchedulers()`, `monitoring-schedulers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
+- **Thin community `Community 812`** (2 nodes): `runtime-diagnostics-sampler.ts`, `createRuntimeDiagnosticsSampler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
+- **Thin community `Community 813`** (2 nodes): `createInput()`, `consolidation-score-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
+- **Thin community `Community 814`** (2 nodes): `relation-graph-factory.ts`, `createRelationGraph()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
+- **Thin community `Community 815`** (2 nodes): `reflexion-procedural-create.ts`, `createProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
+- **Thin community `Community 816`** (2 nodes): `reflexion-procedural-update-replace.ts`, `updateProceduralMemoryReplace()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
+- **Thin community `Community 817`** (2 nodes): `reflexion-procedural-extraction.ts`, `resolveExtractedProceduralMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
+- **Thin community `Community 818`** (2 nodes): `reflexion-procedural-update-versioned.ts`, `updateProceduralMemoryVersioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
+- **Thin community `Community 819`** (2 nodes): `createBaseSchema()`, `database-lock-scenarios.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
+- **Thin community `Community 820`** (2 nodes): `wal-checkpoint-scheduler.spec.ts`, `uniqueWalTestDbPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
+- **Thin community `Community 821`** (2 nodes): `openLockTestDatabase()`, `database-lock-monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
+- **Thin community `Community 822`** (2 nodes): `createProgress()`, `migration-monitor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
+- **Thin community `Community 823`** (2 nodes): `createCoreMemoryRepository()`, `core-memory-repository.factory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
+- **Thin community `Community 824`** (2 nodes): `createCoreMemoryTable()`, `core-memory-auto-load.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `vec-cosine-metric.integration.spec.ts`, `vector()`
+- **Thin community `Community 825`** (2 nodes): `vec-cosine-metric.integration.spec.ts`, `vector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
+- **Thin community `Community 826`** (2 nodes): `bootstrapNewDatabaseSchema()`, `init-bootstrap-new-db.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `log()`, `init-log.ts`
+- **Thin community `Community 827`** (2 nodes): `log()`, `init-log.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
+- **Thin community `Community 828`** (2 nodes): `createDbPath()`, `db-integrity-preflight.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
+- **Thin community `Community 829`** (2 nodes): `migrateExistingDatabaseIfNeeded()`, `init-migrate-existing.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
+- **Thin community `Community 830`** (2 nodes): `recordBundledSchemaSqlMigrationBaseline()`, `init-migration-baseline.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
+- **Thin community `Community 831`** (2 nodes): `configureSqliteSession()`, `init-sqlite-session.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
+- **Thin community `Community 832`** (2 nodes): `createBaseSchema()`, `migration-runner.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
+- **Thin community `Community 833`** (2 nodes): `createBaseSchema()`, `008-arigraph-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
+- **Thin community `Community 834`** (2 nodes): `createBaseSchema()`, `011-meta-memory-stats-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
+- **Thin community `Community 835`** (2 nodes): `createBaseSchema()`, `009-quality-assurance-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
+- **Thin community `Community 836`** (2 nodes): `createBaseSchema()`, `002-mirix-schema-expansion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
+- **Thin community `Community 837`** (2 nodes): `createSchemaWith018()`, `019-backfill-kg-triple-from-memory-item.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
+- **Thin community `Community 838`** (2 nodes): `createBaseSchema()`, `004-anchor-table.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
+- **Thin community `Community 839`** (2 nodes): `applicableTypesFor()`, `038-relation-type-registry-seeds.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
+- **Thin community `Community 840`** (2 nodes): `createBaseSchema()`, `010-add-core-memory-version.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
+- **Thin community `Community 841`** (2 nodes): `createBaseSchema()`, `007-procedural-memory-enhancement.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
+- **Thin community `Community 842`** (2 nodes): `createBaseSchema()`, `003-consolidation-score-fields.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
+- **Thin community `Community 843`** (2 nodes): `mergeBatchSchedulerJobConfig()`, `batch-scheduler-default-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
+- **Thin community `Community 844`** (2 nodes): `collectBatchSchedulerDatabaseStats()`, `batch-scheduler-database-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
+- **Thin community `Community 845`** (2 nodes): `validateBatchJobConfig()`, `batch-scheduler-validate-config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `runAnchorAutoRefresh()`, `batch-scheduler-anchor-handlers.ts`
+- **Thin community `Community 846`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `createCoordinator()`, `batch-job-execution-coordinator.spec.ts`
+- **Thin community `Community 847`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `retry-manager.spec.ts`, `shouldRetry()`
+- **Thin community `Community 848`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `baseResult()`, `memory-review-candidates-run-diagnostics.spec.ts`
+- **Thin community `Community 849`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `initializeTestDatabase()`, `batch-scheduler-consolidation-score.spec.ts`
+- **Thin community `Community 850`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `failingJob()`, `job-execution-retry.spec.ts`
+- **Thin community `Community 851`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `executionCoordinator()`, `batch-scheduler.test-setup.ts`
+- **Thin community `Community 852`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `quality-measurement-batch-job.spec.ts`, `createQualityTables()`
+- **Thin community `Community 853`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `triple-extraction-batch-job.types.ts`, `getErrorCode()`
+- **Thin community `Community 854`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `logBatchSchedulerMessage()`, `batch-scheduler-logging.ts`
+- **Thin community `Community 855`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `checkBatchSchedulerHealth()`, `batch-scheduler-health.ts`
+- **Thin community `Community 856`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `getBatchSchedulerDetailedStats()`, `batch-scheduler-stats.ts`
+- **Thin community `Community 857`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `parseOwnerScopeMode()`, `owner-scope-mode.ts`
+- **Thin community `Community 858`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `rotateJsonlIfNeeded()`, `jsonl-rotation.ts`
+- **Thin community `Community 859`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `emitTfidfFallbackWarningIfNeeded()`, `embedding-provider-diagnostics.ts`
+- **Thin community `Community 860`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `validateAndNormalizeDbPath()`, `db-path.ts`
+- **Thin community `Community 861`** (2 nodes): `operation()`, `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `operation()`, `error-handling.spec.ts`
+- **Thin community `Community 862`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `ensureMemoryReviewCandidateSchema()`, `ensure-memory-review-candidate-schema.ts`
+- **Thin community `Community 863`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `withErrorHandling()`, `error-handling.ts`
+- **Thin community `Community 864`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `ensureMetaMemoryStatsSchema()`, `ensure-meta-memory-stats-schema.ts`
+- **Thin community `Community 865`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `procedural-memory-change-detector.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 866`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `ensureQualityAssuranceSchema()`, `ensure-quality-assurance-schema.ts`
+- **Thin community `Community 867`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `procedural-memory-extractor.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 868`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `schema-initialization.ts`, `initializeDatabase()`
+- **Thin community `Community 869`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `assertMacroCategory()`, `benchmark.types.ts`
+- **Thin community `Community 870`** (2 nodes): `validateConfig()`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `validateConfig()`, `index.ts`
+- **Thin community `Community 871`** (2 nodes): `initializeGemini()`, `gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `initializeGemini()`, `gemini.ts`
+- **Thin community `Community 872`** (2 nodes): `initializeOpenAI()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `initializeOpenAI()`, `openai.ts`
+- **Thin community `Community 873`** (2 nodes): `source-uri.ts`, `validateSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `source-uri.ts`, `validateSource()`
+- **Thin community `Community 874`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `set-anchor-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 875`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `search-local-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 876`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `vector-search-engine-types.ts`, `isInitializableVectorSearchEngine()`
+- **Thin community `Community 877`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `resolveRepoRankingProfile()`, `hybrid-search.factory.spec.ts`
+- **Thin community `Community 878`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `normalizeSearchBySimilarityOutcome()`, `hybrid-search-outcome-utils.ts`
+- **Thin community `Community 879`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `search-engine-sql-builder.ts`, `buildSearchStatement()`
+- **Thin community `Community 880`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `vector-search.repository.spec.ts`, `seedScopedHybridMemories()`
+- **Thin community `Community 881`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `vector-search-scope.ts`, `parseVectorSearchScope()`
+- **Thin community `Community 882`** (2 nodes): `vector-search-result-mapper.spec.ts`, `rawResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `vector-search-result-mapper.spec.ts`, `rawResult()`
+- **Thin community `Community 883`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `vector-performance-tester.spec.ts`, `createMockPerformanceRepository()`
+- **Thin community `Community 884`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `vector-search.service.spec.ts`, `createMockRepository()`
+- **Thin community `Community 885`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `vector-search-facade.spec.ts`, `createMockRepositories()`
+- **Thin community `Community 886`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `vector-index-manager.spec.ts`, `createMockIndexRepository()`
+- **Thin community `Community 887`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `telemetry-feedback-quality-query.ts`, `queryFeedbackQuality()`
+- **Thin community `Community 888`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `telemetry-repository.spec.ts`, `openTelemetryDb()`
+- **Thin community `Community 889`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `isAmbiguousUserMessage()`, `knowledge-candidate-text-ambiguity.ts`
+- **Thin community `Community 890`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `baseCandidate()`, `knowledge-candidate-to-remember-params.spec.ts`
+- **Thin community `Community 891`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `personal-knowledge-agent-service.spec.ts`, `makeDeps()`
+- **Thin community `Community 892`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `createPersonalAgentLlmPort()`, `create-personal-agent-llm-port.ts`
+- **Thin community `Community 893`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `normalizeMemoryTypesForHybridItemSearch()`, `normalize-memory-types-for-item-search.ts`
+- **Thin community `Community 894`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `sigmoidNormalizedNet()`, `feedback-repository.interface.ts`
+- **Thin community `Community 895`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `createKgTripleTable()`, `kg-triple-repository.spec.ts`
+- **Thin community `Community 896`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `process-attribute-repository.spec.ts`, `createProcessAttributeTable()`
+- **Thin community `Community 897`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-repository.spec.ts`
+- **Thin community `Community 898`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `createCoreMemoryTable()`, `core-memory-repository.spec.ts`
+- **Thin community `Community 899`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `remember-tool-vault.ts`, `handleVaultMemory()`
+- **Thin community `Community 900`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `recall-tool-schema.ts`, `normalizeProviderFilter()`
+- **Thin community `Community 901`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `recall-tool-search-execution.ts`, `executeHybridOrTextSearchForMemoryItem()`
+- **Thin community `Community 902`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `recall-tool-neighbors-fetch.ts`, `handleIncludeNeighbors()`
+- **Thin community `Community 903`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `recall-tool-anchor-rotation.ts`, `handleAutoSetAnchor()`
+- **Thin community `Community 904`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `recall-tool-results.ts`, `mapRecallSearchItemsToResultItems()`
+- **Thin community `Community 905`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `remember-tool-core.ts`, `handleCoreMemory()`
+- **Thin community `Community 906`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `recall-tool-anchor-rotation.spec.ts`, `createAnchorTable()`
+- **Thin community `Community 907`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `procedural-diff-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 908`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `procedural-rollback-tool.spec.ts`, `createSchema()`
+- **Thin community `Community 909`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `initializeTestDatabase()`, `export-memories-tool.spec.ts`
+- **Thin community `Community 910`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `remember-procedure-tool.spec.ts`, `initializeTestDatabase()`
+- **Thin community `Community 911`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `parseData()`, `feedback-tool.spec.ts`
+- **Thin community `Community 912`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-persistence-service.spec.ts`
+- **Thin community `Community 913`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `baseRow()`, `memory-review-candidate-selection-scoring.spec.ts`
+- **Thin community `Community 914`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `repetition-meta-update-service.ts`, `updateRepresentativeRepetitionMeta()`
+- **Thin community `Community 915`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `openDb()`, `admin-memory-item-preview-service.spec.ts`
+- **Thin community `Community 916`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `createBaseSchema()`, `memory-review-candidate-selection-service.spec.ts`
+- **Thin community `Community 917`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `createBaseSchema()`, `meta-memory-service.spec.ts`
+- **Thin community `Community 918`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `createKnowledgeVaultTable()`, `knowledge-vault-service.spec.ts`
+- **Thin community `Community 919`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `procedural-rollback-service.spec.ts`, `createSchema()`
+- **Thin community `Community 920`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `procedural-versioning.spec.ts`, `createSchema()`
+- **Thin community `Community 921`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `createBaseSchema()`, `meta-memory-introspection-service.spec.ts`
+- **Thin community `Community 922`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `procedural-memory-diff.spec.ts`, `createSchema()`
+- **Thin community `Community 923`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `semantic-memory-update-types.ts`, `generateSemanticMemoryId()`
+- **Thin community `Community 924`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `applyConsolidationTestSchema()`, `consolidation-test-schema.ts`
+- **Thin community `Community 925`** (2 nodes): `summarization-service.spec.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `summarization-service.spec.ts`, `row()`
+- **Thin community `Community 926`** (2 nodes): `ep()`, `clustering-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ep()`, `clustering-service.spec.ts`
+- **Thin community `Community 927`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `createMemoryDbWithKgTriple()`, `extract-triples-tool.spec.ts`
+- **Thin community `Community 928`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 929`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `rule-based-relation-extractor.spec.ts`, `createTestMemory()`
+- **Thin community `Community 930`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `triple-pipeline-orchestrator.spec.ts`, `extract()`
+- **Thin community `Community 931`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `triple-text-chunker.ts`, `splitTextIntoChunks()`
+- **Thin community `Community 932`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `triple-input-normalizer.ts`, `normalizeChatMessagesToText()`
+- **Thin community `Community 933`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `extractRelationsWithGemini()`, `extract-relations-gemini.ts`
+- **Thin community `Community 934`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `extractRelationsWithOpenAI()`, `extract-relations-openai.ts`
+- **Thin community `Community 935`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `filterRelationCandidatesByEmbedding()`, `embedding-candidate-filter.ts`
+- **Thin community `Community 936`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `extractRelationsWithOllama()`, `extract-relations-ollama.ts`
+- **Thin community `Community 937`** (2 nodes): `matchRelations()`, `matching-rules.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `matchRelations()`, `matching-rules.ts`
+- **Thin community `Community 938`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `buildProvenanceTrace()`, `agent-provenance-graph.ts`
+- **Thin community `Community 939`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `executeAgentCaptureTransaction()`, `agent-capture-transaction.ts`
+- **Thin community `Community 940`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `resolve-error.ts`, `executeResolveError()`
+- **Thin community `Community 941`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `executeErrorStats()`, `error-stats.ts`
+- **Thin community `Community 942`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `createBaseSchema()`, `get-meta-memory-stats-tool.spec.ts`
+- **Thin community `Community 943`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `runtime-diagnostics-logger.spec.ts`, `restoreEnvValue()`
+- **Thin community `Community 944`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `quality-evaluator.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 945`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `quality-threshold-manager.spec.ts`, `createQualityThresholdsTable()`
+- **Thin community `Community 946`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `test-bootstrap.ts`, `testBootstrapIntegration()`
+- **Thin community `Community 947`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `test-sleep-consolidation-isolation.spec.ts`, `measureRecall()`
+- **Thin community `Community 948`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `test-embedding.ts`, `testEmbeddingFunctionality()`
+- **Thin community `Community 949`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `test-search.ts`, `testSearchFunctionality()`
+- **Thin community `Community 950`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `test-forgetting.ts`, `testForgettingFunctionality()`
+- **Thin community `Community 951`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `test-m1-completion.ts`, `testM1Completion()`
+- **Thin community `Community 952`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `test-gemini-embedding.ts`, `testGeminiEmbeddingService()`
+- **Thin community `Community 953`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `test-feedback-ranking.spec.ts`, `parseItems()`
+- **Thin community `Community 954`** (2 nodes): `test-regression.ts`, `testRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `test-regression.ts`, `testRegression()`
+- **Thin community `Community 955`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `test-single-provider-regression.ts`, `testSingleProviderRegression()`
+- **Thin community `Community 956`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `test-vector-search-engine.ts`, `constructor()`
+- **Thin community `Community 957`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `test-memory-neighbors.ts`, `createTestMemories()`
+- **Thin community `Community 958`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `test-lightweight-embedding.ts`, `testLightweightEmbeddingFunctionality()`
+- **Thin community `Community 959`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `test-sleep-consolidation.spec.ts`, `seedCluster()`
+- **Thin community `Community 960`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `search-quality-review-verifier.spec.ts`, `writeFixtureDir()`
+- **Thin community `Community 961`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `search-quality-candidate-builder.ts`, `mergeCandidateIds()`
+- **Thin community `Community 962`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `top-k-retention.ts`, `calculateTopKRetention()`
+- **Thin community `Community 963`** (2 nodes): `copyDir()`, `copy-assets.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `copyDir()`, `copy-assets.js`
+- **Thin community `Community 964`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `readRootPackageJson()`, `npm-publish-bin.spec.ts`
+- **Thin community `Community 965`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `workspace-client-paths.spec.ts`, `readJson()`
+- **Thin community `Community 966`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `readWorkflow()`, `security-check-workflow.spec.ts`
+- **Thin community `Community 967`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `extractFencedBlocks()`, `smoke.spec.ts`
+- **Thin community `Community 968`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `shouldInclude()`, `prepack-bundle-core.js`
+- **Thin community `Community 969`** (2 nodes): `fixMigration()`, `fix-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `fixMigration()`, `fix-migration.js`
+- **Thin community `Community 970`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `simple-update.js`, `updateEmbeddings()`
+- **Thin community `Community 971`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `simple-migrate-wrapper.ts`, `analyzeEmbeddings()`
+- **Thin community `Community 972`** (2 nodes): `runMigration()`, `run-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `runMigration()`, `run-migration.js`
+- **Thin community `Community 973`** (2 nodes): `safeMigration()`, `safe-migration.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `safeMigration()`, `safe-migration.js`
+- **Thin community `Community 974`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `saveWorkMemory()`, `save-work-memory.ts`
+- **Thin community `Community 975`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `main()`, `quality-benchmark-verify-categories.ts`
+- **Thin community `Community 976`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `simple-migrate.js`, `analyzeEmbeddings()`
+- **Thin community `Community 977`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `fixVectorDimensions()`, `fix-vector-dimensions.js`
+- **Thin community `Community 978`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `simple-update-wrapper.ts`, `runUpdateMigration()`
+- **Thin community `Community 979`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `regenerateEmbeddings()`, `regenerate-embeddings.js`
+- **Thin community `Community 980`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `sampleReport()`, `quality-benchmark-category-report.spec.ts`
+- **Thin community `Community 981`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `debugEmbeddings()`, `debug-embeddings.js`
+- **Thin community `Community 982`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `backupEmbeddings()`, `backup-embeddings.js`
+- **Thin community `Community 983`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `makeRng()`, `compare-weight-profiles.spec.ts`
+- **Thin community `Community 984`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `jsonEmbedding()`, `migrate-embedding-data.integration.spec.ts`
+- **Thin community `Community 985`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `supports-tsx-subprocess.ts`, `supportsTsxSubprocess()`
+- **Thin community `Community 986`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `jsonEmbedding()`, `fix-migration.integration.spec.ts`
+- **Thin community `Community 987`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `main()`, `check-embedding-dimensions.ts`
+- **Thin community `Community 988`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `checkConvertibleEpisodicMemories()`, `check-convertible-episodic-memories.ts`
+- **Thin community `Community 989`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `analyzeBenchmarkTestData()`, `analyze-benchmark-test-data.ts`
+- **Thin community `Community 990`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `fixVecTableDimensions()`, `fix-vec-table-dimensions.ts`
+- **Thin community `Community 991`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `shouldSyncToGitHub()`, `promotion.ts`
+- **Thin community `Community 992`** (2 nodes): `config()`, `monitor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `config()`, `monitor.spec.ts`
+- **Thin community `Community 993`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `tryOsNotifyReviewQueueGrowth()`, `review-candidates-panel-poll-notify-os.js`
+- **Thin community `Community 994`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `initReviewCandidatesPanel()`, `review-candidates-panel.js`
+- **Thin community `Community 995`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline-category.js`
+- **Thin community `Community 996`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `init()`, `memory-evolution-demo-shell.js`
+- **Thin community `Community 997`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `eventCategory()`, `agent-sessions-panel-render-timeline.js`
+- **Thin community `Community 998`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `handleSignInResponse()`, `dashboard-auth-sign-in.js`
+- **Thin community `Community 999`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `handleSessionCheckResponse()`, `dashboard-auth-session-check.js`
+- **Thin community `Community 1000`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1001`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1002`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1003`** (1 nodes): `assistant.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `assistant.spec.ts`
+- **Thin community `Community 1004`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `types.ts`
+- **Thin community `Community 1005`** (1 nodes): `types.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `types.spec.ts`
+- **Thin community `Community 1006`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `index.ts`
+- **Thin community `Community 1007`** (1 nodes): `after-assistant-turn.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `after-assistant-turn.spec.ts`
+- **Thin community `Community 1008`** (1 nodes): `auto-remember-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `auto-remember-policy.spec.ts`
+- **Thin community `Community 1009`** (1 nodes): `auto-recall-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `auto-recall-policy.spec.ts`
+- **Thin community `Community 1010`** (1 nodes): `channel-scope.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `channel-scope.spec.ts`
+- **Thin community `Community 1011`** (1 nodes): `stdio-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `stdio-transport.spec.ts`
+- **Thin community `Community 1012`** (1 nodes): `mock-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `mock-transport.spec.ts`
+- **Thin community `Community 1013`** (1 nodes): `transport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `transport.ts`
+- **Thin community `Community 1014`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `index.ts`
+- **Thin community `Community 1015`** (1 nodes): `http-transport.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `http-transport.spec.ts`
+- **Thin community `Community 1016`** (1 nodes): `factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `factory.spec.ts`
+- **Thin community `Community 1017`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1018`** (1 nodes): `retry-queue.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `retry-queue.spec.ts`
+- **Thin community `Community 1019`** (1 nodes): `circuit-breaker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `circuit-breaker.spec.ts`
+- **Thin community `Community 1020`** (1 nodes): `degraded-fallback.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `degraded-fallback.e2e.spec.ts`
+- **Thin community `Community 1021`** (1 nodes): `working-promotion.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `working-promotion.e2e.spec.ts`
+- **Thin community `Community 1022`** (1 nodes): `transport-switch.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `transport-switch.e2e.spec.ts`
+- **Thin community `Community 1023`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `cross-channel-recall.e2e.spec.ts`
+- **Thin community `Community 1024`** (1 nodes): `channel-isolation.e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `channel-isolation.e2e.spec.ts`
+- **Thin community `Community 1025`** (1 nodes): `http.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `http.integration.spec.ts`
+- **Thin community `Community 1026`** (1 nodes): `stdio.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `stdio.integration.spec.ts`
+- **Thin community `Community 1027`** (1 nodes): `http-server-runner.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `http-server-runner.js`
+- **Thin community `Community 1028`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `dashboard-agent-sessions-panel.spec.ts`
+- **Thin community `Community 1029`** (1 nodes): `cli-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `cli-integration.spec.ts`
+- **Thin community `Community 1030`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `review-candidates-changed-fanout.spec.ts`
+- **Thin community `Community 1031`** (1 nodes): `mcp-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `mcp-logger.spec.ts`
+- **Thin community `Community 1032`** (1 nodes): `audit-tool-dispatch.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `audit-tool-dispatch.spec.ts`
+- **Thin community `Community 1033`** (1 nodes): `index-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `index-factory.spec.ts`
+- **Thin community `Community 1034`** (1 nodes): `context.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `context.spec.ts`
+- **Thin community `Community 1035`** (1 nodes): `simple-mcp-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `simple-mcp-server.spec.ts`
+- **Thin community `Community 1036`** (1 nodes): `http-server.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `http-server.spec.ts`
+- **Thin community `Community 1037`** (1 nodes): `bootstrap.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `bootstrap.spec.ts`
+- **Thin community `Community 1038`** (1 nodes): `server-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `server-factory.spec.ts`
+- **Thin community `Community 1039`** (1 nodes): `server-state.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `server-state.spec.ts`
+- **Thin community `Community 1040`** (1 nodes): `server-info.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `server-info.spec.ts`
+- **Thin community `Community 1041`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `review-queue-dashboard-boot.spec.ts`
+- **Thin community `Community 1042`** (1 nodes): `bootstrap.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `bootstrap.ts`
+- **Thin community `Community 1043`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1044`** (1 nodes): `context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `context.ts`
+- **Thin community `Community 1045`** (1 nodes): `cors-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `cors-policy.spec.ts`
+- **Thin community `Community 1046`** (1 nodes): `mcp-tool-call-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `mcp-tool-call-error.spec.ts`
+- **Thin community `Community 1047`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `tool-context-meta-memory-injection.spec.ts`
+- **Thin community `Community 1048`** (1 nodes): `server-services-meta-memory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `server-services-meta-memory.spec.ts`
+- **Thin community `Community 1049`** (1 nodes): `meta-memory-service-initialization.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `meta-memory-service-initialization.spec.ts`
+- **Thin community `Community 1050`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `index.ts`
+- **Thin community `Community 1051`** (1 nodes): `session-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `session-store.spec.ts`
+- **Thin community `Community 1052`** (1 nodes): `quality.routes.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `quality.routes.spec.ts`
+- **Thin community `Community 1053`** (1 nodes): `agent.routes.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `agent.routes.types.ts`
+- **Thin community `Community 1054`** (1 nodes): `agent.routes.constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `agent.routes.constants.ts`
+- **Thin community `Community 1055`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `types.ts`
+- **Thin community `Community 1056`** (1 nodes): `runtime-transport-parity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `runtime-transport-parity.spec.ts`
+- **Thin community `Community 1057`** (1 nodes): `claude-code-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `claude-code-connect.spec.ts`
+- **Thin community `Community 1058`** (1 nodes): `codex-connect.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `codex-connect.spec.ts`
+- **Thin community `Community 1059`** (1 nodes): `agent-ask.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `agent-ask.ts`
+- **Thin community `Community 1060`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `types.ts`
+- **Thin community `Community 1061`** (1 nodes): `test-reflexion-e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `test-reflexion-e2e.ts`
+- **Thin community `Community 1062`** (1 nodes): `test-meta-memory-e2e.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `test-meta-memory-e2e.spec.ts`
+- **Thin community `Community 1063`** (1 nodes): `test-performance-monitor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `test-performance-monitor.ts`
+- **Thin community `Community 1064`** (1 nodes): `test-reflexion-performance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `test-reflexion-performance.ts`
+- **Thin community `Community 1065`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1066`** (1 nodes): `brave-search-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `brave-search-provider.spec.ts`
+- **Thin community `Community 1067`** (1 nodes): `search-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `search-provider.ts`
+- **Thin community `Community 1068`** (1 nodes): `llm-provider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `llm-provider.ts`
+- **Thin community `Community 1069`** (1 nodes): `claude-provider.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `claude-provider.spec.ts`
+- **Thin community `Community 1070`** (1 nodes): `system-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `system-prompt.ts`
+- **Thin community `Community 1071`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1072`** (1 nodes): `injection-contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `injection-contract.spec.ts`
+- **Thin community `Community 1073`** (1 nodes): `redaction-size.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `redaction-size.spec.ts`
+- **Thin community `Community 1074`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `types.ts`
+- **Thin community `Community 1075`** (1 nodes): `schema-normalize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `schema-normalize.spec.ts`
+- **Thin community `Community 1076`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `index.ts`
+- **Thin community `Community 1077`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1078`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1079`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `types.ts`
+- **Thin community `Community 1080`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1081`** (1 nodes): `runner.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `runner.spec.ts`
+- **Thin community `Community 1082`** (1 nodes): `settings.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `settings.spec.ts`
+- **Thin community `Community 1083`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `types.ts`
+- **Thin community `Community 1084`** (1 nodes): `diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `diagnostics.spec.ts`
+- **Thin community `Community 1085`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1086`** (1 nodes): `utils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `utils.ts`
+- **Thin community `Community 1087`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `index.ts`
+- **Thin community `Community 1088`** (1 nodes): `agent-api.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `agent-api.spec.ts`
+- **Thin community `Community 1089`** (1 nodes): `feedback.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `feedback.integration.spec.ts`
+- **Thin community `Community 1090`** (1 nodes): `client-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `client-context.ts`
+- **Thin community `Community 1091`** (1 nodes): `async-optimizer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `async-optimizer.ts`
+- **Thin community `Community 1092`** (1 nodes): `async-optimizer.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `async-optimizer.types.ts`
+- **Thin community `Community 1093`** (1 nodes): `triple-extraction-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `triple-extraction-logger.spec.ts`
+- **Thin community `Community 1094`** (1 nodes): `database-optimize-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `database-optimize-tool.spec.ts`
+- **Thin community `Community 1095`** (1 nodes): `database-optimizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `database-optimizer.spec.ts`
+- **Thin community `Community 1096`** (1 nodes): `core-memory-repository.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `core-memory-repository.factory.spec.ts`
+- **Thin community `Community 1097`** (1 nodes): `cache-version-sync.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `cache-version-sync.integration.spec.ts`
+- **Thin community `Community 1098`** (1 nodes): `init.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `init.spec.ts`
+- **Thin community `Community 1099`** (1 nodes): `vec-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `vec-schema.spec.ts`
+- **Thin community `Community 1100`** (1 nodes): `migrate.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `migrate.spec.ts`
+- **Thin community `Community 1101`** (1 nodes): `schema-version-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `schema-version-manager.spec.ts`
+- **Thin community `Community 1102`** (1 nodes): `migration-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `migration-logger.spec.ts`
+- **Thin community `Community 1103`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `types.ts`
+- **Thin community `Community 1104`** (1 nodes): `migration-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `migration-detector.spec.ts`
+- **Thin community `Community 1105`** (1 nodes): `backup-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `backup-manager.spec.ts`
+- **Thin community `Community 1106`** (1 nodes): `dependency-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `dependency-validator.spec.ts`
+- **Thin community `Community 1107`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `036-agent-memory-promotion-schema.spec.ts`
+- **Thin community `Community 1108`** (1 nodes): `037-memory-forgetting-event.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `037-memory-forgetting-event.spec.ts`
+- **Thin community `Community 1109`** (1 nodes): `039-event-outbox.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `039-event-outbox.spec.ts`
+- **Thin community `Community 1110`** (1 nodes): `040-audit-hash-chain.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `040-audit-hash-chain.spec.ts`
+- **Thin community `Community 1111`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `035-agent-integration-schema.contract.spec.ts`
+- **Thin community `Community 1112`** (1 nodes): `035-agent-integration-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `035-agent-integration-schema.spec.ts`
+- **Thin community `Community 1113`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `sqlite-core-memory-adapter.spec.ts`
+- **Thin community `Community 1114`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `core-memory-repository-sqlite.impl.spec.ts`
+- **Thin community `Community 1115`** (1 nodes): `cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `cache-service.spec.ts`
+- **Thin community `Community 1116`** (1 nodes): `batch-scheduler-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `batch-scheduler-types.ts`
+- **Thin community `Community 1117`** (1 nodes): `batch-scheduler-run-context.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `batch-scheduler-run-context.ts`
+- **Thin community `Community 1118`** (1 nodes): `file-logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `file-logger.spec.ts`
+- **Thin community `Community 1119`** (1 nodes): `health-checker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `health-checker.spec.ts`
+- **Thin community `Community 1120`** (1 nodes): `relation-validator-executor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `relation-validator-executor.spec.ts`
+- **Thin community `Community 1121`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `batch-job-timeout-resolver.spec.ts`
+- **Thin community `Community 1122`** (1 nodes): `maintenance-jobs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `maintenance-jobs.spec.ts`
+- **Thin community `Community 1123`** (1 nodes): `error-handling.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `error-handling.spec.ts`
+- **Thin community `Community 1124`** (1 nodes): `run-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `run-job.spec.ts`
+- **Thin community `Community 1125`** (1 nodes): `logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `logging.spec.ts`
+- **Thin community `Community 1126`** (1 nodes): `env-defaults.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `env-defaults.spec.ts`
+- **Thin community `Community 1127`** (1 nodes): `lifecycle.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `lifecycle.spec.ts`
+- **Thin community `Community 1128`** (1 nodes): `status-diagnostics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `status-diagnostics.spec.ts`
+- **Thin community `Community 1129`** (1 nodes): `constructor-config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `constructor-config.spec.ts`
+- **Thin community `Community 1130`** (1 nodes): `relation-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `relation-validation.spec.ts`
+- **Thin community `Community 1131`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `telemetry-cleanup-batch-job.spec.ts`
+- **Thin community `Community 1132`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `sleep-consolidation-batch-job.spec.ts`
+- **Thin community `Community 1133`** (1 nodes): `reflection-notes-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `reflection-notes-schema.spec.ts`
+- **Thin community `Community 1134`** (1 nodes): `stopwords.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `stopwords.spec.ts`
+- **Thin community `Community 1135`** (1 nodes): `db-path.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `db-path.spec.ts`
+- **Thin community `Community 1136`** (1 nodes): `fts5-migration-status.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `fts5-migration-status.spec.ts`
+- **Thin community `Community 1137`** (1 nodes): `procedural-memory-extractor.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `procedural-memory-extractor.types.ts`
+- **Thin community `Community 1138`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1139`** (1 nodes): `owner-scope-mode.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `owner-scope-mode.spec.ts`
+- **Thin community `Community 1140`** (1 nodes): `environment-check.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `environment-check.spec.ts`
+- **Thin community `Community 1141`** (1 nodes): `write-coalescing.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `write-coalescing.spec.ts`
+- **Thin community `Community 1142`** (1 nodes): `configuration-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `configuration-validator.spec.ts`
+- **Thin community `Community 1143`** (1 nodes): `logger.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `logger.spec.ts`
+- **Thin community `Community 1144`** (1 nodes): `relation-type-converter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `relation-type-converter.spec.ts`
+- **Thin community `Community 1145`** (1 nodes): `sql-security-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `sql-security-validator.spec.ts`
+- **Thin community `Community 1146`** (1 nodes): `pii-masker-api-key.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `pii-masker-api-key.spec.ts`
+- **Thin community `Community 1147`** (1 nodes): `path-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `path-validator.spec.ts`
+- **Thin community `Community 1148`** (1 nodes): `triple-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `triple-cache.spec.ts`
+- **Thin community `Community 1149`** (1 nodes): `memento-resource-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `memento-resource-uri.spec.ts`
+- **Thin community `Community 1150`** (1 nodes): `jsonl-rotation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `jsonl-rotation.spec.ts`
+- **Thin community `Community 1151`** (1 nodes): `type-param-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `type-param-validator.spec.ts`
+- **Thin community `Community 1152`** (1 nodes): `external-api-retry-logging.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `external-api-retry-logging.spec.ts`
+- **Thin community `Community 1153`** (1 nodes): `logger-schema-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `logger-schema-validation.spec.ts`
+- **Thin community `Community 1154`** (1 nodes): `logging-rate-limiter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `logging-rate-limiter.spec.ts`
+- **Thin community `Community 1155`** (1 nodes): `logger-schema.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `logger-schema.spec.ts`
+- **Thin community `Community 1156`** (1 nodes): `pii-masker-env-control.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `pii-masker-env-control.spec.ts`
+- **Thin community `Community 1157`** (1 nodes): `logging-helpers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `logging-helpers.spec.ts`
+- **Thin community `Community 1158`** (1 nodes): `pii-masker-integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `pii-masker-integration.spec.ts`
+- **Thin community `Community 1159`** (1 nodes): `migration.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `migration.types.ts`
+- **Thin community `Community 1160`** (1 nodes): `consolidation-score.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `consolidation-score.types.ts`
+- **Thin community `Community 1161`** (1 nodes): `consolidation.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `consolidation.types.ts`
+- **Thin community `Community 1162`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1163`** (1 nodes): `spaced-repetition.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `spaced-repetition.types.ts`
+- **Thin community `Community 1164`** (1 nodes): `procedural-versioning.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `procedural-versioning.ts`
+- **Thin community `Community 1165`** (1 nodes): `triple-extraction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `triple-extraction.ts`
+- **Thin community `Community 1166`** (1 nodes): `feedback.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `feedback.types.ts`
+- **Thin community `Community 1167`** (1 nodes): `embedding.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `embedding.types.ts`
+- **Thin community `Community 1168`** (1 nodes): `relation-graph.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `relation-graph.ts`
+- **Thin community `Community 1169`** (1 nodes): `failure-event.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `failure-event.ts`
+- **Thin community `Community 1170`** (1 nodes): `error-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `error-types.ts`
+- **Thin community `Community 1171`** (1 nodes): `ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `ranking.types.ts`
+- **Thin community `Community 1172`** (1 nodes): `alerts.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `alerts.types.ts`
+- **Thin community `Community 1173`** (1 nodes): `search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `search.types.ts`
+- **Thin community `Community 1174`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1175`** (1 nodes): `embedding-provider-monitoring.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `embedding-provider-monitoring.types.ts`
+- **Thin community `Community 1176`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `constants.ts`
+- **Thin community `Community 1177`** (1 nodes): `vector-search.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `vector-search.config.ts`
+- **Thin community `Community 1178`** (1 nodes): `ranking-weights-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `ranking-weights-loader.spec.ts`
+- **Thin community `Community 1179`** (1 nodes): `constants.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `constants.spec.ts`
+- **Thin community `Community 1180`** (1 nodes): `llm-model-resolver.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `llm-model-resolver.spec.ts`
+- **Thin community `Community 1181`** (1 nodes): `config-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `config-validation.spec.ts`
+- **Thin community `Community 1182`** (1 nodes): `retry-options-loader.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `retry-options-loader.spec.ts`
+- **Thin community `Community 1183`** (1 nodes): `environment-paths.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `environment-paths.spec.ts`
+- **Thin community `Community 1184`** (1 nodes): `config-loader-utils.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `config-loader-utils.spec.ts`
+- **Thin community `Community 1185`** (1 nodes): `schema-version.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `schema-version.ts`
+- **Thin community `Community 1186`** (1 nodes): `relation-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `relation-constants.ts`
+- **Thin community `Community 1187`** (1 nodes): `introspection-constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `introspection-constants.ts`
+- **Thin community `Community 1188`** (1 nodes): `http-bind-policy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `http-bind-policy.spec.ts`
+- **Thin community `Community 1189`** (1 nodes): `reflexion-worker.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `reflexion-worker.interface.ts`
+- **Thin community `Community 1190`** (1 nodes): `retry-manager.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `retry-manager.interface.ts`
+- **Thin community `Community 1191`** (1 nodes): `cache.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `cache.interface.ts`
+- **Thin community `Community 1192`** (1 nodes): `async-task-queue.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `async-task-queue.interface.ts`
+- **Thin community `Community 1193`** (1 nodes): `error-logging.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `error-logging.interface.ts`
+- **Thin community `Community 1194`** (1 nodes): `spaced-repetition.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `spaced-repetition.interface.ts`
+- **Thin community `Community 1195`** (1 nodes): `consolidation-score.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `consolidation-score.interface.ts`
+- **Thin community `Community 1196`** (1 nodes): `database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `database.interface.ts`
+- **Thin community `Community 1197`** (1 nodes): `database-optimizer.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `database-optimizer.interface.ts`
+- **Thin community `Community 1198`** (1 nodes): `batch-scheduler.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `batch-scheduler.interface.ts`
+- **Thin community `Community 1199`** (1 nodes): `initialize.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `initialize.spec.ts`
+- **Thin community `Community 1200`** (1 nodes): `openai-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `openai-client.spec.ts`
+- **Thin community `Community 1201`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `llm-provider-fallback-ollama.spec.ts`
+- **Thin community `Community 1202`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `llm-provider-fallback-gemini.spec.ts`
+- **Thin community `Community 1203`** (1 nodes): `ollama-connection.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `ollama-connection.spec.ts`
+- **Thin community `Community 1204`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `llm-provider-fallback-auto.spec.ts`
+- **Thin community `Community 1205`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `llm-provider-fallback-openai.spec.ts`
+- **Thin community `Community 1206`** (1 nodes): `environment-priority.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `environment-priority.spec.ts`
+- **Thin community `Community 1207`** (1 nodes): `validate-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `validate-api-keys.spec.ts`
+- **Thin community `Community 1208`** (1 nodes): `gemini-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `gemini-client.spec.ts`
+- **Thin community `Community 1209`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `types.ts`
+- **Thin community `Community 1210`** (1 nodes): `source-uri.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `source-uri.spec.ts`
+- **Thin community `Community 1211`** (1 nodes): `fallback-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `fallback-search-service.spec.ts`
+- **Thin community `Community 1212`** (1 nodes): `anchor-manager.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `anchor-manager.spec.ts`
+- **Thin community `Community 1213`** (1 nodes): `anchor-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `anchor-search-service.spec.ts`
+- **Thin community `Community 1214`** (1 nodes): `query-filter-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `query-filter-service.spec.ts`
+- **Thin community `Community 1215`** (1 nodes): `anchor-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `anchor-cache-service.spec.ts`
+- **Thin community `Community 1216`** (1 nodes): `search-strategy-interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `search-strategy-interfaces.ts`
+- **Thin community `Community 1217`** (1 nodes): `embedding-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `embedding-types.ts`
+- **Thin community `Community 1218`** (1 nodes): `n-hop-search-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `n-hop-search-strategy.spec.ts`
+- **Thin community `Community 1219`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `index.ts`
+- **Thin community `Community 1220`** (1 nodes): `query-filter-strategy.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `query-filter-strategy.spec.ts`
+- **Thin community `Community 1221`** (1 nodes): `database-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `database-types.ts`
+- **Thin community `Community 1222`** (1 nodes): `local-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `local-search-service.spec.ts`
+- **Thin community `Community 1223`** (1 nodes): `n-hop-search-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `n-hop-search-service.spec.ts`
+- **Thin community `Community 1224`** (1 nodes): `evolution-demo.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `evolution-demo.spec.ts`
+- **Thin community `Community 1225`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `types.ts`
+- **Thin community `Community 1226`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `index.ts`
+- **Thin community `Community 1227`** (1 nodes): `spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `spec.ts`
+- **Thin community `Community 1228`** (1 nodes): `forgetting-policy.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `forgetting-policy.snapshots.ts`
+- **Thin community `Community 1229`** (1 nodes): `answer-over-time.snapshots.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `answer-over-time.snapshots.ts`
+- **Thin community `Community 1230`** (1 nodes): `vector-search.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `vector-search.factory.spec.ts`
+- **Thin community `Community 1231`** (1 nodes): `hybrid-search-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `hybrid-search-types.ts`
+- **Thin community `Community 1232`** (1 nodes): `search-ranking.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `search-ranking.types.ts`
+- **Thin community `Community 1233`** (1 nodes): `procedural-memory-matcher.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `procedural-memory-matcher.spec.ts`
+- **Thin community `Community 1234`** (1 nodes): `search-ranking.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `search-ranking.spec.ts`
+- **Thin community `Community 1235`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `hybrid-search-engine-consolidation.spec.ts`
+- **Thin community `Community 1236`** (1 nodes): `process-attribute-fit.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `process-attribute-fit.spec.ts`
+- **Thin community `Community 1237`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `search-result-combiner-consolidation.spec.ts`
+- **Thin community `Community 1238`** (1 nodes): `search-engine.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `search-engine.types.ts`
+- **Thin community `Community 1239`** (1 nodes): `vector-performance.repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `vector-performance.repository.spec.ts`
+- **Thin community `Community 1240`** (1 nodes): `vector-search.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `vector-search.types.ts`
+- **Thin community `Community 1241`** (1 nodes): `vector-search-result-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `vector-search-result-normalizer.spec.ts`
+- **Thin community `Community 1242`** (1 nodes): `forgetting-event-log.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `forgetting-event-log.spec.ts`
+- **Thin community `Community 1243`** (1 nodes): `spaced-repetition.factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `spaced-repetition.factory.spec.ts`
+- **Thin community `Community 1244`** (1 nodes): `spaced-repetition-refactored.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `spaced-repetition-refactored.spec.ts`
+- **Thin community `Community 1245`** (1 nodes): `spaced-repetition.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `spaced-repetition.spec.ts`
+- **Thin community `Community 1246`** (1 nodes): `forgetting-algorithm.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `forgetting-algorithm.spec.ts`
+- **Thin community `Community 1247`** (1 nodes): `forgetting-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `forgetting-stats-tool.spec.ts`
+- **Thin community `Community 1248`** (1 nodes): `forgetting-policy-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `forgetting-policy-service.spec.ts`
+- **Thin community `Community 1249`** (1 nodes): `review-scheduling.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `review-scheduling.service.spec.ts`
+- **Thin community `Community 1250`** (1 nodes): `interval-calculation.service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `interval-calculation.service.spec.ts`
+- **Thin community `Community 1251`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `index.ts`
+- **Thin community `Community 1252`** (1 nodes): `telemetry.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `telemetry.types.ts`
+- **Thin community `Community 1253`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `telemetry-feedback-quality-query.spec.ts`
+- **Thin community `Community 1254`** (1 nodes): `audit-hash-chain-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `audit-hash-chain-service.spec.ts`
+- **Thin community `Community 1255`** (1 nodes): `telemetry-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `telemetry-service.spec.ts`
+- **Thin community `Community 1256`** (1 nodes): `event-outbox-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `event-outbox-service.spec.ts`
+- **Thin community `Community 1257`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `index.ts`
+- **Thin community `Community 1258`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `knowledge-candidate-extractor.spec.ts`
+- **Thin community `Community 1259`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `knowledge-candidate-text-ambiguity.spec.ts`
+- **Thin community `Community 1260`** (1 nodes): `personal-agent-llm-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `personal-agent-llm-error.spec.ts`
+- **Thin community `Community 1261`** (1 nodes): `llm-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `llm-port.ts`
+- **Thin community `Community 1262`** (1 nodes): `persistence-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `persistence-port.ts`
+- **Thin community `Community 1263`** (1 nodes): `context-port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `context-port.ts`
+- **Thin community `Community 1264`** (1 nodes): `agent-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `agent-types.ts`
+- **Thin community `Community 1265`** (1 nodes): `personal-agent-llm-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `personal-agent-llm-env.spec.ts`
+- **Thin community `Community 1266`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `tool-context-remember-persistence-adapter.spec.ts`
+- **Thin community `Community 1267`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `openai-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1268`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `gemini-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1269`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `ollama-chat-llm-adapter.spec.ts`
+- **Thin community `Community 1270`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `deterministic-mock-llm-adapter.spec.ts`
+- **Thin community `Community 1271`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `create-personal-agent-llm-port.spec.ts`
+- **Thin community `Community 1272`** (1 nodes): `core-memory-database.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `core-memory-database.interface.ts`
+- **Thin community `Community 1273`** (1 nodes): `knowledge-vault-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `knowledge-vault-repository.interface.ts`
+- **Thin community `Community 1274`** (1 nodes): `core-memory-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `core-memory-repository.interface.ts`
+- **Thin community `Community 1275`** (1 nodes): `kg-triple-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `kg-triple-repository.interface.ts`
+- **Thin community `Community 1276`** (1 nodes): `process-attribute-repository.interface.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `process-attribute-repository.interface.ts`
+- **Thin community `Community 1277`** (1 nodes): `feedback-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `feedback-repository.spec.ts`
+- **Thin community `Community 1278`** (1 nodes): `recall-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `recall-tool-host.ts`
+- **Thin community `Community 1279`** (1 nodes): `recall-tool-definition.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `recall-tool-definition.ts`
+- **Thin community `Community 1280`** (1 nodes): `remember-tool-schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `remember-tool-schema.ts`
+- **Thin community `Community 1281`** (1 nodes): `remember-tool-host.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `remember-tool-host.ts`
+- **Thin community `Community 1282`** (1 nodes): `remember-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `remember-tool-types.ts`
+- **Thin community `Community 1283`** (1 nodes): `recall-tool-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `recall-tool-types.ts`
+- **Thin community `Community 1284`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `get-memory-neighbors-tool.spec.ts`
+- **Thin community `Community 1285`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `telemetry-instrumentation.integration.spec.ts`
+- **Thin community `Community 1286`** (1 nodes): `forget-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `forget-tool.spec.ts`
+- **Thin community `Community 1287`** (1 nodes): `cleanup-memory-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `cleanup-memory-tool.spec.ts`
+- **Thin community `Community 1288`** (1 nodes): `get-introspection-summary-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `get-introspection-summary-tool.spec.ts`
+- **Thin community `Community 1289`** (1 nodes): `memory-injection-prompt.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `memory-injection-prompt.spec.ts`
+- **Thin community `Community 1290`** (1 nodes): `unpin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `unpin-tool.spec.ts`
+- **Thin community `Community 1291`** (1 nodes): `pin-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `pin-tool.spec.ts`
+- **Thin community `Community 1292`** (1 nodes): `memory-review-queue-health-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `memory-review-queue-health-service.spec.ts`
+- **Thin community `Community 1293`** (1 nodes): `memory-review-candidate-persistence.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `memory-review-candidate-persistence.types.ts`
+- **Thin community `Community 1294`** (1 nodes): `memory-review-candidate-selection.types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `memory-review-candidate-selection.types.ts`
+- **Thin community `Community 1295`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `memory-review-candidate-selection-env.spec.ts`
+- **Thin community `Community 1296`** (1 nodes): `procedural-llm-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `procedural-llm-extractor.spec.ts`
+- **Thin community `Community 1297`** (1 nodes): `introspection-scan-cache.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `introspection-scan-cache.spec.ts`
+- **Thin community `Community 1298`** (1 nodes): `repetition-meta-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `repetition-meta-update-service.spec.ts`
+- **Thin community `Community 1299`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `knowledge-context-bundle-builder.spec.ts`
+- **Thin community `Community 1300`** (1 nodes): `memory-neighbor-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `memory-neighbor-service.spec.ts`
+- **Thin community `Community 1301`** (1 nodes): `memory-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `memory-embedding-service.spec.ts`
+- **Thin community `Community 1302`** (1 nodes): `core-memory-cache-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `core-memory-cache-service.spec.ts`
+- **Thin community `Community 1303`** (1 nodes): `semantic-memory-update-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `semantic-memory-update-service.spec.ts`
+- **Thin community `Community 1304`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `index.ts`
+- **Thin community `Community 1305`** (1 nodes): `consolidation-repository.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `consolidation-repository.spec.ts`
+- **Thin community `Community 1306`** (1 nodes): `relation-graph.port.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `relation-graph.port.ts`
+- **Thin community `Community 1307`** (1 nodes): `remove-relation-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `remove-relation-tool.spec.ts`
+- **Thin community `Community 1308`** (1 nodes): `relation-tools-registry.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `relation-tools-registry.spec.ts`
+- **Thin community `Community 1309`** (1 nodes): `relation-quality-validator.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `relation-quality-validator.spec.ts`
+- **Thin community `Community 1310`** (1 nodes): `provider-auto.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `provider-auto.spec.ts`
+- **Thin community `Community 1311`** (1 nodes): `provider-no-api-keys.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `provider-no-api-keys.spec.ts`
+- **Thin community `Community 1312`** (1 nodes): `provider-ollama.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `provider-ollama.spec.ts`
+- **Thin community `Community 1313`** (1 nodes): `provider-openai.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `provider-openai.spec.ts`
+- **Thin community `Community 1314`** (1 nodes): `provider-init-failure.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `provider-init-failure.spec.ts`
+- **Thin community `Community 1315`** (1 nodes): `provider-gemini.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `provider-gemini.spec.ts`
+- **Thin community `Community 1316`** (1 nodes): `triple-extraction-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `triple-extraction-service.spec.ts`
+- **Thin community `Community 1317`** (1 nodes): `interfaces.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `interfaces.ts`
+- **Thin community `Community 1318`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `triple-extraction-llm-pipeline.spec.ts`
+- **Thin community `Community 1319`** (1 nodes): `triple-chunk-merge.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `triple-chunk-merge.spec.ts`
+- **Thin community `Community 1320`** (1 nodes): `triple-text-chunker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `triple-text-chunker.spec.ts`
+- **Thin community `Community 1321`** (1 nodes): `predicate-canonicalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `predicate-canonicalizer.spec.ts`
+- **Thin community `Community 1322`** (1 nodes): `triple-input-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `triple-input-normalizer.spec.ts`
+- **Thin community `Community 1323`** (1 nodes): `entity-linker.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `entity-linker.spec.ts`
+- **Thin community `Community 1324`** (1 nodes): `triple-normalizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `triple-normalizer.spec.ts`
+- **Thin community `Community 1325`** (1 nodes): `interfaces.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `interfaces.spec.ts`
+- **Thin community `Community 1326`** (1 nodes): `triple-extractor.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `triple-extractor.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `triple-parser.spec.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `types.ts`
+- **Thin community `Community 1327`** (1 nodes): `triple-parser.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1328`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1329`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `agent-integration-repository.ts`
+- **Thin community `Community 1330`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
+- **Thin community `Community 1331`** (1 nodes): `agent-integration-repository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `agent-lifecycle-service.spec.ts`
+- **Thin community `Community 1332`** (1 nodes): `sqlite-hybrid-agent-context-source.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `agent-context-injection-service.spec.ts`
+- **Thin community `Community 1333`** (1 nodes): `agent-lifecycle-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `embedding-provider-factory.spec.ts`
+- **Thin community `Community 1334`** (1 nodes): `agent-context-injection-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `retry-manager-usage.spec.ts`
+- **Thin community `Community 1335`** (1 nodes): `embedding-provider-factory.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `vector-compatibility-service.spec.ts`
+- **Thin community `Community 1336`** (1 nodes): `retry-manager-usage.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `unified-embedding-service.spec.ts`
+- **Thin community `Community 1337`** (1 nodes): `vector-compatibility-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `minilm-embedding-service.spec.ts`
+- **Thin community `Community 1338`** (1 nodes): `unified-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `embedding-reindex-service.spec.ts`
+- **Thin community `Community 1339`** (1 nodes): `minilm-embedding-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `types.ts`
+- **Thin community `Community 1340`** (1 nodes): `embedding-reindex-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `performance-stats-tool.spec.ts`
+- **Thin community `Community 1341`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `resolve-error.spec.ts`
+- **Thin community `Community 1342`** (1 nodes): `performance-stats-tool.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `error-stats.spec.ts`
+- **Thin community `Community 1343`** (1 nodes): `resolve-error.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `performance-monitor-types.ts`
+- **Thin community `Community 1344`** (1 nodes): `error-stats.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `failure-detector.spec.ts`
+- **Thin community `Community 1345`** (1 nodes): `performance-monitor-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `error-logging-service.spec.ts`
+- **Thin community `Community 1346`** (1 nodes): `failure-detector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `alert-notification-service.spec.ts`
+- **Thin community `Community 1347`** (1 nodes): `error-logging-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `performance-alert-service.spec.ts`
+- **Thin community `Community 1348`** (1 nodes): `alert-notification-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `quality-metrics-collector.spec.ts`
+- **Thin community `Community 1349`** (1 nodes): `performance-alert-service.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `quality-metrics-types.ts`
+- **Thin community `Community 1350`** (1 nodes): `quality-metrics-collector.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `types.ts`
+- **Thin community `Community 1351`** (1 nodes): `quality-metrics-types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `mock-database.spec.ts`
+- **Thin community `Community 1352`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1353`** (1 nodes): `mock-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
+- **Thin community `Community 1354`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `embedding-integration-test.ts`
+- **Thin community `Community 1355`** (1 nodes): `test-vector-search-quality-with-consolidation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `test-batch-scheduler.ts`
+- **Thin community `Community 1356`** (1 nodes): `embedding-integration-test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `test-memory-injection-prompt.ts`
+- **Thin community `Community 1357`** (1 nodes): `test-batch-scheduler.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `search-quality-review-checklist.spec.ts`
+- **Thin community `Community 1358`** (1 nodes): `test-memory-injection-prompt.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `vector-search-quality-metrics.spec.ts`
+- **Thin community `Community 1359`** (1 nodes): `search-quality-review-checklist.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `search-quality-candidate-builder.spec.ts`
+- **Thin community `Community 1360`** (1 nodes): `vector-search-quality-metrics.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
+- **Thin community `Community 1361`** (1 nodes): `search-quality-candidate-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
+- **Thin community `Community 1362`** (1 nodes): `search-quality-benchmark-builder.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `benchmark-search-database.spec.ts`
+- **Thin community `Community 1363`** (1 nodes): `search-quality-benchmark-fixtures.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `vector-search-quality-metrics.ts`
+- **Thin community `Community 1364`** (1 nodes): `benchmark-search-database.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `types.ts`
+- **Thin community `Community 1365`** (1 nodes): `vector-search-quality-metrics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `memory-export-import.spec.ts`
+- **Thin community `Community 1366`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `anchor-map.e2e.ts`
+- **Thin community `Community 1367`** (1 nodes): `memory-export-import.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `agent-sessions.e2e.ts`
+- **Thin community `Community 1368`** (1 nodes): `anchor-map.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `sync-root-server-dist.js`
+- **Thin community `Community 1369`** (1 nodes): `agent-sessions.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `pack-with-restore.js`
+- **Thin community `Community 1370`** (1 nodes): `sync-root-server-dist.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
+- **Thin community `Community 1371`** (1 nodes): `pack-with-restore.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `verify-bin.js`
+- **Thin community `Community 1372`** (1 nodes): `quality-feedback-reappearance-report.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `agent-memory-benchmark.spec.ts`
+- **Thin community `Community 1373`** (1 nodes): `verify-bin.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `longmemeval-validation.spec.ts`
+- **Thin community `Community 1374`** (1 nodes): `agent-memory-benchmark.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `acquire-longmemeval.spec.ts`
+- **Thin community `Community 1375`** (1 nodes): `longmemeval-validation.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `postpack-restore-workspace.js`
+- **Thin community `Community 1376`** (1 nodes): `acquire-longmemeval.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
+- **Thin community `Community 1377`** (1 nodes): `postpack-restore-workspace.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `count-console-logs.spec.ts`
+- **Thin community `Community 1378`** (1 nodes): `agent-memory-benchmark-adapter.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `simple-update-wrapper.spec.ts`
+- **Thin community `Community 1379`** (1 nodes): `count-console-logs.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `legacy-script-removal.spec.ts`
+- **Thin community `Community 1380`** (1 nodes): `simple-update-wrapper.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `legacy-script-verification.spec.ts`
+- **Thin community `Community 1381`** (1 nodes): `legacy-script-removal.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `check-magic-numbers.spec.ts`
+- **Thin community `Community 1382`** (1 nodes): `legacy-script-verification.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `check-db-integrity.integration.spec.ts`
+- **Thin community `Community 1383`** (1 nodes): `check-magic-numbers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
+- **Thin community `Community 1384`** (1 nodes): `check-db-integrity.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `restore-legacy.ps1`
+- **Thin community `Community 1385`** (1 nodes): `regenerate-embeddings.integration.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `types.ts`
+- **Thin community `Community 1386`** (1 nodes): `restore-legacy.ps1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `promotion.spec.ts`
+- **Thin community `Community 1387`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `issue-body.spec.ts`
+- **Thin community `Community 1388`** (1 nodes): `promotion.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `github-client.spec.ts`
+- **Thin community `Community 1389`** (1 nodes): `issue-body.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `config.spec.ts`
+- **Thin community `Community 1390`** (1 nodes): `github-client.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `detectors.spec.ts`
+- **Thin community `Community 1391`** (1 nodes): `config.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `sources.spec.ts`
+- **Thin community `Community 1392`** (1 nodes): `detectors.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `parsers.spec.ts`
+- **Thin community `Community 1393`** (1 nodes): `sources.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `fingerprint.spec.ts`
+- **Thin community `Community 1394`** (1 nodes): `parsers.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `state-store.spec.ts`
+- **Thin community `Community 1395`** (1 nodes): `fingerprint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `sanitizer.spec.ts`
+- **Thin community `Community 1396`** (1 nodes): `state-store.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `entrypoint.spec.ts`
+- **Thin community `Community 1397`** (1 nodes): `sanitizer.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.spec.ts`
+- **Thin community `Community 1398`** (1 nodes): `entrypoint.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `review-candidates-panel-poll-fetch.js`
+- **Thin community `Community 1399`** (1 nodes): `index.spec.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `embedding-map-state.js`
+- **Thin community `Community 1400`** (1 nodes): `review-candidates-panel-poll-fetch.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `memory-evolution-demo-shell-render.js`
+- **Thin community `Community 1401`** (1 nodes): `embedding-map-state.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `dashboard-auth.js`
+- **Thin community `Community 1402`** (1 nodes): `memory-evolution-demo-shell-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `dashboard-auth-error.js`
+- **Thin community `Community 1403`** (1 nodes): `dashboard-auth.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `review-candidates-panel-poll.js`
+- **Thin community `Community 1404`** (1 nodes): `dashboard-auth-error.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `dashboard-auth-render-message.js`
+- **Thin community `Community 1405`** (1 nodes): `review-candidates-panel-poll.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `graph.js`
+- **Thin community `Community 1406`** (1 nodes): `dashboard-auth-render-message.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `graph-shared.js`
+- **Thin community `Community 1407`** (1 nodes): `graph.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `dashboard-auth-render-form.js`
+- **Thin community `Community 1408`** (1 nodes): `graph-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `agent-sessions-panel-shared.js`
+- **Thin community `Community 1409`** (1 nodes): `dashboard-auth-render-form.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `agent-sessions-panel-render.js`
+- **Thin community `Community 1410`** (1 nodes): `agent-sessions-panel-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `anchor-map-shared.js`
+- **Thin community `Community 1411`** (1 nodes): `agent-sessions-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `dashboard-auth-render-status.js`
+- **Thin community `Community 1412`** (1 nodes): `anchor-map-shared.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `review-candidates-panel-poll-toast.js`
+- **Thin community `Community 1413`** (1 nodes): `dashboard-auth-render-status.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `agent-sessions-panel-render-injections.js`
+- **Thin community `Community 1414`** (1 nodes): `review-candidates-panel-poll-toast.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
+- **Thin community `Community 1415`** (1 nodes): `agent-sessions-panel-render-injections.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `review-candidates-panel-health.js`
+- **Thin community `Community 1416`** (1 nodes): `review-candidates-panel-poll-snapshot.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `agent-sessions-panel-render-provenance.js`
+- **Thin community `Community 1417`** (1 nodes): `review-candidates-panel-health.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `embedding-map-chart-colors.js`
+- **Thin community `Community 1418`** (1 nodes): `agent-sessions-panel-render-provenance.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `review-candidates-panel-poll-cycle.js`
+- **Thin community `Community 1419`** (1 nodes): `embedding-map-chart-colors.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `agent-sessions-panel-render-sessions.js`
+- **Thin community `Community 1420`** (1 nodes): `review-candidates-panel-poll-cycle.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `dashboard-auth-requests.js`
+- **Thin community `Community 1421`** (1 nodes): `agent-sessions-panel-render-sessions.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `review-candidates-panel-render.js`
+- **Thin community `Community 1422`** (1 nodes): `dashboard-auth-requests.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `dashboard-auth-ui.js`
+- **Thin community `Community 1423`** (1 nodes): `review-candidates-panel-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `dashboard-auth-render-tabs.js`
+- **Thin community `Community 1424`** (1 nodes): `dashboard-auth-ui.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `review-candidates-panel-poll-badge.js`
+- **Thin community `Community 1425`** (1 nodes): `dashboard-auth-render-tabs.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `graph-embed-init.js`
+- **Thin community `Community 1426`** (1 nodes): `review-candidates-panel-poll-badge.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `dashboard-auth-render.js`
+- **Thin community `Community 1427`** (1 nodes): `graph-embed-init.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1428`** (1 nodes): `dashboard-auth-render.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -9,7 +9,7 @@
       "source_file": "vitest.config.ts",
       "source_location": "L1",
       "id": "vitest_config_ts",
-      "community": 999
+      "community": 1000
     },
     {
       "label": "playwright.config.ts",
@@ -17,7 +17,7 @@
       "source_file": "playwright.config.ts",
       "source_location": "L1",
       "id": "playwright_config_ts",
-      "community": 1000
+      "community": 1001
     },
     {
       "label": "vitest.config.ts",
@@ -25,7 +25,7 @@
       "source_file": "packages/memento-assistant/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_vitest_config_ts",
-      "community": 1001
+      "community": 1002
     },
     {
       "label": "assistant.spec.ts",
@@ -33,7 +33,7 @@
       "source_file": "packages/memento-assistant/src/assistant.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_assistant_spec_ts",
-      "community": 1002
+      "community": 1003
     },
     {
       "label": "types.ts",
@@ -41,7 +41,7 @@
       "source_file": "packages/memento-assistant/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_ts",
-      "community": 1003
+      "community": 1004
     },
     {
       "label": "types.spec.ts",
@@ -49,7 +49,7 @@
       "source_file": "packages/memento-assistant/src/types.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_types_spec_ts",
-      "community": 1004
+      "community": 1005
     },
     {
       "label": "assistant.ts",
@@ -129,7 +129,7 @@
       "source_file": "packages/memento-assistant/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_index_ts",
-      "community": 1005
+      "community": 1006
     },
     {
       "label": "before-user-turn.spec.ts",
@@ -137,7 +137,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_spec_ts",
-      "community": 622
+      "community": 623
     },
     {
       "label": "SlowTransport",
@@ -145,7 +145,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L111",
       "id": "before_user_turn_spec_slowtransport",
-      "community": 622
+      "community": 623
     },
     {
       "label": ".recall()",
@@ -153,7 +153,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.spec.ts",
       "source_location": "L112",
       "id": "before_user_turn_spec_slowtransport_recall",
-      "community": 622
+      "community": 623
     },
     {
       "label": "after-assistant-turn.spec.ts",
@@ -161,7 +161,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_spec_ts",
-      "community": 1006
+      "community": 1007
     },
     {
       "label": "after-assistant-turn.ts",
@@ -169,7 +169,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_after_assistant_turn_ts",
-      "community": 735
+      "community": 737
     },
     {
       "label": "afterAssistantTurn()",
@@ -177,7 +177,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/after-assistant-turn.ts",
       "source_location": "L19",
       "id": "after_assistant_turn_afterassistantturn",
-      "community": 735
+      "community": 737
     },
     {
       "label": "before-user-turn.ts",
@@ -185,7 +185,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_lifecycle_before_user_turn_ts",
-      "community": 623
+      "community": 624
     },
     {
       "label": "beforeUserTurn()",
@@ -193,7 +193,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L17",
       "id": "before_user_turn_beforeuserturn",
-      "community": 623
+      "community": 624
     },
     {
       "label": "withTimeout()",
@@ -201,7 +201,7 @@
       "source_file": "packages/memento-assistant/src/lifecycle/before-user-turn.ts",
       "source_location": "L52",
       "id": "before_user_turn_withtimeout",
-      "community": 623
+      "community": 624
     },
     {
       "label": "auto-recall-policy.ts",
@@ -209,7 +209,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_ts",
-      "community": 736
+      "community": 738
     },
     {
       "label": "shouldAutoRecall()",
@@ -217,7 +217,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.ts",
       "source_location": "L4",
       "id": "auto_recall_policy_shouldautorecall",
-      "community": 736
+      "community": 738
     },
     {
       "label": "auto-remember-policy.spec.ts",
@@ -225,7 +225,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_spec_ts",
-      "community": 1007
+      "community": 1008
     },
     {
       "label": "auto-remember-policy.ts",
@@ -233,7 +233,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_remember_policy_ts",
-      "community": 737
+      "community": 739
     },
     {
       "label": "rememberDispatch()",
@@ -241,7 +241,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-remember-policy.ts",
       "source_location": "L11",
       "id": "auto_remember_policy_rememberdispatch",
-      "community": 737
+      "community": 739
     },
     {
       "label": "auto-recall-policy.spec.ts",
@@ -249,7 +249,7 @@
       "source_file": "packages/memento-assistant/src/policy/auto-recall-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_policy_auto_recall_policy_spec_ts",
-      "community": 1008
+      "community": 1009
     },
     {
       "label": "channel-scope.ts",
@@ -257,7 +257,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_ts",
-      "community": 624
+      "community": 625
     },
     {
       "label": "scopeRecallFilters()",
@@ -265,7 +265,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L14",
       "id": "channel_scope_scoperecallfilters",
-      "community": 624
+      "community": 625
     },
     {
       "label": "scopeRememberTags()",
@@ -273,7 +273,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.ts",
       "source_location": "L34",
       "id": "channel_scope_scoperemembertags",
-      "community": 624
+      "community": 625
     },
     {
       "label": "channel-scope.spec.ts",
@@ -281,7 +281,7 @@
       "source_file": "packages/memento-assistant/src/scoping/channel-scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_scoping_channel_scope_spec_ts",
-      "community": 1009
+      "community": 1010
     },
     {
       "label": "http-transport.ts",
@@ -361,7 +361,7 @@
       "source_file": "packages/memento-assistant/src/transport/stdio-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_stdio_transport_spec_ts",
-      "community": 1010
+      "community": 1011
     },
     {
       "label": "mock-transport.spec.ts",
@@ -369,7 +369,7 @@
       "source_file": "packages/memento-assistant/src/transport/mock-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_mock_transport_spec_ts",
-      "community": 1011
+      "community": 1012
     },
     {
       "label": "transport.ts",
@@ -377,7 +377,7 @@
       "source_file": "packages/memento-assistant/src/transport/transport.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_transport_ts",
-      "community": 1012
+      "community": 1013
     },
     {
       "label": "index.ts",
@@ -385,7 +385,7 @@
       "source_file": "packages/memento-assistant/src/transport/index.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_index_ts",
-      "community": 1013
+      "community": 1014
     },
     {
       "label": "http-transport.spec.ts",
@@ -393,7 +393,7 @@
       "source_file": "packages/memento-assistant/src/transport/http-transport.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_http_transport_spec_ts",
-      "community": 1014
+      "community": 1015
     },
     {
       "label": "factory.ts",
@@ -401,7 +401,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_ts",
-      "community": 738
+      "community": 740
     },
     {
       "label": "createTransportFromEnv()",
@@ -409,7 +409,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.ts",
       "source_location": "L13",
       "id": "factory_createtransportfromenv",
-      "community": 738
+      "community": 740
     },
     {
       "label": "stdio-transport.ts",
@@ -489,7 +489,7 @@
       "source_file": "packages/memento-assistant/src/transport/factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_transport_factory_spec_ts",
-      "community": 1015
+      "community": 1016
     },
     {
       "label": "mock-transport.ts",
@@ -609,7 +609,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_ts",
-      "community": 491
+      "community": 492
     },
     {
       "label": "createRateLimitedLogger()",
@@ -617,7 +617,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L17",
       "id": "logger_createratelimitedlogger",
-      "community": 491
+      "community": 492
     },
     {
       "label": "levelFromEnv()",
@@ -625,7 +625,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L37",
       "id": "logger_levelfromenv",
-      "community": 491
+      "community": 492
     },
     {
       "label": "consoleSink()",
@@ -633,7 +633,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.ts",
       "source_location": "L43",
       "id": "logger_consolesink",
-      "community": 491
+      "community": 492
     },
     {
       "label": "logger.spec.ts",
@@ -641,7 +641,7 @@
       "source_file": "packages/memento-assistant/src/fallback/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_logger_spec_ts",
-      "community": 1016
+      "community": 1017
     },
     {
       "label": "retry-queue.spec.ts",
@@ -649,7 +649,7 @@
       "source_file": "packages/memento-assistant/src/fallback/retry-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_retry_queue_spec_ts",
-      "community": 1017
+      "community": 1018
     },
     {
       "label": "circuit-breaker.spec.ts",
@@ -657,7 +657,7 @@
       "source_file": "packages/memento-assistant/src/fallback/circuit-breaker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_src_fallback_circuit_breaker_spec_ts",
-      "community": 1018
+      "community": 1019
     },
     {
       "label": "retry-queue.ts",
@@ -721,7 +721,7 @@
       "source_file": "packages/memento-assistant/test/e2e/degraded-fallback.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_degraded_fallback_e2e_spec_ts",
-      "community": 1019
+      "community": 1020
     },
     {
       "label": "working-promotion.e2e.spec.ts",
@@ -729,7 +729,7 @@
       "source_file": "packages/memento-assistant/test/e2e/working-promotion.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_working_promotion_e2e_spec_ts",
-      "community": 1020
+      "community": 1021
     },
     {
       "label": "transport-switch.e2e.spec.ts",
@@ -737,7 +737,7 @@
       "source_file": "packages/memento-assistant/test/e2e/transport-switch.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_transport_switch_e2e_spec_ts",
-      "community": 1021
+      "community": 1022
     },
     {
       "label": "cross-channel-recall.e2e.spec.ts",
@@ -745,7 +745,7 @@
       "source_file": "packages/memento-assistant/test/e2e/cross-channel-recall.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_cross_channel_recall_e2e_spec_ts",
-      "community": 1022
+      "community": 1023
     },
     {
       "label": "channel-isolation.e2e.spec.ts",
@@ -753,7 +753,7 @@
       "source_file": "packages/memento-assistant/test/e2e/channel-isolation.e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_e2e_channel_isolation_e2e_spec_ts",
-      "community": 1023
+      "community": 1024
     },
     {
       "label": "http.integration.spec.ts",
@@ -761,7 +761,7 @@
       "source_file": "packages/memento-assistant/test/integration/http.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_http_integration_spec_ts",
-      "community": 1024
+      "community": 1025
     },
     {
       "label": "stdio.integration.spec.ts",
@@ -769,7 +769,7 @@
       "source_file": "packages/memento-assistant/test/integration/stdio.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_integration_stdio_integration_spec_ts",
-      "community": 1025
+      "community": 1026
     },
     {
       "label": "start-http-server.ts",
@@ -777,7 +777,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_start_http_server_ts",
-      "community": 492
+      "community": 493
     },
     {
       "label": "startTestHttpServer()",
@@ -785,7 +785,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L15",
       "id": "start_http_server_starttesthttpserver",
-      "community": 492
+      "community": 493
     },
     {
       "label": "findFreePort()",
@@ -793,7 +793,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L45",
       "id": "start_http_server_findfreeport",
-      "community": 492
+      "community": 493
     },
     {
       "label": "waitForHealth()",
@@ -801,7 +801,7 @@
       "source_file": "packages/memento-assistant/test/helpers/start-http-server.ts",
       "source_location": "L56",
       "id": "start_http_server_waitforhealth",
-      "community": 492
+      "community": 493
     },
     {
       "label": "http-server-runner.js",
@@ -809,7 +809,7 @@
       "source_file": "packages/memento-assistant/test/helpers/http-server-runner.js",
       "source_location": "L1",
       "id": "packages_memento_assistant_test_helpers_http_server_runner_js",
-      "community": 1026
+      "community": 1027
     },
     {
       "label": "test-integration.js",
@@ -937,7 +937,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L1",
       "id": "packages_mcp_client_test_basic_js",
-      "community": 739
+      "community": 741
     },
     {
       "label": "testBasicFunctionality()",
@@ -945,7 +945,7 @@
       "source_file": "packages/mcp-client/test-basic.js",
       "source_location": "L9",
       "id": "test_basic_testbasicfunctionality",
-      "community": 739
+      "community": 741
     },
     {
       "label": "performance-optimizer.js",
@@ -1121,7 +1121,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_basic_usage_ts",
-      "community": 740
+      "community": 742
     },
     {
       "label": "basicUsageExample()",
@@ -1129,7 +1129,7 @@
       "source_file": "packages/mcp-client/examples/basic-usage.ts",
       "source_location": "L9",
       "id": "basic_usage_basicusageexample",
-      "community": 740
+      "community": 742
     },
     {
       "label": "performance-examples.ts",
@@ -1225,7 +1225,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L1",
       "id": "packages_mcp_client_examples_advanced_usage_ts",
-      "community": 741
+      "community": 743
     },
     {
       "label": "advancedUsageExample()",
@@ -1233,7 +1233,7 @@
       "source_file": "packages/mcp-client/examples/advanced-usage.ts",
       "source_location": "L9",
       "id": "advanced_usage_advancedusageexample",
-      "community": 741
+      "community": 743
     },
     {
       "label": "migration-guide.ts",
@@ -1529,7 +1529,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_telemetry_cli_spec_ts",
-      "community": 742
+      "community": 744
     },
     {
       "label": "makeNullRunner()",
@@ -1537,7 +1537,7 @@
       "source_file": "packages/memento-server/src/telemetry-cli.spec.ts",
       "source_location": "L131",
       "id": "telemetry_cli_spec_makenullrunner",
-      "community": 742
+      "community": 744
     },
     {
       "label": "telemetry-cli.ts",
@@ -1793,7 +1793,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-agent-sessions-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_agent_sessions_panel_spec_ts",
-      "community": 1027
+      "community": 1028
     },
     {
       "label": "cli-integration.spec.ts",
@@ -1801,7 +1801,7 @@
       "source_file": "packages/memento-server/src/server/cli-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_cli_integration_spec_ts",
-      "community": 1028
+      "community": 1029
     },
     {
       "label": "review-candidates-changed-fanout.spec.ts",
@@ -1809,7 +1809,7 @@
       "source_file": "packages/memento-server/src/server/review-candidates-changed-fanout.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_candidates_changed_fanout_spec_ts",
-      "community": 1029
+      "community": 1030
     },
     {
       "label": "dashboard-auth-assets.spec.ts",
@@ -1945,7 +1945,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_memory_evolution_demo_shell_spec_ts",
-      "community": 743
+      "community": 745
     },
     {
       "label": "readShellSources()",
@@ -1953,7 +1953,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-memory-evolution-demo-shell.spec.ts",
       "source_location": "L47",
       "id": "dashboard_memory_evolution_demo_shell_spec_readshellsources",
-      "community": 743
+      "community": 745
     },
     {
       "label": "programmatic-auth.integration.spec.ts",
@@ -2017,7 +2017,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_env_config_spec_ts",
-      "community": 493
+      "community": 494
     },
     {
       "label": "getRepoRoot()",
@@ -2025,7 +2025,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L5",
       "id": "env_config_spec_getreporoot",
-      "community": 493
+      "community": 494
     },
     {
       "label": "collectEnvKeys()",
@@ -2033,7 +2033,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L11",
       "id": "env_config_spec_collectenvkeys",
-      "community": 493
+      "community": 494
     },
     {
       "label": "expectNoDuplicateKeys()",
@@ -2041,7 +2041,7 @@
       "source_file": "packages/memento-server/src/server/env-config.spec.ts",
       "source_location": "L23",
       "id": "env_config_spec_expectnoduplicatekeys",
-      "community": 493
+      "community": 494
     },
     {
       "label": "server-info.ts",
@@ -2113,7 +2113,7 @@
       "source_file": "packages/memento-server/src/server/mcp-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_logger_spec_ts",
-      "community": 1030
+      "community": 1031
     },
     {
       "label": "audit-tool-dispatch.spec.ts",
@@ -2121,7 +2121,7 @@
       "source_file": "packages/memento-server/src/server/audit-tool-dispatch.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_audit_tool_dispatch_spec_ts",
-      "community": 1031
+      "community": 1032
     },
     {
       "label": "mcp.routes.cors.spec.ts",
@@ -2129,7 +2129,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_mcp_routes_cors_spec_ts",
-      "community": 625
+      "community": 626
     },
     {
       "label": "createMockResponse()",
@@ -2137,7 +2137,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L14",
       "id": "mcp_routes_cors_spec_createmockresponse",
-      "community": 625
+      "community": 626
     },
     {
       "label": "sendOptions()",
@@ -2145,7 +2145,7 @@
       "source_file": "packages/memento-server/src/server/mcp.routes.cors.spec.ts",
       "source_location": "L35",
       "id": "mcp_routes_cors_spec_sendoptions",
-      "community": 625
+      "community": 626
     },
     {
       "label": "dashboard-review-candidates-panel.spec.ts",
@@ -2153,7 +2153,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_dashboard_review_candidates_panel_spec_ts",
-      "community": 626
+      "community": 627
     },
     {
       "label": "readReviewCandidatesPanelSources()",
@@ -2161,7 +2161,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L44",
       "id": "dashboard_review_candidates_panel_spec_readreviewcandidatespanelsources",
-      "community": 626
+      "community": 627
     },
     {
       "label": "createPollHarness()",
@@ -2169,7 +2169,7 @@
       "source_file": "packages/memento-server/src/server/dashboard-review-candidates-panel.spec.ts",
       "source_location": "L67",
       "id": "dashboard_review_candidates_panel_spec_createpollharness",
-      "community": 626
+      "community": 627
     },
     {
       "label": "index-factory.spec.ts",
@@ -2177,7 +2177,7 @@
       "source_file": "packages/memento-server/src/server/index-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_factory_spec_ts",
-      "community": 1032
+      "community": 1033
     },
     {
       "label": "context.spec.ts",
@@ -2185,7 +2185,7 @@
       "source_file": "packages/memento-server/src/server/context.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_spec_ts",
-      "community": 1033
+      "community": 1034
     },
     {
       "label": "simple-mcp-server.spec.ts",
@@ -2193,7 +2193,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_spec_ts",
-      "community": 1034
+      "community": 1035
     },
     {
       "label": "server-factory.ts",
@@ -2201,7 +2201,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_ts",
-      "community": 744
+      "community": 746
     },
     {
       "label": "createServerFactory()",
@@ -2209,7 +2209,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.ts",
       "source_location": "L74",
       "id": "server_factory_createserverfactory",
-      "community": 744
+      "community": 746
     },
     {
       "label": "http-auth-docs.spec.ts",
@@ -2217,7 +2217,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_auth_docs_spec_ts",
-      "community": 627
+      "community": 628
     },
     {
       "label": "readRepoFile()",
@@ -2225,7 +2225,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L9",
       "id": "http_auth_docs_spec_readrepofile",
-      "community": 627
+      "community": 628
     },
     {
       "label": "sectionBetween()",
@@ -2233,7 +2233,7 @@
       "source_file": "packages/memento-server/src/server/http-auth-docs.spec.ts",
       "source_location": "L13",
       "id": "http_auth_docs_spec_sectionbetween",
-      "community": 627
+      "community": 628
     },
     {
       "label": "http-server.spec.ts",
@@ -2241,7 +2241,7 @@
       "source_file": "packages/memento-server/src/server/http-server.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_spec_ts",
-      "community": 1035
+      "community": 1036
     },
     {
       "label": "bootstrap.spec.ts",
@@ -2249,7 +2249,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_spec_ts",
-      "community": 1036
+      "community": 1037
     },
     {
       "label": "review-candidates-changed-fanout.ts",
@@ -2297,7 +2297,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_websocket_ts",
-      "community": 745
+      "community": 747
     },
     {
       "label": "setupWebSocketServer()",
@@ -2305,7 +2305,7 @@
       "source_file": "packages/memento-server/src/server/http-server-websocket.ts",
       "source_location": "L20",
       "id": "http_server_websocket_setupwebsocketserver",
-      "community": 745
+      "community": 747
     },
     {
       "label": "review-queue-dashboard-boot.ts",
@@ -2369,7 +2369,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_stdio_server_impl_ts",
-      "community": 746
+      "community": 748
     },
     {
       "label": "startStdioServer()",
@@ -2377,7 +2377,7 @@
       "source_file": "packages/memento-server/src/server/stdio-server-impl.ts",
       "source_location": "L15",
       "id": "stdio_server_impl_startstdioserver",
-      "community": 746
+      "community": 748
     },
     {
       "label": "audit-tool-dispatch.ts",
@@ -2441,7 +2441,7 @@
       "source_file": "packages/memento-server/src/server/server-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_factory_spec_ts",
-      "community": 1037
+      "community": 1038
     },
     {
       "label": "server-state.spec.ts",
@@ -2449,7 +2449,7 @@
       "source_file": "packages/memento-server/src/server/server-state.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_state_spec_ts",
-      "community": 1038
+      "community": 1039
     },
     {
       "label": "auth-session.integration.spec.ts",
@@ -2609,7 +2609,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_owner_scope_integration_spec_ts",
-      "community": 494
+      "community": 495
     },
     {
       "label": "postJson()",
@@ -2617,7 +2617,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L16",
       "id": "owner_scope_integration_spec_postjson",
-      "community": 494
+      "community": 495
     },
     {
       "label": "seedOwnerScopedMemories()",
@@ -2625,7 +2625,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L56",
       "id": "owner_scope_integration_spec_seedownerscopedmemories",
-      "community": 494
+      "community": 495
     },
     {
       "label": "startRealHttpServer()",
@@ -2633,7 +2633,7 @@
       "source_file": "packages/memento-server/src/server/owner-scope.integration.spec.ts",
       "source_location": "L69",
       "id": "owner_scope_integration_spec_startrealhttpserver",
-      "community": 494
+      "community": 495
     },
     {
       "label": "server-info.spec.ts",
@@ -2641,7 +2641,7 @@
       "source_file": "packages/memento-server/src/server/server-info.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_server_info_spec_ts",
-      "community": 1039
+      "community": 1040
     },
     {
       "label": "simple-mcp-server.ts",
@@ -2649,7 +2649,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_simple_mcp_server_ts",
-      "community": 747
+      "community": 749
     },
     {
       "label": "startSimpleMcpServer()",
@@ -2657,7 +2657,7 @@
       "source_file": "packages/memento-server/src/server/simple-mcp-server.ts",
       "source_location": "L188",
       "id": "simple_mcp_server_startsimplemcpserver",
-      "community": 747
+      "community": 749
     },
     {
       "label": "http-server-lifecycle.ts",
@@ -2665,7 +2665,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_http_server_lifecycle_ts",
-      "community": 495
+      "community": 496
     },
     {
       "label": "createRuntimeDiagnosticsWriter()",
@@ -2673,7 +2673,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L18",
       "id": "http_server_lifecycle_createruntimediagnosticswriter",
-      "community": 495
+      "community": 496
     },
     {
       "label": "performCleanup()",
@@ -2681,7 +2681,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L37",
       "id": "http_server_lifecycle_performcleanup",
-      "community": 495
+      "community": 496
     },
     {
       "label": "registerCleanupHandlers()",
@@ -2689,7 +2689,7 @@
       "source_file": "packages/memento-server/src/server/http-server-lifecycle.ts",
       "source_location": "L106",
       "id": "http_server_lifecycle_registercleanuphandlers",
-      "community": 495
+      "community": 496
     },
     {
       "label": "admin-auth-security.integration.spec.ts",
@@ -2697,7 +2697,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_admin_auth_security_integration_spec_ts",
-      "community": 628
+      "community": 629
     },
     {
       "label": "createMockResponse()",
@@ -2705,7 +2705,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L14",
       "id": "admin_auth_security_integration_spec_createmockresponse",
-      "community": 628
+      "community": 629
     },
     {
       "label": "runAdminAuthProbe()",
@@ -2713,7 +2713,7 @@
       "source_file": "packages/memento-server/src/server/admin-auth-security.integration.spec.ts",
       "source_location": "L30",
       "id": "admin_auth_security_integration_spec_runadminauthprobe",
-      "community": 628
+      "community": 629
     },
     {
       "label": "server-state.ts",
@@ -2849,7 +2849,7 @@
       "source_file": "packages/memento-server/src/server/review-queue-dashboard-boot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_review_queue_dashboard_boot_spec_ts",
-      "community": 1040
+      "community": 1041
     },
     {
       "label": "bootstrap.ts",
@@ -2857,7 +2857,7 @@
       "source_file": "packages/memento-server/src/server/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_bootstrap_ts",
-      "community": 1041
+      "community": 1042
     },
     {
       "label": "review-candidates-sse-hub.ts",
@@ -2905,7 +2905,7 @@
       "source_file": "packages/memento-server/src/server/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_index_spec_ts",
-      "community": 1042
+      "community": 1043
     },
     {
       "label": "sse-server-impl.ts",
@@ -2913,7 +2913,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_sse_server_impl_ts",
-      "community": 496
+      "community": 497
     },
     {
       "label": "startSseServer()",
@@ -2921,7 +2921,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L15",
       "id": "sse_server_impl_startsseserver",
-      "community": 496
+      "community": 497
     },
     {
       "label": "stopSseServer()",
@@ -2929,7 +2929,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L26",
       "id": "sse_server_impl_stopsseserver",
-      "community": 496
+      "community": 497
     },
     {
       "label": "cleanupSseServer()",
@@ -2937,7 +2937,7 @@
       "source_file": "packages/memento-server/src/server/sse-server-impl.ts",
       "source_location": "L37",
       "id": "sse_server_impl_cleanupsseserver",
-      "community": 496
+      "community": 497
     },
     {
       "label": "http-server.ts",
@@ -3065,7 +3065,7 @@
       "source_file": "packages/memento-server/src/server/context.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_context_ts",
-      "community": 1043
+      "community": 1044
     },
     {
       "label": "batch-run-history.ts",
@@ -3249,7 +3249,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_ts",
-      "community": 629
+      "community": 630
     },
     {
       "label": "resolveCorsAllowOrigin()",
@@ -3257,7 +3257,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L6",
       "id": "cors_policy_resolvecorsalloworigin",
-      "community": 629
+      "community": 630
     },
     {
       "label": "buildMcpManualCorsHeaders()",
@@ -3265,7 +3265,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.ts",
       "source_location": "L22",
       "id": "cors_policy_buildmcpmanualcorsheaders",
-      "community": 629
+      "community": 630
     },
     {
       "label": "cors-policy.spec.ts",
@@ -3273,7 +3273,7 @@
       "source_file": "packages/memento-server/src/server/utils/cors-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_cors_policy_spec_ts",
-      "community": 1044
+      "community": 1045
     },
     {
       "label": "mcp-tool-call-error.spec.ts",
@@ -3281,7 +3281,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_spec_ts",
-      "community": 1045
+      "community": 1046
     },
     {
       "label": "mcp-tool-call-error.ts",
@@ -3289,7 +3289,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_utils_mcp_tool_call_error_ts",
-      "community": 748
+      "community": 750
     },
     {
       "label": "mapToolExecutionErrorToJsonRpc()",
@@ -3297,7 +3297,7 @@
       "source_file": "packages/memento-server/src/server/utils/mcp-tool-call-error.ts",
       "source_location": "L13",
       "id": "mcp_tool_call_error_maptoolexecutionerrortojsonrpc",
-      "community": 748
+      "community": 750
     },
     {
       "label": "tool-result.utils.ts",
@@ -3305,7 +3305,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_handlers_tool_result_utils_ts",
-      "community": 749
+      "community": 751
     },
     {
       "label": "extractToolResultPayload()",
@@ -3313,7 +3313,7 @@
       "source_file": "packages/memento-server/src/server/handlers/tool-result.utils.ts",
       "source_location": "L6",
       "id": "tool_result_utils_extracttoolresultpayload",
-      "community": 749
+      "community": 751
     },
     {
       "label": "anchor-map.handler.spec.ts",
@@ -3417,7 +3417,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/tool-context-meta-memory-injection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_tool_context_meta_memory_injection_spec_ts",
-      "community": 1046
+      "community": 1047
     },
     {
       "label": "server-services-meta-memory.spec.ts",
@@ -3425,7 +3425,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/server-services-meta-memory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_server_services_meta_memory_spec_ts",
-      "community": 1047
+      "community": 1048
     },
     {
       "label": "meta-memory-service-initialization.spec.ts",
@@ -3433,7 +3433,7 @@
       "source_file": "packages/memento-server/src/server/__tests__/meta-memory-service-initialization.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_tests_meta_memory_service_initialization_spec_ts",
-      "community": 1048
+      "community": 1049
     },
     {
       "label": "http-rate-limit.middleware.spec.ts",
@@ -3441,7 +3441,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_rate_limit_middleware_spec_ts",
-      "community": 750
+      "community": 752
     },
     {
       "label": "getRequest()",
@@ -3449,7 +3449,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-rate-limit.middleware.spec.ts",
       "source_location": "L8",
       "id": "http_rate_limit_middleware_spec_getrequest",
-      "community": 750
+      "community": 752
     },
     {
       "label": "owner-scope.middleware.ts",
@@ -3457,7 +3457,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_ts",
-      "community": 497
+      "community": 498
     },
     {
       "label": "hasOwnerIdInBody()",
@@ -3465,7 +3465,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L10",
       "id": "owner_scope_middleware_hasowneridinbody",
-      "community": 497
+      "community": 498
     },
     {
       "label": "isOwnerScopedToolRequest()",
@@ -3473,7 +3473,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L27",
       "id": "owner_scope_middleware_isownerscopedtoolrequest",
-      "community": 497
+      "community": 498
     },
     {
       "label": "createOwnerScopeMiddleware()",
@@ -3481,7 +3481,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.ts",
       "source_location": "L36",
       "id": "owner_scope_middleware_createownerscopemiddleware",
-      "community": 497
+      "community": 498
     },
     {
       "label": "admin-auth.middleware.spec.ts",
@@ -3489,7 +3489,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_spec_ts",
-      "community": 630
+      "community": 631
     },
     {
       "label": "makeMocks()",
@@ -3497,7 +3497,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L13",
       "id": "admin_auth_middleware_spec_makemocks",
-      "community": 630
+      "community": 631
     },
     {
       "label": "createMiddleware()",
@@ -3505,7 +3505,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.spec.ts",
       "source_location": "L23",
       "id": "admin_auth_middleware_spec_createmiddleware",
-      "community": 630
+      "community": 631
     },
     {
       "label": "programmatic-auth.middleware.ts",
@@ -3737,7 +3737,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_tool_context_middleware_ts",
-      "community": 751
+      "community": 753
     },
     {
       "label": "createToolContextMiddleware()",
@@ -3745,7 +3745,7 @@
       "source_file": "packages/memento-server/src/server/middleware/tool-context.middleware.ts",
       "source_location": "L33",
       "id": "tool_context_middleware_createtoolcontextmiddleware",
-      "community": 751
+      "community": 753
     },
     {
       "label": "session-auth.middleware.spec.ts",
@@ -3753,7 +3753,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_spec_ts",
-      "community": 752
+      "community": 754
     },
     {
       "label": "createMockResponse()",
@@ -3761,7 +3761,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "session_auth_middleware_spec_createmockresponse",
-      "community": 752
+      "community": 754
     },
     {
       "label": "index.ts",
@@ -3769,7 +3769,7 @@
       "source_file": "packages/memento-server/src/server/middleware/index.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_index_ts",
-      "community": 1049
+      "community": 1050
     },
     {
       "label": "session-auth.middleware.ts",
@@ -3777,7 +3777,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_session_auth_middleware_ts",
-      "community": 498
+      "community": 499
     },
     {
       "label": "readCookie()",
@@ -3785,7 +3785,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L9",
       "id": "session_auth_middleware_readcookie",
-      "community": 498
+      "community": 499
     },
     {
       "label": "writeUnauthorized()",
@@ -3793,7 +3793,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L24",
       "id": "session_auth_middleware_writeunauthorized",
-      "community": 498
+      "community": 499
     },
     {
       "label": "createSessionAuthMiddleware()",
@@ -3801,7 +3801,7 @@
       "source_file": "packages/memento-server/src/server/middleware/session-auth.middleware.ts",
       "source_location": "L32",
       "id": "session_auth_middleware_createsessionauthmiddleware",
-      "community": 498
+      "community": 499
     },
     {
       "label": "http-audit.middleware.spec.ts",
@@ -3809,7 +3809,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_http_audit_middleware_spec_ts",
-      "community": 753
+      "community": 755
     },
     {
       "label": "createMockResponse()",
@@ -3817,7 +3817,7 @@
       "source_file": "packages/memento-server/src/server/middleware/http-audit.middleware.spec.ts",
       "source_location": "L18",
       "id": "http_audit_middleware_spec_createmockresponse",
-      "community": 753
+      "community": 755
     },
     {
       "label": "service-injector.middleware.ts",
@@ -3825,7 +3825,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_service_injector_middleware_ts",
-      "community": 754
+      "community": 756
     },
     {
       "label": "createServiceInjector()",
@@ -3833,7 +3833,7 @@
       "source_file": "packages/memento-server/src/server/middleware/service-injector.middleware.ts",
       "source_location": "L32",
       "id": "service_injector_middleware_createserviceinjector",
-      "community": 754
+      "community": 756
     },
     {
       "label": "admin-auth.middleware.ts",
@@ -3841,7 +3841,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_admin_auth_middleware_ts",
-      "community": 755
+      "community": 757
     },
     {
       "label": "createAdminAuthMiddleware()",
@@ -3849,7 +3849,7 @@
       "source_file": "packages/memento-server/src/server/middleware/admin-auth.middleware.ts",
       "source_location": "L16",
       "id": "admin_auth_middleware_createadminauthmiddleware",
-      "community": 755
+      "community": 757
     },
     {
       "label": "http-rate-limit.middleware.ts",
@@ -3913,7 +3913,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_programmatic_auth_middleware_spec_ts",
-      "community": 631
+      "community": 632
     },
     {
       "label": "createMockResponse()",
@@ -3921,7 +3921,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L7",
       "id": "programmatic_auth_middleware_spec_createmockresponse",
-      "community": 631
+      "community": 632
     },
     {
       "label": "createRegistry()",
@@ -3929,7 +3929,7 @@
       "source_file": "packages/memento-server/src/server/middleware/programmatic-auth.middleware.spec.ts",
       "source_location": "L21",
       "id": "programmatic_auth_middleware_spec_createregistry",
-      "community": 631
+      "community": 632
     },
     {
       "label": "owner-scope.middleware.spec.ts",
@@ -3937,7 +3937,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_middleware_owner_scope_middleware_spec_ts",
-      "community": 756
+      "community": 758
     },
     {
       "label": "runMiddleware()",
@@ -3945,7 +3945,7 @@
       "source_file": "packages/memento-server/src/server/middleware/owner-scope.middleware.spec.ts",
       "source_location": "L18",
       "id": "owner_scope_middleware_spec_runmiddleware",
-      "community": 756
+      "community": 758
     },
     {
       "label": "session-store.spec.ts",
@@ -3953,7 +3953,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_spec_ts",
-      "community": 1050
+      "community": 1051
     },
     {
       "label": "session-store.ts",
@@ -3961,7 +3961,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_auth_session_store_ts",
-      "community": 757
+      "community": 759
     },
     {
       "label": "createSessionStore()",
@@ -3969,7 +3969,7 @@
       "source_file": "packages/memento-server/src/server/auth/session-store.ts",
       "source_location": "L22",
       "id": "session_store_createsessionstore",
-      "community": 757
+      "community": 759
     },
     {
       "label": "stdio-server.ts",
@@ -4081,7 +4081,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_ts",
-      "community": 758
+      "community": 760
     },
     {
       "label": "createAgentRouter()",
@@ -4089,7 +4089,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.ts",
       "source_location": "L44",
       "id": "agent_routes_createagentrouter",
-      "community": 758
+      "community": 760
     },
     {
       "label": "quality.routes.spec.ts",
@@ -4097,7 +4097,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_spec_ts",
-      "community": 1051
+      "community": 1052
     },
     {
       "label": "agent.routes.validation.ts",
@@ -4161,7 +4161,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_personal_ts",
-      "community": 499
+      "community": 500
     },
     {
       "label": "parsePersonalRunBody()",
@@ -4169,7 +4169,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L15",
       "id": "agent_routes_personal_parsepersonalrunbody",
-      "community": 499
+      "community": 500
     },
     {
       "label": "handlePostPersonalRun()",
@@ -4177,7 +4177,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L27",
       "id": "agent_routes_personal_handlepostpersonalrun",
-      "community": 499
+      "community": 500
     },
     {
       "label": "handlePostPersonalPersistApproved()",
@@ -4185,7 +4185,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.personal.ts",
       "source_location": "L50",
       "id": "agent_routes_personal_handlepostpersonalpersistapproved",
-      "community": 499
+      "community": 500
     },
     {
       "label": "maintenance.routes.spec.ts",
@@ -4193,7 +4193,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_maintenance_routes_spec_ts",
-      "community": 759
+      "community": 761
     },
     {
       "label": "request()",
@@ -4201,7 +4201,7 @@
       "source_file": "packages/memento-server/src/server/routes/maintenance.routes.spec.ts",
       "source_location": "L8",
       "id": "maintenance_routes_spec_request",
-      "community": 759
+      "community": 761
     },
     {
       "label": "agent.routes.spec.ts",
@@ -4209,7 +4209,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_spec_ts",
-      "community": 632
+      "community": 633
     },
     {
       "label": "event()",
@@ -4217,7 +4217,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L13",
       "id": "agent_routes_spec_event",
-      "community": 632
+      "community": 633
     },
     {
       "label": "invoke()",
@@ -4225,7 +4225,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.spec.ts",
       "source_location": "L159",
       "id": "agent_routes_spec_invoke",
-      "community": 632
+      "community": 633
     },
     {
       "label": "agent-transcript-import.spec.ts",
@@ -4353,7 +4353,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_personal_routes_spec_ts",
-      "community": 760
+      "community": 762
     },
     {
       "label": "invoke()",
@@ -4361,7 +4361,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent-personal.routes.spec.ts",
       "source_location": "L33",
       "id": "agent_personal_routes_spec_invoke",
-      "community": 760
+      "community": 762
     },
     {
       "label": "agent.routes.promotions.ts",
@@ -4513,7 +4513,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_events_ts",
-      "community": 761
+      "community": 763
     },
     {
       "label": "prepareEvent()",
@@ -4521,7 +4521,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.events.ts",
       "source_location": "L14",
       "id": "agent_routes_events_prepareevent",
-      "community": 761
+      "community": 763
     },
     {
       "label": "agent.routes.types.ts",
@@ -4529,7 +4529,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_types_ts",
-      "community": 1052
+      "community": 1053
     },
     {
       "label": "admin.routes.ts",
@@ -4537,7 +4537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_routes_ts",
-      "community": 762
+      "community": 764
     },
     {
       "label": "createAdminRouter()",
@@ -4545,7 +4545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin.routes.ts",
       "source_location": "L29",
       "id": "admin_routes_createadminrouter",
-      "community": 762
+      "community": 764
     },
     {
       "label": "agent.routes.status.ts",
@@ -4697,7 +4697,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.constants.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_constants_ts",
-      "community": 1053
+      "community": 1054
     },
     {
       "label": "mcp.routes.ts",
@@ -4705,7 +4705,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_routes_ts",
-      "community": 763
+      "community": 765
     },
     {
       "label": "createMcpRouter()",
@@ -4713,7 +4713,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp.routes.ts",
       "source_location": "L17",
       "id": "mcp_routes_createmcprouter",
-      "community": 763
+      "community": 765
     },
     {
       "label": "admin.routes.spec.ts",
@@ -4969,7 +4969,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_tools_routes_ts",
-      "community": 764
+      "community": 766
     },
     {
       "label": "createToolsRouter()",
@@ -4977,7 +4977,7 @@
       "source_file": "packages/memento-server/src/server/routes/tools.routes.ts",
       "source_location": "L19",
       "id": "tools_routes_createtoolsrouter",
-      "community": 764
+      "community": 766
     },
     {
       "label": "agent.routes.injection.ts",
@@ -4985,7 +4985,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_agent_routes_injection_ts",
-      "community": 500
+      "community": 501
     },
     {
       "label": "initialInjectionQuery()",
@@ -4993,7 +4993,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L5",
       "id": "agent_routes_injection_initialinjectionquery",
-      "community": 500
+      "community": 501
     },
     {
       "label": "injectionScope()",
@@ -5001,7 +5001,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L16",
       "id": "agent_routes_injection_injectionscope",
-      "community": 500
+      "community": 501
     },
     {
       "label": "buildInjectionDetails()",
@@ -5009,7 +5009,7 @@
       "source_file": "packages/memento-server/src/server/routes/agent.routes.injection.ts",
       "source_location": "L25",
       "id": "agent_routes_injection_buildinjectiondetails",
-      "community": 500
+      "community": 501
     },
     {
       "label": "audit.routes.spec.ts",
@@ -5017,7 +5017,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_audit_routes_spec_ts",
-      "community": 765
+      "community": 767
     },
     {
       "label": "request()",
@@ -5025,7 +5025,7 @@
       "source_file": "packages/memento-server/src/server/routes/audit.routes.spec.ts",
       "source_location": "L8",
       "id": "audit_routes_spec_request",
-      "community": 765
+      "community": 767
     },
     {
       "label": "api.routes.ts",
@@ -5033,7 +5033,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_api_routes_ts",
-      "community": 766
+      "community": 768
     },
     {
       "label": "createApiRouter()",
@@ -5041,7 +5041,7 @@
       "source_file": "packages/memento-server/src/server/routes/api.routes.ts",
       "source_location": "L24",
       "id": "api_routes_createapirouter",
-      "community": 766
+      "community": 768
     },
     {
       "label": "agent.routes.utils.ts",
@@ -5145,7 +5145,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_quality_routes_ts",
-      "community": 767
+      "community": 769
     },
     {
       "label": "createQualityRouter()",
@@ -5153,7 +5153,7 @@
       "source_file": "packages/memento-server/src/server/routes/quality.routes.ts",
       "source_location": "L16",
       "id": "quality_routes_createqualityrouter",
-      "community": 767
+      "community": 769
     },
     {
       "label": "agent.routes.context.ts",
@@ -5329,7 +5329,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_types_ts",
-      "community": 1054
+      "community": 1055
     },
     {
       "label": "handlers.ts",
@@ -5401,7 +5401,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/runtime-transport-parity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_runtime_transport_parity_spec_ts",
-      "community": 1055
+      "community": 1056
     },
     {
       "label": "json-rpc.ts",
@@ -5409,7 +5409,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_mcp_json_rpc_ts",
-      "community": 501
+      "community": 502
     },
     {
       "label": "isJsonRpcNotification()",
@@ -5417,7 +5417,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L3",
       "id": "json_rpc_isjsonrpcnotification",
-      "community": 501
+      "community": 502
     },
     {
       "label": "isInitializeRequest()",
@@ -5425,7 +5425,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L7",
       "id": "json_rpc_isinitializerequest",
-      "community": 501
+      "community": 502
     },
     {
       "label": "createJsonRpcError()",
@@ -5433,7 +5433,7 @@
       "source_file": "packages/memento-server/src/server/routes/mcp/json-rpc.ts",
       "source_location": "L11",
       "id": "json_rpc_createjsonrpcerror",
-      "community": 501
+      "community": 502
     },
     {
       "label": "message-processor.ts",
@@ -5529,7 +5529,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_ts",
-      "community": 768
+      "community": 770
     },
     {
       "label": "registerAdminEvolutionDemoRoutes()",
@@ -5537,7 +5537,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.ts",
       "source_location": "L13",
       "id": "admin_evolution_demo_routes_registeradminevolutiondemoroutes",
-      "community": 768
+      "community": 770
     },
     {
       "label": "admin-memory-review.routes.ts",
@@ -5545,7 +5545,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_memory_review_routes_ts",
-      "community": 502
+      "community": 503
     },
     {
       "label": "parseReviewCandidateStatusQuery()",
@@ -5553,7 +5553,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L33",
       "id": "admin_memory_review_routes_parsereviewcandidatestatusquery",
-      "community": 502
+      "community": 503
     },
     {
       "label": "parseBulkSelector()",
@@ -5561,7 +5561,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L45",
       "id": "admin_memory_review_routes_parsebulkselector",
-      "community": 502
+      "community": 503
     },
     {
       "label": "registerAdminMemoryReviewRoutes()",
@@ -5569,7 +5569,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-memory-review.routes.ts",
       "source_location": "L83",
       "id": "admin_memory_review_routes_registeradminmemoryreviewroutes",
-      "community": 502
+      "community": 503
     },
     {
       "label": "admin-embedding-map-response.spec.ts",
@@ -5625,7 +5625,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_embedding_map_routes_ts",
-      "community": 633
+      "community": 634
     },
     {
       "label": "parseParams()",
@@ -5633,7 +5633,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L21",
       "id": "admin_embedding_map_routes_parseparams",
-      "community": 633
+      "community": 634
     },
     {
       "label": "registerAdminEmbeddingMapRoute()",
@@ -5641,7 +5641,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-embedding-map.routes.ts",
       "source_location": "L58",
       "id": "admin_embedding_map_routes_registeradminembeddingmaproute",
-      "community": 633
+      "community": 634
     },
     {
       "label": "admin-evolution-demo.routes.spec.ts",
@@ -5649,7 +5649,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_evolution_demo_routes_spec_ts",
-      "community": 634
+      "community": 635
     },
     {
       "label": "listen()",
@@ -5657,7 +5657,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L11",
       "id": "admin_evolution_demo_routes_spec_listen",
-      "community": 634
+      "community": 635
     },
     {
       "label": "getAdmin()",
@@ -5665,7 +5665,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-evolution-demo.routes.spec.ts",
       "source_location": "L25",
       "id": "admin_evolution_demo_routes_spec_getadmin",
-      "community": 634
+      "community": 635
     },
     {
       "label": "admin-stats-and-health.routes.ts",
@@ -5673,7 +5673,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_stats_and_health_routes_ts",
-      "community": 769
+      "community": 771
     },
     {
       "label": "registerAdminStatsAndHealthRoutes()",
@@ -5681,7 +5681,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-stats-and-health.routes.ts",
       "source_location": "L10",
       "id": "admin_stats_and_health_routes_registeradminstatsandhealthroutes",
-      "community": 769
+      "community": 771
     },
     {
       "label": "admin-graph-response.ts",
@@ -5689,7 +5689,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_response_ts",
-      "community": 770
+      "community": 772
     },
     {
       "label": "buildGraphResponse()",
@@ -5697,7 +5697,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph-response.ts",
       "source_location": "L75",
       "id": "admin_graph_response_buildgraphresponse",
-      "community": 770
+      "community": 772
     },
     {
       "label": "admin-tools.routes.ts",
@@ -5705,7 +5705,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_tools_routes_ts",
-      "community": 771
+      "community": 773
     },
     {
       "label": "registerAdminToolRoutes()",
@@ -5713,7 +5713,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-tools.routes.ts",
       "source_location": "L17",
       "id": "admin_tools_routes_registeradmintoolroutes",
-      "community": 771
+      "community": 773
     },
     {
       "label": "admin-batch.routes.ts",
@@ -5721,7 +5721,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_batch_routes_ts",
-      "community": 772
+      "community": 774
     },
     {
       "label": "registerAdminBatchRoutes()",
@@ -5729,7 +5729,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-batch.routes.ts",
       "source_location": "L18",
       "id": "admin_batch_routes_registeradminbatchroutes",
-      "community": 772
+      "community": 774
     },
     {
       "label": "admin-forgetting.routes.ts",
@@ -5737,7 +5737,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_forgetting_routes_ts",
-      "community": 773
+      "community": 775
     },
     {
       "label": "registerAdminForgettingRoutes()",
@@ -5745,7 +5745,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-forgetting.routes.ts",
       "source_location": "L11",
       "id": "admin_forgetting_routes_registeradminforgettingroutes",
-      "community": 773
+      "community": 775
     },
     {
       "label": "admin-graph.routes.ts",
@@ -5753,7 +5753,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_graph_routes_ts",
-      "community": 774
+      "community": 776
     },
     {
       "label": "registerAdminGraphRoute()",
@@ -5761,7 +5761,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-graph.routes.ts",
       "source_location": "L10",
       "id": "admin_graph_routes_registeradmingraphroute",
-      "community": 774
+      "community": 776
     },
     {
       "label": "admin-project-memory.routes.ts",
@@ -5769,7 +5769,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_project_memory_routes_ts",
-      "community": 635
+      "community": 636
     },
     {
       "label": "parseCleanupParams()",
@@ -5777,7 +5777,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L12",
       "id": "admin_project_memory_routes_parsecleanupparams",
-      "community": 635
+      "community": 636
     },
     {
       "label": "registerAdminProjectMemoryRoutes()",
@@ -5785,7 +5785,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-project-memory.routes.ts",
       "source_location": "L33",
       "id": "admin_project_memory_routes_registeradminprojectmemoryroutes",
-      "community": 635
+      "community": 636
     },
     {
       "label": "admin-relations.routes.ts",
@@ -5841,7 +5841,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_runtime_performance_routes_ts",
-      "community": 775
+      "community": 777
     },
     {
       "label": "registerAdminRuntimePerformanceRoutes()",
@@ -5849,7 +5849,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-runtime-performance.routes.ts",
       "source_location": "L8",
       "id": "admin_runtime_performance_routes_registeradminruntimeperformanceroutes",
-      "community": 775
+      "community": 777
     },
     {
       "label": "admin-telemetry.routes.ts",
@@ -5857,7 +5857,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_routes_ts",
-      "community": 776
+      "community": 778
     },
     {
       "label": "registerAdminTelemetryRoutes()",
@@ -5865,7 +5865,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry.routes.ts",
       "source_location": "L15",
       "id": "admin_telemetry_routes_registeradmintelemetryroutes",
-      "community": 776
+      "community": 778
     },
     {
       "label": "admin-telemetry-utils.ts",
@@ -5873,7 +5873,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_telemetry_utils_ts",
-      "community": 777
+      "community": 779
     },
     {
       "label": "effectiveTelemetryPeriod()",
@@ -5881,7 +5881,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-telemetry-utils.ts",
       "source_location": "L9",
       "id": "admin_telemetry_utils_effectivetelemetryperiod",
-      "community": 777
+      "community": 779
     },
     {
       "label": "admin-embedding-map-response.ts",
@@ -5977,7 +5977,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_server_routes_admin_admin_export_routes_ts",
-      "community": 636
+      "community": 637
     },
     {
       "label": "parseTypesQuery()",
@@ -5985,7 +5985,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L12",
       "id": "admin_export_routes_parsetypesquery",
-      "community": 636
+      "community": 637
     },
     {
       "label": "registerAdminExportRoutes()",
@@ -5993,7 +5993,7 @@
       "source_file": "packages/memento-server/src/server/routes/admin/admin-export.routes.ts",
       "source_location": "L21",
       "id": "admin_export_routes_registeradminexportroutes",
-      "community": 636
+      "community": 637
     },
     {
       "label": "claude-code-hook.ts",
@@ -6041,7 +6041,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_spec_ts",
-      "community": 778
+      "community": 780
     },
     {
       "label": "argv()",
@@ -6049,7 +6049,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.spec.ts",
       "source_location": "L9",
       "id": "agent_ask_spec_argv",
-      "community": 778
+      "community": 780
     },
     {
       "label": "agent-ask-issue237.e2e.spec.ts",
@@ -6097,7 +6097,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_connect_spec_ts",
-      "community": 1056
+      "community": 1057
     },
     {
       "label": "agent-ops-demo.ts",
@@ -6105,7 +6105,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_demo_ts",
-      "community": 779
+      "community": 781
     },
     {
       "label": "runDemo()",
@@ -6113,7 +6113,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops-demo.ts",
       "source_location": "L11",
       "id": "agent_ops_demo_rundemo",
-      "community": 779
+      "community": 781
     },
     {
       "label": "env-loader.ts",
@@ -6121,7 +6121,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_env_loader_ts",
-      "community": 637
+      "community": 638
     },
     {
       "label": "resolveEnvPath()",
@@ -6129,7 +6129,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L26",
       "id": "env_loader_resolveenvpath",
-      "community": 637
+      "community": 638
     },
     {
       "label": "loadEnv()",
@@ -6137,7 +6137,7 @@
       "source_file": "packages/memento-server/src/cli/env-loader.ts",
       "source_location": "L55",
       "id": "env_loader_loadenv",
-      "community": 637
+      "community": 638
     },
     {
       "label": "codex-connect.spec.ts",
@@ -6145,7 +6145,7 @@
       "source_file": "packages/memento-server/src/cli/codex-connect.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_connect_spec_ts",
-      "community": 1057
+      "community": 1058
     },
     {
       "label": "codex-hook.ts",
@@ -6241,7 +6241,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_cli_ac5_ac6_spec_ts",
-      "community": 638
+      "community": 639
     },
     {
       "label": "runCli()",
@@ -6249,7 +6249,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L68",
       "id": "cli_ac5_ac6_spec_runcli",
-      "community": 638
+      "community": 639
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6257,7 +6257,7 @@
       "source_file": "packages/memento-server/src/cli/cli-ac5-ac6.spec.ts",
       "source_location": "L99",
       "id": "cli_ac5_ac6_spec_createreviewqueuedatabase",
-      "community": 638
+      "community": 639
     },
     {
       "label": "agent-ask.ts",
@@ -6265,7 +6265,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_ts",
-      "community": 1058
+      "community": 1059
     },
     {
       "label": "agent-ops.spec.ts",
@@ -6273,7 +6273,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ops_spec_ts",
-      "community": 639
+      "community": 640
     },
     {
       "label": "response()",
@@ -6281,7 +6281,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L9",
       "id": "agent_ops_spec_response",
-      "community": 639
+      "community": 640
     },
     {
       "label": "baseDependencies()",
@@ -6289,7 +6289,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ops.spec.ts",
       "source_location": "L13",
       "id": "agent_ops_spec_basedependencies",
-      "community": 639
+      "community": 640
     },
     {
       "label": "review-queue-cleanup.spec.ts",
@@ -6297,7 +6297,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_review_queue_cleanup_spec_ts",
-      "community": 640
+      "community": 641
     },
     {
       "label": "createReviewQueueDatabase()",
@@ -6305,7 +6305,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L13",
       "id": "review_queue_cleanup_spec_createreviewqueuedatabase",
-      "community": 640
+      "community": 641
     },
     {
       "label": "pendingCount()",
@@ -6313,7 +6313,7 @@
       "source_file": "packages/memento-server/src/cli/review-queue-cleanup.spec.ts",
       "source_location": "L54",
       "id": "review_queue_cleanup_spec_pendingcount",
-      "community": 640
+      "community": 641
     },
     {
       "label": "claude-code-connect.ts",
@@ -6409,7 +6409,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_claude_code_hook_spec_ts",
-      "community": 780
+      "community": 782
     },
     {
       "label": "event()",
@@ -6417,7 +6417,7 @@
       "source_file": "packages/memento-server/src/cli/claude-code-hook.spec.ts",
       "source_location": "L7",
       "id": "claude_code_hook_spec_event",
-      "community": 780
+      "community": 782
     },
     {
       "label": "agent-ops.ts",
@@ -6481,7 +6481,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_codex_hook_spec_ts",
-      "community": 781
+      "community": 783
     },
     {
       "label": "event()",
@@ -6489,7 +6489,7 @@
       "source_file": "packages/memento-server/src/cli/codex-hook.spec.ts",
       "source_location": "L7",
       "id": "codex_hook_spec_event",
-      "community": 781
+      "community": 783
     },
     {
       "label": "agent-ops-core.ts",
@@ -6817,7 +6817,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_approval_ts",
-      "community": 782
+      "community": 784
     },
     {
       "label": "promptApproveInteractive()",
@@ -6825,7 +6825,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/approval.ts",
       "source_location": "L7",
       "id": "approval_promptapproveinteractive",
-      "community": 782
+      "community": 784
     },
     {
       "label": "help.ts",
@@ -6833,7 +6833,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_cli_agent_ask_help_ts",
-      "community": 783
+      "community": 785
     },
     {
       "label": "agentAskHelpText()",
@@ -6841,7 +6841,7 @@
       "source_file": "packages/memento-server/src/cli/agent-ask/help.ts",
       "source_location": "L1",
       "id": "help_agentaskhelptext",
-      "community": 783
+      "community": 785
     },
     {
       "label": "types.ts",
@@ -6849,7 +6849,7 @@
       "source_file": "packages/memento-server/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_tools_types_ts",
-      "community": 1059
+      "community": 1060
     },
     {
       "label": "quality-measurement-hook.ts",
@@ -6857,7 +6857,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_quality_measurement_hook_ts",
-      "community": 641
+      "community": 642
     },
     {
       "label": "initializeQualityMeasurement()",
@@ -6865,7 +6865,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L29",
       "id": "quality_measurement_hook_initializequalitymeasurement",
-      "community": 641
+      "community": 642
     },
     {
       "label": "runQualityMeasurement()",
@@ -6873,7 +6873,7 @@
       "source_file": "packages/memento-server/src/test/quality-measurement-hook.ts",
       "source_location": "L74",
       "id": "quality_measurement_hook_runqualitymeasurement",
-      "community": 641
+      "community": 642
     },
     {
       "label": "test-simple-alerts.ts",
@@ -6881,7 +6881,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_simple_alerts_ts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "testSimpleAlerts()",
@@ -6889,7 +6889,7 @@
       "source_file": "packages/memento-server/src/test/test-simple-alerts.ts",
       "source_location": "L14",
       "id": "test_simple_alerts_testsimplealerts",
-      "community": 784
+      "community": 786
     },
     {
       "label": "test-http-server-v2-simple.ts",
@@ -6897,7 +6897,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_http_server_v2_simple_ts",
-      "community": 785
+      "community": 787
     },
     {
       "label": "testBasicFunctionality()",
@@ -6905,7 +6905,7 @@
       "source_file": "packages/memento-server/src/test/test-http-server-v2-simple.ts",
       "source_location": "L13",
       "id": "test_http_server_v2_simple_testbasicfunctionality",
-      "community": 785
+      "community": 787
     },
     {
       "label": "test-performance-monitoring.ts",
@@ -6913,7 +6913,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitoring_ts",
-      "community": 786
+      "community": 788
     },
     {
       "label": "testPerformanceMonitoring()",
@@ -6921,7 +6921,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitoring.ts",
       "source_location": "L9",
       "id": "test_performance_monitoring_testperformancemonitoring",
-      "community": 786
+      "community": 788
     },
     {
       "label": "test-server-synchronization.ts",
@@ -6929,7 +6929,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_server_synchronization_ts",
-      "community": 642
+      "community": 643
     },
     {
       "label": "compareServices()",
@@ -6937,7 +6937,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L16",
       "id": "test_server_synchronization_compareservices",
-      "community": 642
+      "community": 643
     },
     {
       "label": "testServerSynchronization()",
@@ -6945,7 +6945,7 @@
       "source_file": "packages/memento-server/src/test/test-server-synchronization.ts",
       "source_location": "L77",
       "id": "test_server_synchronization_testserversynchronization",
-      "community": 642
+      "community": 643
     },
     {
       "label": "test-error-logging.ts",
@@ -6953,7 +6953,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_error_logging_ts",
-      "community": 787
+      "community": 789
     },
     {
       "label": "testErrorLogging()",
@@ -6961,7 +6961,7 @@
       "source_file": "packages/memento-server/src/test/test-error-logging.ts",
       "source_location": "L10",
       "id": "test_error_logging_testerrorlogging",
-      "community": 787
+      "community": 789
     },
     {
       "label": "debug-http-v2.ts",
@@ -6969,7 +6969,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_debug_http_v2_ts",
-      "community": 788
+      "community": 790
     },
     {
       "label": "testFetch()",
@@ -6977,7 +6977,7 @@
       "source_file": "packages/memento-server/src/test/debug-http-v2.ts",
       "source_location": "L10",
       "id": "debug_http_v2_testfetch",
-      "community": 788
+      "community": 790
     },
     {
       "label": "test-reflexion-error-cases.spec.ts",
@@ -6985,7 +6985,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_error_cases_spec_ts",
-      "community": 789
+      "community": 791
     },
     {
       "label": "initializeTestDatabase()",
@@ -6993,7 +6993,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-error-cases.spec.ts",
       "source_location": "L22",
       "id": "test_reflexion_error_cases_spec_initializetestdatabase",
-      "community": 789
+      "community": 791
     },
     {
       "label": "test-reflexion-e2e.ts",
@@ -7001,7 +7001,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_ts",
-      "community": 1060
+      "community": 1061
     },
     {
       "label": "test-meta-memory-e2e.spec.ts",
@@ -7009,7 +7009,7 @@
       "source_file": "packages/memento-server/src/test/test-meta-memory-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_meta_memory_e2e_spec_ts",
-      "community": 1061
+      "community": 1062
     },
     {
       "label": "test-reflexion-e2e.spec.ts",
@@ -7017,7 +7017,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_e2e_spec_ts",
-      "community": 790
+      "community": 792
     },
     {
       "label": "testReflexionE2E()",
@@ -7025,7 +7025,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-e2e.spec.ts",
       "source_location": "L18",
       "id": "test_reflexion_e2e_spec_testreflexione2e",
-      "community": 790
+      "community": 792
     },
     {
       "label": "test-alerts-direct.ts",
@@ -7033,7 +7033,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_alerts_direct_ts",
-      "community": 791
+      "community": 793
     },
     {
       "label": "testAlertsDirect()",
@@ -7041,7 +7041,7 @@
       "source_file": "packages/memento-server/src/test/test-alerts-direct.ts",
       "source_location": "L12",
       "id": "test_alerts_direct_testalertsdirect",
-      "community": 791
+      "community": 793
     },
     {
       "label": "test-client.ts",
@@ -7049,7 +7049,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_client_ts",
-      "community": 643
+      "community": 644
     },
     {
       "label": "assert()",
@@ -7057,7 +7057,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L9",
       "id": "test_client_assert",
-      "community": 643
+      "community": 644
     },
     {
       "label": "testMementoClient()",
@@ -7065,7 +7065,7 @@
       "source_file": "packages/memento-server/src/test/test-client.ts",
       "source_location": "L13",
       "id": "test_client_testmementoclient",
-      "community": 643
+      "community": 644
     },
     {
       "label": "test-performance-monitor.ts",
@@ -7073,7 +7073,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-monitor.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_monitor_ts",
-      "community": 1062
+      "community": 1063
     },
     {
       "label": "test-http-server-v2.ts",
@@ -7153,7 +7153,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_performance_alerts_ts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "testPerformanceAlerts()",
@@ -7161,7 +7161,7 @@
       "source_file": "packages/memento-server/src/test/test-performance-alerts.ts",
       "source_location": "L9",
       "id": "test_performance_alerts_testperformancealerts",
-      "community": 792
+      "community": 794
     },
     {
       "label": "test-security-path-traversal.ts",
@@ -7169,7 +7169,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_path_traversal_ts",
-      "community": 793
+      "community": 795
     },
     {
       "label": "testPathTraversalE2E()",
@@ -7177,7 +7177,7 @@
       "source_file": "packages/memento-server/src/test/test-security-path-traversal.ts",
       "source_location": "L26",
       "id": "test_security_path_traversal_testpathtraversale2e",
-      "community": 793
+      "community": 795
     },
     {
       "label": "test-security-sql-injection.ts",
@@ -7185,7 +7185,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_security_sql_injection_ts",
-      "community": 794
+      "community": 796
     },
     {
       "label": "testSqlInjectionE2E()",
@@ -7193,7 +7193,7 @@
       "source_file": "packages/memento-server/src/test/test-security-sql-injection.ts",
       "source_location": "L24",
       "id": "test_security_sql_injection_testsqlinjectione2e",
-      "community": 794
+      "community": 796
     },
     {
       "label": "test-reflexion-performance.ts",
@@ -7201,7 +7201,7 @@
       "source_file": "packages/memento-server/src/test/test-reflexion-performance.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_test_reflexion_performance_ts",
-      "community": 1063
+      "community": 1064
     },
     {
       "label": "mcp-relation-tools.spec.ts",
@@ -7209,7 +7209,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_server_src_test_integration_mcp_relation_tools_spec_ts",
-      "community": 644
+      "community": 645
     },
     {
       "label": "createBaseSchema()",
@@ -7217,7 +7217,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L27",
       "id": "mcp_relation_tools_spec_createbaseschema",
-      "community": 644
+      "community": 645
     },
     {
       "label": "createTestMemory()",
@@ -7225,7 +7225,7 @@
       "source_file": "packages/memento-server/src/test/integration/mcp-relation-tools.spec.ts",
       "source_location": "L62",
       "id": "mcp_relation_tools_spec_createtestmemory",
-      "community": 644
+      "community": 645
     },
     {
       "label": "anchor-map-search-highlight.spec.ts",
@@ -7289,7 +7289,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_vitest_config_ts",
-      "community": 1064
+      "community": 1065
     },
     {
       "label": "brave-search-provider.spec.ts",
@@ -7297,7 +7297,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_spec_ts",
-      "community": 1065
+      "community": 1066
     },
     {
       "label": "brave-search-provider.ts",
@@ -7305,7 +7305,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_brave_search_provider_ts",
-      "community": 503
+      "community": 504
     },
     {
       "label": "BraveSearchProvider",
@@ -7313,7 +7313,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L4",
       "id": "brave_search_provider_bravesearchprovider",
-      "community": 503
+      "community": 504
     },
     {
       "label": ".constructor()",
@@ -7321,7 +7321,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L5",
       "id": "brave_search_provider_bravesearchprovider_constructor",
-      "community": 503
+      "community": 504
     },
     {
       "label": ".search()",
@@ -7329,7 +7329,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/brave-search-provider.ts",
       "source_location": "L7",
       "id": "brave_search_provider_bravesearchprovider_search",
-      "community": 503
+      "community": 504
     },
     {
       "label": "noop-search-provider.ts",
@@ -7337,7 +7337,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_noop_search_provider_ts",
-      "community": 645
+      "community": 646
     },
     {
       "label": "NoopSearchProvider",
@@ -7345,7 +7345,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L4",
       "id": "noop_search_provider_noopsearchprovider",
-      "community": 645
+      "community": 646
     },
     {
       "label": ".search()",
@@ -7353,7 +7353,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/noop-search-provider.ts",
       "source_location": "L5",
       "id": "noop_search_provider_noopsearchprovider_search",
-      "community": 645
+      "community": 646
     },
     {
       "label": "search-factory.ts",
@@ -7361,7 +7361,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_factory_ts",
-      "community": 795
+      "community": 797
     },
     {
       "label": "createSearchProvider()",
@@ -7369,7 +7369,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-factory.ts",
       "source_location": "L5",
       "id": "search_factory_createsearchprovider",
-      "community": 795
+      "community": 797
     },
     {
       "label": "search-provider.ts",
@@ -7377,7 +7377,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/search/search-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_search_search_provider_ts",
-      "community": 1066
+      "community": 1067
     },
     {
       "label": "llm-provider.ts",
@@ -7385,7 +7385,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/llm-provider.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_llm_provider_ts",
-      "community": 1067
+      "community": 1068
     },
     {
       "label": "claude-provider.spec.ts",
@@ -7393,7 +7393,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/providers/llm/claude-provider.spec.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_providers_llm_claude_provider_spec_ts",
-      "community": 1068
+      "community": 1069
     },
     {
       "label": "types.ts",
@@ -7401,7 +7401,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_core_types_ts",
-      "community": 796
+      "community": 798
     },
     {
       "label": "loadAgentConfig()",
@@ -7409,7 +7409,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/core/types.ts",
       "source_location": "L27",
       "id": "types_loadagentconfig",
-      "community": 796
+      "community": 798
     },
     {
       "label": "system-prompt.ts",
@@ -7417,7 +7417,7 @@
       "source_file": "packages/_archived/memento-agent-issue-100/src/prompts/system-prompt.ts",
       "source_location": "L1",
       "id": "packages_archived_memento_agent_issue_100_src_prompts_system_prompt_ts",
-      "community": 1069
+      "community": 1070
     },
     {
       "label": "vitest.config.ts",
@@ -7425,7 +7425,7 @@
       "source_file": "packages/memento-agent-integration/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_vitest_config_ts",
-      "community": 1070
+      "community": 1071
     },
     {
       "label": "injection-contract.spec.ts",
@@ -7433,7 +7433,7 @@
       "source_file": "packages/memento-agent-integration/src/injection-contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_injection_contract_spec_ts",
-      "community": 1071
+      "community": 1072
     },
     {
       "label": "queue-runtime.spec.ts",
@@ -7441,7 +7441,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_queue_runtime_spec_ts",
-      "community": 797
+      "community": 799
     },
     {
       "label": "transport()",
@@ -7449,7 +7449,7 @@
       "source_file": "packages/memento-agent-integration/src/queue-runtime.spec.ts",
       "source_location": "L179",
       "id": "queue_runtime_spec_transport",
-      "community": 797
+      "community": 799
     },
     {
       "label": "redaction-size.spec.ts",
@@ -7457,7 +7457,7 @@
       "source_file": "packages/memento-agent-integration/src/redaction-size.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_redaction_size_spec_ts",
-      "community": 1072
+      "community": 1073
     },
     {
       "label": "injection-contract.ts",
@@ -7585,7 +7585,7 @@
       "source_file": "packages/memento-agent-integration/src/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_types_ts",
-      "community": 1073
+      "community": 1074
     },
     {
       "label": "runtime.ts",
@@ -7681,7 +7681,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_test_fixtures_ts",
-      "community": 798
+      "community": 800
     },
     {
       "label": "eventFixture()",
@@ -7689,7 +7689,7 @@
       "source_file": "packages/memento-agent-integration/src/test-fixtures.ts",
       "source_location": "L15",
       "id": "test_fixtures_eventfixture",
-      "community": 798
+      "community": 800
     },
     {
       "label": "schema-normalize.spec.ts",
@@ -7697,7 +7697,7 @@
       "source_file": "packages/memento-agent-integration/src/schema-normalize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_schema_normalize_spec_ts",
-      "community": 1074
+      "community": 1075
     },
     {
       "label": "normalize.ts",
@@ -7705,7 +7705,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_normalize_ts",
-      "community": 504
+      "community": 505
     },
     {
       "label": "normalizeJson()",
@@ -7713,7 +7713,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L4",
       "id": "normalize_normalizejson",
-      "community": 504
+      "community": 505
     },
     {
       "label": "canonicalize()",
@@ -7721,7 +7721,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L33",
       "id": "normalize_canonicalize",
-      "community": 504
+      "community": 505
     },
     {
       "label": "normalizeAgentEvent()",
@@ -7729,7 +7729,7 @@
       "source_file": "packages/memento-agent-integration/src/normalize.ts",
       "source_location": "L47",
       "id": "normalize_normalizeagentevent",
-      "community": 504
+      "community": 505
     },
     {
       "label": "index.ts",
@@ -7737,7 +7737,7 @@
       "source_file": "packages/memento-agent-integration/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_index_ts",
-      "community": 1075
+      "community": 1076
     },
     {
       "label": "priority-queue.ts",
@@ -7945,7 +7945,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_scope_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "git()",
@@ -7953,7 +7953,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L22",
       "id": "scope_spec_git",
-      "community": 646
+      "community": 647
     },
     {
       "label": "runner.spec.ts",
@@ -7961,7 +7961,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_spec_ts",
-      "community": 1076
+      "community": 1077
     },
     {
       "label": "adapter.ts",
@@ -8057,7 +8057,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_settings_spec_ts",
-      "community": 1077
+      "community": 1078
     },
     {
       "label": "types.ts",
@@ -8065,7 +8065,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_types_ts",
-      "community": 1078
+      "community": 1079
     },
     {
       "label": "scope.ts",
@@ -8121,7 +8121,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_spec_ts",
-      "community": 1079
+      "community": 1080
     },
     {
       "label": "diagnostics.ts",
@@ -8129,7 +8129,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_diagnostics_ts",
-      "community": 799
+      "community": 801
     },
     {
       "label": "diagnoseCodex()",
@@ -8137,7 +8137,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/diagnostics.ts",
       "source_location": "L21",
       "id": "diagnostics_diagnosecodex",
-      "community": 799
+      "community": 801
     },
     {
       "label": "settings.ts",
@@ -8185,7 +8185,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_runner_ts",
-      "community": 800
+      "community": 802
     },
     {
       "label": "runCodexHook()",
@@ -8193,7 +8193,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/runner.ts",
       "source_location": "L6",
       "id": "runner_runcodexhook",
-      "community": 800
+      "community": 802
     },
     {
       "label": "adapter.spec.ts",
@@ -8201,7 +8201,7 @@
       "source_file": "packages/memento-agent-integration/src/codex/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_codex_adapter_spec_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "fixture()",
@@ -8209,7 +8209,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L12",
       "id": "adapter_spec_fixture",
-      "community": 506
+      "community": 507
     },
     {
       "label": "scope.spec.ts",
@@ -8217,7 +8217,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/scope.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_scope_spec_ts",
-      "community": 646
+      "community": 647
     },
     {
       "label": "runner.spec.ts",
@@ -8225,7 +8225,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_spec_ts",
-      "community": 1080
+      "community": 1081
     },
     {
       "label": "adapter.ts",
@@ -8297,7 +8297,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/settings.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_settings_spec_ts",
-      "community": 1081
+      "community": 1082
     },
     {
       "label": "types.ts",
@@ -8305,7 +8305,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/types.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_types_ts",
-      "community": 1082
+      "community": 1083
     },
     {
       "label": "scope.ts",
@@ -8337,7 +8337,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_spec_ts",
-      "community": 1083
+      "community": 1084
     },
     {
       "label": "diagnostics.ts",
@@ -8345,7 +8345,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_diagnostics_ts",
-      "community": 505
+      "community": 506
     },
     {
       "label": "parseVersion()",
@@ -8353,7 +8353,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L19",
       "id": "diagnostics_parseversion",
-      "community": 505
+      "community": 506
     },
     {
       "label": "versionAtLeast()",
@@ -8361,7 +8361,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L31",
       "id": "diagnostics_versionatleast",
-      "community": 505
+      "community": 506
     },
     {
       "label": "diagnoseClaudeCode()",
@@ -8369,7 +8369,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/diagnostics.ts",
       "source_location": "L42",
       "id": "diagnostics_diagnoseclaudecode",
-      "community": 505
+      "community": 506
     },
     {
       "label": "settings.ts",
@@ -8417,7 +8417,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_runner_ts",
-      "community": 647
+      "community": 648
     },
     {
       "label": "invalid()",
@@ -8425,7 +8425,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L6",
       "id": "runner_invalid",
-      "community": 647
+      "community": 648
     },
     {
       "label": "runClaudeCodeHook()",
@@ -8433,7 +8433,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/runner.ts",
       "source_location": "L10",
       "id": "runner_runclaudecodehook",
-      "community": 647
+      "community": 648
     },
     {
       "label": "adapter.spec.ts",
@@ -8441,7 +8441,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_agent_integration_src_claude_code_adapter_spec_ts",
-      "community": 506
+      "community": 507
     },
     {
       "label": "fixtureUrl()",
@@ -8449,7 +8449,7 @@
       "source_file": "packages/memento-agent-integration/src/claude-code/adapter.spec.ts",
       "source_location": "L9",
       "id": "adapter_spec_fixtureurl",
-      "community": 506
+      "community": 507
     },
     {
       "label": "vitest.config.ts",
@@ -8457,7 +8457,7 @@
       "source_file": "packages/memento-client/vitest.config.ts",
       "source_location": "L1",
       "id": "packages_memento_client_vitest_config_ts",
-      "community": 1084
+      "community": 1085
     },
     {
       "label": "utils.spec.ts",
@@ -8465,7 +8465,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_spec_ts",
-      "community": 801
+      "community": 803
     },
     {
       "label": "buildMemory()",
@@ -8473,7 +8473,7 @@
       "source_file": "packages/memento-client/src/utils.spec.ts",
       "source_location": "L5",
       "id": "utils_spec_buildmemory",
-      "community": 801
+      "community": 803
     },
     {
       "label": "context-injector.ts",
@@ -9217,7 +9217,7 @@
       "source_file": "packages/memento-client/src/utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_utils_ts",
-      "community": 1085
+      "community": 1086
     },
     {
       "label": "index.ts",
@@ -9225,7 +9225,7 @@
       "source_file": "packages/memento-client/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_index_ts",
-      "community": 1086
+      "community": 1087
     },
     {
       "label": "agent-api.spec.ts",
@@ -9233,7 +9233,7 @@
       "source_file": "packages/memento-client/src/agent-api.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_agent_api_spec_ts",
-      "community": 1087
+      "community": 1088
     },
     {
       "label": "logger.ts",
@@ -9241,7 +9241,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_logger_ts",
-      "community": 648
+      "community": 649
     },
     {
       "label": "shouldLog()",
@@ -9249,7 +9249,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L15",
       "id": "logger_shouldlog",
-      "community": 648
+      "community": 649
     },
     {
       "label": "log()",
@@ -9257,7 +9257,7 @@
       "source_file": "packages/memento-client/src/logger.ts",
       "source_location": "L19",
       "id": "logger_log",
-      "community": 648
+      "community": 649
     },
     {
       "label": "feedback.integration.spec.ts",
@@ -9265,7 +9265,7 @@
       "source_file": "packages/memento-client/src/__tests__/feedback.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_tests_feedback_integration_spec_ts",
-      "community": 1088
+      "community": 1089
     },
     {
       "label": "http-transport.ts",
@@ -9329,7 +9329,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_client_ts",
-      "community": 649
+      "community": 650
     },
     {
       "label": "recall()",
@@ -9337,7 +9337,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L16",
       "id": "search_client_recall",
-      "community": 649
+      "community": 650
     },
     {
       "label": "hybridSearch()",
@@ -9345,7 +9345,7 @@
       "source_file": "packages/memento-client/src/client/search-client.ts",
       "source_location": "L49",
       "id": "search_client_hybridsearch",
-      "community": 649
+      "community": 650
     },
     {
       "label": "client-context.ts",
@@ -9353,7 +9353,7 @@
       "source_file": "packages/memento-client/src/client/client-context.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_client_context_ts",
-      "community": 1089
+      "community": 1090
     },
     {
       "label": "tools-client.ts",
@@ -9513,7 +9513,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_format_utils_ts",
-      "community": 507
+      "community": 508
     },
     {
       "label": "toSafeCSVCell()",
@@ -9521,7 +9521,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L6",
       "id": "format_utils_tosafecsvcell",
-      "community": 507
+      "community": 508
     },
     {
       "label": "memoriesToCSV()",
@@ -9529,7 +9529,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L17",
       "id": "format_utils_memoriestocsv",
-      "community": 507
+      "community": 508
     },
     {
       "label": "memoriesToMarkdown()",
@@ -9537,7 +9537,7 @@
       "source_file": "packages/memento-client/src/client/format-utils.ts",
       "source_location": "L52",
       "id": "format_utils_memoriestomarkdown",
-      "community": 507
+      "community": 508
     },
     {
       "label": "memory-utils.ts",
@@ -9601,7 +9601,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_search_utils_ts",
-      "community": 508
+      "community": 509
     },
     {
       "label": "normalizeQuery()",
@@ -9609,7 +9609,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L6",
       "id": "search_utils_normalizequery",
-      "community": 508
+      "community": 509
     },
     {
       "label": "normalizeScore()",
@@ -9617,7 +9617,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L17",
       "id": "search_utils_normalizescore",
-      "community": 508
+      "community": 509
     },
     {
       "label": "groupSearchResults()",
@@ -9625,7 +9625,7 @@
       "source_file": "packages/memento-client/src/client/search-utils.ts",
       "source_location": "L25",
       "id": "search_utils_groupsearchresults",
-      "community": 508
+      "community": 509
     },
     {
       "label": "memory-client.ts",
@@ -9689,7 +9689,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_time_utils_ts",
-      "community": 650
+      "community": 651
     },
     {
       "label": "getRelativeTime()",
@@ -9697,7 +9697,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L4",
       "id": "time_utils_getrelativetime",
-      "community": 650
+      "community": 651
     },
     {
       "label": "createDateRangeFilter()",
@@ -9705,7 +9705,7 @@
       "source_file": "packages/memento-client/src/client/time-utils.ts",
       "source_location": "L26",
       "id": "time_utils_createdaterangefilter",
-      "community": 650
+      "community": 651
     },
     {
       "label": "validation-utils.ts",
@@ -9761,7 +9761,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L1",
       "id": "packages_memento_client_src_client_factory_ts",
-      "community": 802
+      "community": 804
     },
     {
       "label": "createMementoClient()",
@@ -9769,7 +9769,7 @@
       "source_file": "packages/memento-client/src/client/factory.ts",
       "source_location": "L7",
       "id": "factory_createmementoclient",
-      "community": 802
+      "community": 804
     },
     {
       "label": "bootstrap.spec.ts",
@@ -9777,7 +9777,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_spec_ts",
-      "community": 509
+      "community": 510
     },
     {
       "label": "constructor()",
@@ -9785,7 +9785,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L246",
       "id": "bootstrap_spec_constructor",
-      "community": 509
+      "community": 510
     },
     {
       "label": "loadBootstrap()",
@@ -9793,7 +9793,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L269",
       "id": "bootstrap_spec_loadbootstrap",
-      "community": 509
+      "community": 510
     },
     {
       "label": "installTimeoutSpy()",
@@ -9801,7 +9801,7 @@
       "source_file": "packages/memento-core/src/bootstrap.spec.ts",
       "source_location": "L273",
       "id": "bootstrap_spec_installtimeoutspy",
-      "community": 509
+      "community": 510
     },
     {
       "label": "index.ts",
@@ -9809,7 +9809,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_index_ts",
-      "community": 651
+      "community": 652
     },
     {
       "label": "createMementoCore()",
@@ -9817,7 +9817,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L25",
       "id": "index_createmementocore",
-      "community": 651
+      "community": 652
     },
     {
       "label": "closeDatabase()",
@@ -9825,7 +9825,7 @@
       "source_file": "packages/memento-core/src/index.ts",
       "source_location": "L33",
       "id": "index_closedatabase",
-      "community": 651
+      "community": 652
     },
     {
       "label": "bootstrap.ts",
@@ -9833,7 +9833,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_ts",
-      "community": 803
+      "community": 805
     },
     {
       "label": "initializeServices()",
@@ -9841,7 +9841,7 @@
       "source_file": "packages/memento-core/src/bootstrap.ts",
       "source_location": "L72",
       "id": "bootstrap_initializeservices",
-      "community": 803
+      "community": 805
     },
     {
       "label": "context.ts",
@@ -9849,7 +9849,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_context_ts",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createServerContext()",
@@ -9857,7 +9857,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L17",
       "id": "context_createservercontext",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createToolContext()",
@@ -9865,7 +9865,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L26",
       "id": "context_createtoolcontext",
-      "community": 510
+      "community": 511
     },
     {
       "label": "createToolContextFromServerContext()",
@@ -9873,7 +9873,7 @@
       "source_file": "packages/memento-core/src/context.ts",
       "source_location": "L39",
       "id": "context_createtoolcontextfromservercontext",
-      "community": 510
+      "community": 511
     },
     {
       "label": "write-and-meta.ts",
@@ -9881,7 +9881,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_write_and_meta_ts",
-      "community": 804
+      "community": 806
     },
     {
       "label": "createWriteCoalescingMetaAndScore()",
@@ -9889,7 +9889,7 @@
       "source_file": "packages/memento-core/src/bootstrap/write-and-meta.ts",
       "source_location": "L10",
       "id": "write_and_meta_createwritecoalescingmetaandscore",
-      "community": 804
+      "community": 806
     },
     {
       "label": "batch-telemetry-relation.ts",
@@ -9897,7 +9897,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_batch_telemetry_relation_ts",
-      "community": 805
+      "community": 807
     },
     {
       "label": "createBatchTelemetryRelationAndSleep()",
@@ -9905,7 +9905,7 @@
       "source_file": "packages/memento-core/src/bootstrap/batch-telemetry-relation.ts",
       "source_location": "L14",
       "id": "batch_telemetry_relation_createbatchtelemetryrelationandsleep",
-      "community": 805
+      "community": 807
     },
     {
       "label": "anchor-stack.ts",
@@ -9913,7 +9913,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_anchor_stack_ts",
-      "community": 806
+      "community": 808
     },
     {
       "label": "createAnchorStack()",
@@ -9921,7 +9921,7 @@
       "source_file": "packages/memento-core/src/bootstrap/anchor-stack.ts",
       "source_location": "L10",
       "id": "anchor_stack_createanchorstack",
-      "community": 806
+      "community": 808
     },
     {
       "label": "failure-reflexion.ts",
@@ -9929,7 +9929,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_failure_reflexion_ts",
-      "community": 807
+      "community": 809
     },
     {
       "label": "startFailureAndReflexion()",
@@ -9937,7 +9937,7 @@
       "source_file": "packages/memento-core/src/bootstrap/failure-reflexion.ts",
       "source_location": "L5",
       "id": "failure_reflexion_startfailureandreflexion",
-      "community": 807
+      "community": 809
     },
     {
       "label": "search-and-embedding.ts",
@@ -9945,7 +9945,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_search_and_embedding_ts",
-      "community": 808
+      "community": 810
     },
     {
       "label": "createSearchEmbeddingAndOptimizerServices()",
@@ -9953,7 +9953,7 @@
       "source_file": "packages/memento-core/src/bootstrap/search-and-embedding.ts",
       "source_location": "L8",
       "id": "search_and_embedding_createsearchembeddingandoptimizerservices",
-      "community": 808
+      "community": 810
     },
     {
       "label": "monitoring-schedulers.ts",
@@ -9961,7 +9961,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_monitoring_schedulers_ts",
-      "community": 809
+      "community": 811
     },
     {
       "label": "createMonitoringAndSchedulers()",
@@ -9969,7 +9969,7 @@
       "source_file": "packages/memento-core/src/bootstrap/monitoring-schedulers.ts",
       "source_location": "L9",
       "id": "monitoring_schedulers_createmonitoringandschedulers",
-      "community": 809
+      "community": 811
     },
     {
       "label": "runtime-diagnostics-sampler.ts",
@@ -9977,7 +9977,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_bootstrap_runtime_diagnostics_sampler_ts",
-      "community": 810
+      "community": 812
     },
     {
       "label": "createRuntimeDiagnosticsSampler()",
@@ -9985,7 +9985,7 @@
       "source_file": "packages/memento-core/src/bootstrap/runtime-diagnostics-sampler.ts",
       "source_location": "L6",
       "id": "runtime_diagnostics_sampler_createruntimediagnosticssampler",
-      "community": 810
+      "community": 812
     },
     {
       "label": "consolidation-score-worker.ts",
@@ -10297,7 +10297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_ts",
-      "community": 1090
+      "community": 1091
     },
     {
       "label": "consolidation-score-service.spec.ts",
@@ -10305,7 +10305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_consolidation_score_service_spec_ts",
-      "community": 811
+      "community": 813
     },
     {
       "label": "createInput()",
@@ -10313,7 +10313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/consolidation-score-service.spec.ts",
       "source_location": "L236",
       "id": "consolidation_score_service_spec_createinput",
-      "community": 811
+      "community": 813
     },
     {
       "label": "reflexion-procedural-memory-service.ts",
@@ -10529,7 +10529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_relation_graph_factory_ts",
-      "community": 812
+      "community": 814
     },
     {
       "label": "createRelationGraph()",
@@ -10537,7 +10537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/relation-graph-factory.ts",
       "source_location": "L15",
       "id": "relation_graph_factory_createrelationgraph",
-      "community": 812
+      "community": 814
     },
     {
       "label": "consolidation-score-service.ts",
@@ -10937,7 +10937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_parsers_ts",
-      "community": 511
+      "community": 512
     },
     {
       "label": "failedTaskDataToTaskFields()",
@@ -10945,7 +10945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L4",
       "id": "async_optimizer_parsers_failedtaskdatatotaskfields",
-      "community": 511
+      "community": 512
     },
     {
       "label": "parseMemoryOperationTaskData()",
@@ -10953,7 +10953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L50",
       "id": "async_optimizer_parsers_parsememoryoperationtaskdata",
-      "community": 511
+      "community": 512
     },
     {
       "label": "parseFailureEventTaskData()",
@@ -10961,7 +10961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer-parsers.ts",
       "source_location": "L69",
       "id": "async_optimizer_parsers_parsefailureeventtaskdata",
-      "community": 511
+      "community": 512
     },
     {
       "label": "async-optimizer.types.ts",
@@ -10969,7 +10969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/async-optimizer/async-optimizer.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_async_optimizer_async_optimizer_types_ts",
-      "community": 1091
+      "community": 1092
     },
     {
       "label": "async-task-worker.ts",
@@ -11073,7 +11073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/logging/triple-extraction-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_logging_triple_extraction_logger_spec_ts",
-      "community": 1092
+      "community": 1093
     },
     {
       "label": "triple-extraction-logger.ts",
@@ -11193,7 +11193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_health_ts",
-      "community": 512
+      "community": 513
     },
     {
       "label": "startHealthCheck()",
@@ -11201,7 +11201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L20",
       "id": "reflexion_worker_health_starthealthcheck",
-      "community": 512
+      "community": 513
     },
     {
       "label": "performHealthCheck()",
@@ -11209,7 +11209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L30",
       "id": "reflexion_worker_health_performhealthcheck",
-      "community": 512
+      "community": 513
     },
     {
       "label": "attemptRestart()",
@@ -11217,7 +11217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-health.ts",
       "source_location": "L61",
       "id": "reflexion_worker_health_attemptrestart",
-      "community": 512
+      "community": 513
     },
     {
       "label": "reflexion-worker-failure-handler.ts",
@@ -11225,7 +11225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_failure_handler_ts",
-      "community": 652
+      "community": 653
     },
     {
       "label": "registerHandler()",
@@ -11233,7 +11233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L14",
       "id": "reflexion_worker_failure_handler_registerhandler",
-      "community": 652
+      "community": 653
     },
     {
       "label": "updateProceduralMemory()",
@@ -11241,7 +11241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-failure-handler.ts",
       "source_location": "L22",
       "id": "reflexion_worker_failure_handler_updateproceduralmemory",
-      "community": 652
+      "community": 653
     },
     {
       "label": "reflexion-worker-metrics.ts",
@@ -11249,7 +11249,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_worker_reflexion_worker_metrics_ts",
-      "community": 653
+      "community": 654
     },
     {
       "label": "getReflexionMetrics()",
@@ -11257,7 +11257,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L14",
       "id": "reflexion_worker_metrics_getreflexionmetrics",
-      "community": 653
+      "community": 654
     },
     {
       "label": "getIntegratedMetrics()",
@@ -11265,7 +11265,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-worker/reflexion-worker-metrics.ts",
       "source_location": "L42",
       "id": "reflexion_worker_metrics_getintegratedmetrics",
-      "community": 653
+      "community": 654
     },
     {
       "label": "reflexion-procedural-create.ts",
@@ -11273,7 +11273,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_create_ts",
-      "community": 813
+      "community": 815
     },
     {
       "label": "createProceduralMemory()",
@@ -11281,7 +11281,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-create.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_create_createproceduralmemory",
-      "community": 813
+      "community": 815
     },
     {
       "label": "reflexion-procedural-update-replace.ts",
@@ -11289,7 +11289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_replace_ts",
-      "community": 814
+      "community": 816
     },
     {
       "label": "updateProceduralMemoryReplace()",
@@ -11297,7 +11297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-replace.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_replace_updateproceduralmemoryreplace",
-      "community": 814
+      "community": 816
     },
     {
       "label": "reflexion-procedural-extraction.ts",
@@ -11305,7 +11305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_extraction_ts",
-      "community": 815
+      "community": 817
     },
     {
       "label": "resolveExtractedProceduralMemory()",
@@ -11313,7 +11313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-extraction.ts",
       "source_location": "L10",
       "id": "reflexion_procedural_extraction_resolveextractedproceduralmemory",
-      "community": 815
+      "community": 817
     },
     {
       "label": "reflexion-procedural-update-versioned.ts",
@@ -11321,7 +11321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_versioned_ts",
-      "community": 816
+      "community": 818
     },
     {
       "label": "updateProceduralMemoryVersioned()",
@@ -11329,7 +11329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-versioned.ts",
       "source_location": "L11",
       "id": "reflexion_procedural_update_versioned_updateproceduralmemoryversioned",
-      "community": 816
+      "community": 818
     },
     {
       "label": "reflexion-procedural-update-incremental.ts",
@@ -11337,7 +11337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_reflexion_procedural_memory_service_reflexion_procedural_update_incremental_ts",
-      "community": 654
+      "community": 655
     },
     {
       "label": "mergeProceduralSteps()",
@@ -11345,7 +11345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L7",
       "id": "reflexion_procedural_update_incremental_mergeproceduralsteps",
-      "community": 654
+      "community": 655
     },
     {
       "label": "updateProceduralMemoryIncremental()",
@@ -11353,7 +11353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/reflexion-procedural-memory-service/reflexion-procedural-update-incremental.ts",
       "source_location": "L33",
       "id": "reflexion_procedural_update_incremental_updateproceduralmemoryincremental",
-      "community": 654
+      "community": 655
     },
     {
       "label": "database-optimize-tool.ts",
@@ -11361,7 +11361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_optimize_tool_ts",
-      "community": 513
+      "community": 514
     },
     {
       "label": "DatabaseOptimizeTool",
@@ -11369,7 +11369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L15",
       "id": "database_optimize_tool_databaseoptimizetool",
-      "community": 513
+      "community": 514
     },
     {
       "label": ".constructor()",
@@ -11377,7 +11377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L16",
       "id": "database_optimize_tool_databaseoptimizetool_constructor",
-      "community": 513
+      "community": 514
     },
     {
       "label": ".handle()",
@@ -11385,7 +11385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-optimize-tool.ts",
       "source_location": "L38",
       "id": "database_optimize_tool_databaseoptimizetool_handle",
-      "community": 513
+      "community": 514
     },
     {
       "label": "migration-history-service.ts",
@@ -11705,7 +11705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_performance_integration_spec_ts",
-      "community": 655
+      "community": 656
     },
     {
       "label": "createBaseSchema()",
@@ -11713,7 +11713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L26",
       "id": "database_performance_integration_spec_createbaseschema",
-      "community": 655
+      "community": 656
     },
     {
       "label": "measureTime()",
@@ -11721,7 +11721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-performance.integration.spec.ts",
       "source_location": "L50",
       "id": "database_performance_integration_spec_measuretime",
-      "community": 655
+      "community": 656
     },
     {
       "label": "database-lock-scenarios.integration.spec.ts",
@@ -11729,7 +11729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_scenarios_integration_spec_ts",
-      "community": 817
+      "community": 819
     },
     {
       "label": "createBaseSchema()",
@@ -11737,7 +11737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-scenarios.integration.spec.ts",
       "source_location": "L23",
       "id": "database_lock_scenarios_integration_spec_createbaseschema",
-      "community": 817
+      "community": 819
     },
     {
       "label": "wal-checkpoint-scheduler.ts",
@@ -11841,7 +11841,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_wal_checkpoint_scheduler_spec_ts",
-      "community": 818
+      "community": 820
     },
     {
       "label": "uniqueWalTestDbPath()",
@@ -11849,7 +11849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/wal-checkpoint-scheduler.spec.ts",
       "source_location": "L14",
       "id": "wal_checkpoint_scheduler_spec_uniquewaltestdbpath",
-      "community": 818
+      "community": 820
     },
     {
       "label": "migration-monitor-service.ts",
@@ -11953,7 +11953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_lock_monitor_spec_ts",
-      "community": 819
+      "community": 821
     },
     {
       "label": "openLockTestDatabase()",
@@ -11961,7 +11961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database-lock-monitor.spec.ts",
       "source_location": "L97",
       "id": "database_lock_monitor_spec_openlocktestdatabase",
-      "community": 819
+      "community": 821
     },
     {
       "label": "migration-history-service.spec.ts",
@@ -11969,7 +11969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_history_service_spec_ts",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createMigrationHistoryTable()",
@@ -11977,7 +11977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L6",
       "id": "migration_history_service_spec_createmigrationhistorytable",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createPlan()",
@@ -11985,7 +11985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L50",
       "id": "migration_history_service_spec_createplan",
-      "community": 514
+      "community": 515
     },
     {
       "label": "createResult()",
@@ -11993,7 +11993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-history-service.spec.ts",
       "source_location": "L65",
       "id": "migration_history_service_spec_createresult",
-      "community": 514
+      "community": 515
     },
     {
       "label": "migration-monitor-service.spec.ts",
@@ -12001,7 +12001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_migration_monitor_service_spec_ts",
-      "community": 820
+      "community": 822
     },
     {
       "label": "createProgress()",
@@ -12009,7 +12009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/migration-monitor-service.spec.ts",
       "source_location": "L16",
       "id": "migration_monitor_service_spec_createprogress",
-      "community": 820
+      "community": 822
     },
     {
       "label": "database-optimize-tool.spec.ts",
@@ -12017,7 +12017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimize-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimize_tool_spec_ts",
-      "community": 1093
+      "community": 1094
     },
     {
       "label": "database-optimizer.spec.ts",
@@ -12025,7 +12025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/__tests__/database-optimizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_tests_database_optimizer_spec_ts",
-      "community": 1094
+      "community": 1095
     },
     {
       "label": "core-memory-repository.factory.ts",
@@ -12033,7 +12033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_core_memory_repository_factory_ts",
-      "community": 821
+      "community": 823
     },
     {
       "label": "createCoreMemoryRepository()",
@@ -12041,7 +12041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/core-memory-repository.factory.ts",
       "source_location": "L34",
       "id": "core_memory_repository_factory_createcorememoryrepository",
-      "community": 821
+      "community": 823
     },
     {
       "label": "core-memory-repository.factory.spec.ts",
@@ -12049,7 +12049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/factories/__tests__/core-memory-repository.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_factories_tests_core_memory_repository_factory_spec_ts",
-      "community": 1095
+      "community": 1096
     },
     {
       "label": "core-memory-auto-load.integration.spec.ts",
@@ -12057,7 +12057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_core_memory_auto_load_integration_spec_ts",
-      "community": 822
+      "community": 824
     },
     {
       "label": "createCoreMemoryTable()",
@@ -12065,7 +12065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/core-memory-auto-load.integration.spec.ts",
       "source_location": "L21",
       "id": "core_memory_auto_load_integration_spec_createcorememorytable",
-      "community": 822
+      "community": 824
     },
     {
       "label": "vec-cosine-metric.integration.spec.ts",
@@ -12073,7 +12073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/vec-cosine-metric.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_vec_cosine_metric_integration_spec_ts",
-      "community": 823
+      "community": 825
     },
     {
       "label": "vector()",
@@ -12081,7 +12081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/vec-cosine-metric.integration.spec.ts",
       "source_location": "L65",
       "id": "vec_cosine_metric_integration_spec_vector",
-      "community": 823
+      "community": 825
     },
     {
       "label": "vec-schema.ts",
@@ -12201,7 +12201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_bootstrap_new_db_ts",
-      "community": 824
+      "community": 826
     },
     {
       "label": "bootstrapNewDatabaseSchema()",
@@ -12209,7 +12209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-bootstrap-new-db.ts",
       "source_location": "L14",
       "id": "init_bootstrap_new_db_bootstrapnewdatabaseschema",
-      "community": 824
+      "community": 826
     },
     {
       "label": "ensure-memory-item-triple-extraction-columns.ts",
@@ -12217,7 +12217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_ensure_memory_item_triple_extraction_columns_ts",
-      "community": 656
+      "community": 657
     },
     {
       "label": "addMissingColumn()",
@@ -12225,7 +12225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L8",
       "id": "ensure_memory_item_triple_extraction_columns_addmissingcolumn",
-      "community": 656
+      "community": 657
     },
     {
       "label": "ensureMemoryItemTripleExtractionColumns()",
@@ -12233,7 +12233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/ensure-memory-item-triple-extraction-columns.ts",
       "source_location": "L26",
       "id": "ensure_memory_item_triple_extraction_columns_ensurememoryitemtripleextractioncolumns",
-      "community": 656
+      "community": 657
     },
     {
       "label": "cache-version-sync.integration.spec.ts",
@@ -12241,7 +12241,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/cache-version-sync.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_cache_version_sync_integration_spec_ts",
-      "community": 1096
+      "community": 1097
     },
     {
       "label": "db-integrity-preflight.ts",
@@ -12345,7 +12345,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_log_ts",
-      "community": 825
+      "community": 827
     },
     {
       "label": "log()",
@@ -12353,7 +12353,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-log.ts",
       "source_location": "L5",
       "id": "init_log_log",
-      "community": 825
+      "community": 827
     },
     {
       "label": "init.spec.ts",
@@ -12361,7 +12361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_spec_ts",
-      "community": 1097
+      "community": 1098
     },
     {
       "label": "init.ts",
@@ -12369,7 +12369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_ts",
-      "community": 657
+      "community": 658
     },
     {
       "label": "initializeDatabase()",
@@ -12377,7 +12377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L29",
       "id": "init_initializedatabase",
-      "community": 657
+      "community": 658
     },
     {
       "label": "closeDatabase()",
@@ -12385,7 +12385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init.ts",
       "source_location": "L116",
       "id": "init_closedatabase",
-      "community": 657
+      "community": 658
     },
     {
       "label": "vec-schema.spec.ts",
@@ -12393,7 +12393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/vec-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_vec_schema_spec_ts",
-      "community": 1098
+      "community": 1099
     },
     {
       "label": "db-integrity-preflight.spec.ts",
@@ -12401,7 +12401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_db_integrity_preflight_spec_ts",
-      "community": 826
+      "community": 828
     },
     {
       "label": "createDbPath()",
@@ -12409,7 +12409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/db-integrity-preflight.spec.ts",
       "source_location": "L8",
       "id": "db_integrity_preflight_spec_createdbpath",
-      "community": 826
+      "community": 828
     },
     {
       "label": "init-migrate-existing.ts",
@@ -12417,7 +12417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migrate_existing_ts",
-      "community": 827
+      "community": 829
     },
     {
       "label": "migrateExistingDatabaseIfNeeded()",
@@ -12425,7 +12425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migrate-existing.ts",
       "source_location": "L6",
       "id": "init_migrate_existing_migrateexistingdatabaseifneeded",
-      "community": 827
+      "community": 829
     },
     {
       "label": "migrate.spec.ts",
@@ -12433,7 +12433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_spec_ts",
-      "community": 1099
+      "community": 1100
     },
     {
       "label": "init-migration-baseline.ts",
@@ -12441,7 +12441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_migration_baseline_ts",
-      "community": 828
+      "community": 830
     },
     {
       "label": "recordBundledSchemaSqlMigrationBaseline()",
@@ -12449,7 +12449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-migration-baseline.ts",
       "source_location": "L11",
       "id": "init_migration_baseline_recordbundledschemasqlmigrationbaseline",
-      "community": 828
+      "community": 830
     },
     {
       "label": "init-sqlite-session.ts",
@@ -12457,7 +12457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_init_sqlite_session_ts",
-      "community": 829
+      "community": 831
     },
     {
       "label": "configureSqliteSession()",
@@ -12465,7 +12465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/init-sqlite-session.ts",
       "source_location": "L8",
       "id": "init_sqlite_session_configuresqlitesession",
-      "community": 829
+      "community": 831
     },
     {
       "label": "init-legacy-schema.ts",
@@ -12529,7 +12529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migrate_ts",
-      "community": 515
+      "community": 516
     },
     {
       "label": "isDuplicateColumnError()",
@@ -12537,7 +12537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L19",
       "id": "migrate_isduplicatecolumnerror",
-      "community": 515
+      "community": 516
     },
     {
       "label": "loadVecExtension()",
@@ -12545,7 +12545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L27",
       "id": "migrate_loadvecextension",
-      "community": 515
+      "community": 516
     },
     {
       "label": "migrateDatabase()",
@@ -12553,7 +12553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migrate.ts",
       "source_location": "L41",
       "id": "migrate_migratedatabase",
-      "community": 515
+      "community": 516
     },
     {
       "label": "schema-version-manager.spec.ts",
@@ -12561,7 +12561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/schema-version-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_schema_version_manager_spec_ts",
-      "community": 1100
+      "community": 1101
     },
     {
       "label": "migration-runner.ts",
@@ -12641,7 +12641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_runner_integration_spec_ts",
-      "community": 830
+      "community": 832
     },
     {
       "label": "createBaseSchema()",
@@ -12649,7 +12649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-runner.integration.spec.ts",
       "source_location": "L22",
       "id": "migration_runner_integration_spec_createbaseschema",
-      "community": 830
+      "community": 832
     },
     {
       "label": "migration-logger.spec.ts",
@@ -12657,7 +12657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_logger_spec_ts",
-      "community": 1101
+      "community": 1102
     },
     {
       "label": "migration-detector.ts",
@@ -12849,7 +12849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_types_ts",
-      "community": 1102
+      "community": 1103
     },
     {
       "label": "migration-detector.spec.ts",
@@ -12857,7 +12857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migration-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migration_detector_spec_ts",
-      "community": 1103
+      "community": 1104
     },
     {
       "label": "backup-manager.ts",
@@ -12945,7 +12945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/backup-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_backup_manager_spec_ts",
-      "community": 1104
+      "community": 1105
     },
     {
       "label": "dependency-validator.ts",
@@ -13049,7 +13049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/dependency-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_dependency_validator_spec_ts",
-      "community": 1105
+      "community": 1106
     },
     {
       "label": "schema-version-manager.ts",
@@ -13137,7 +13137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/036-agent-memory-promotion-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_036_agent_memory_promotion_schema_spec_ts",
-      "community": 1106
+      "community": 1107
     },
     {
       "label": "032-add-project-id.spec.ts",
@@ -13145,7 +13145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_032_add_project_id_spec_ts",
-      "community": 516
+      "community": 517
     },
     {
       "label": "createMemoryItemTable()",
@@ -13153,7 +13153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L8",
       "id": "032_add_project_id_spec_creatememoryitemtable",
-      "community": 516
+      "community": 517
     },
     {
       "label": "columnExists()",
@@ -13161,7 +13161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L20",
       "id": "032_add_project_id_spec_columnexists",
-      "community": 516
+      "community": 517
     },
     {
       "label": "indexExists()",
@@ -13169,7 +13169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/032-add-project-id.spec.ts",
       "source_location": "L25",
       "id": "032_add_project_id_spec_indexexists",
-      "community": 516
+      "community": 517
     },
     {
       "label": "008-arigraph-schema-expansion.ts",
@@ -14041,7 +14041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_008_arigraph_schema_expansion_spec_ts",
-      "community": 831
+      "community": 833
     },
     {
       "label": "createBaseSchema()",
@@ -14049,7 +14049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/008-arigraph-schema-expansion.spec.ts",
       "source_location": "L9",
       "id": "008_arigraph_schema_expansion_spec_createbaseschema",
-      "community": 831
+      "community": 833
     },
     {
       "label": "003-consolidation-score-fields.ts",
@@ -14289,7 +14289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_011_meta_memory_stats_schema_spec_ts",
-      "community": 832
+      "community": 834
     },
     {
       "label": "createBaseSchema()",
@@ -14297,7 +14297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/011-meta-memory-stats-schema.spec.ts",
       "source_location": "L9",
       "id": "011_meta_memory_stats_schema_spec_createbaseschema",
-      "community": 832
+      "community": 834
     },
     {
       "label": "002-mirix-schema-expansion.ts",
@@ -14593,7 +14593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_009_quality_assurance_schema_spec_ts",
-      "community": 833
+      "community": 835
     },
     {
       "label": "createBaseSchema()",
@@ -14601,7 +14601,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/009-quality-assurance-schema.spec.ts",
       "source_location": "L9",
       "id": "009_quality_assurance_schema_spec_createbaseschema",
-      "community": 833
+      "community": 835
     },
     {
       "label": "031-soft-delete-fields.spec.ts",
@@ -14761,7 +14761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/037-memory-forgetting-event.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_037_memory_forgetting_event_spec_ts",
-      "community": 1107
+      "community": 1108
     },
     {
       "label": "010-add-core-memory-version.ts",
@@ -14929,7 +14929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/039-event-outbox.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_039_event_outbox_spec_ts",
-      "community": 1108
+      "community": 1109
     },
     {
       "label": "021-feedback-event-attribution.ts",
@@ -15009,7 +15009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/040-audit-hash-chain.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_040_audit_hash_chain_spec_ts",
-      "community": 1109
+      "community": 1110
     },
     {
       "label": "009-quality-assurance-schema.ts",
@@ -15105,7 +15105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_033_memory_review_candidate_schema_spec_ts",
-      "community": 658
+      "community": 659
     },
     {
       "label": "createMemoryItemTable()",
@@ -15113,7 +15113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L8",
       "id": "033_memory_review_candidate_schema_spec_creatememoryitemtable",
-      "community": 658
+      "community": 659
     },
     {
       "label": "tableExists()",
@@ -15121,7 +15121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/033-memory-review-candidate-schema.spec.ts",
       "source_location": "L21",
       "id": "033_memory_review_candidate_schema_spec_tableexists",
-      "community": 658
+      "community": 659
     },
     {
       "label": "028-telemetry-daily-metrics.ts",
@@ -15361,7 +15361,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_034_review_queue_health_snapshot_spec_ts",
-      "community": 659
+      "community": 660
     },
     {
       "label": "createMemoryItemTable()",
@@ -15369,7 +15369,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L9",
       "id": "034_review_queue_health_snapshot_spec_creatememoryitemtable",
-      "community": 659
+      "community": 660
     },
     {
       "label": "tableExists()",
@@ -15377,7 +15377,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/034-review-queue-health-snapshot.spec.ts",
       "source_location": "L22",
       "id": "034_review_queue_health_snapshot_spec_tableexists",
-      "community": 659
+      "community": 660
     },
     {
       "label": "014-procedural-version-indexes.ts",
@@ -15457,7 +15457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_002_mirix_schema_expansion_spec_ts",
-      "community": 834
+      "community": 836
     },
     {
       "label": "createBaseSchema()",
@@ -15465,7 +15465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/002-mirix-schema-expansion.spec.ts",
       "source_location": "L8",
       "id": "002_mirix_schema_expansion_spec_createbaseschema",
-      "community": 834
+      "community": 836
     },
     {
       "label": "005-relation-engine-schema.ts",
@@ -15569,7 +15569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_019_backfill_kg_triple_from_memory_item_spec_ts",
-      "community": 835
+      "community": 837
     },
     {
       "label": "createSchemaWith018()",
@@ -15577,7 +15577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/019-backfill-kg-triple-from-memory-item.spec.ts",
       "source_location": "L18",
       "id": "019_backfill_kg_triple_from_memory_item_spec_createschemawith018",
-      "community": 835
+      "community": 837
     },
     {
       "label": "004-anchor-table.spec.ts",
@@ -15585,7 +15585,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_004_anchor_table_spec_ts",
-      "community": 836
+      "community": 838
     },
     {
       "label": "createBaseSchema()",
@@ -15593,7 +15593,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/004-anchor-table.spec.ts",
       "source_location": "L9",
       "id": "004_anchor_table_spec_createbaseschema",
-      "community": 836
+      "community": 838
     },
     {
       "label": "037-memory-forgetting-event.ts",
@@ -15657,7 +15657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_013_procedural_version_fields_spec_ts",
-      "community": 517
+      "community": 518
     },
     {
       "label": "createMemoryItemTableWithoutVersion()",
@@ -15665,7 +15665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L12",
       "id": "013_procedural_version_fields_spec_creatememoryitemtablewithoutversion",
-      "community": 517
+      "community": 518
     },
     {
       "label": "createMemoryLinkTable()",
@@ -15673,7 +15673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L42",
       "id": "013_procedural_version_fields_spec_creatememorylinktable",
-      "community": 517
+      "community": 518
     },
     {
       "label": "createSchemaVersionTable()",
@@ -15681,7 +15681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/013-procedural-version-fields.spec.ts",
       "source_location": "L57",
       "id": "013_procedural_version_fields_spec_createschemaversiontable",
-      "community": 517
+      "community": 518
     },
     {
       "label": "016-memory-item-attribution.ts",
@@ -15865,7 +15865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_038_relation_type_registry_seeds_spec_ts",
-      "community": 837
+      "community": 839
     },
     {
       "label": "applicableTypesFor()",
@@ -15873,7 +15873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/038-relation-type-registry-seeds.spec.ts",
       "source_location": "L12",
       "id": "038_relation_type_registry_seeds_spec_applicabletypesfor",
-      "community": 837
+      "community": 839
     },
     {
       "label": "013-procedural-version-fields.ts",
@@ -16097,7 +16097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.contract.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_contract_spec_ts",
-      "community": 1110
+      "community": 1111
     },
     {
       "label": "017-fact-metadata-fields.spec.ts",
@@ -16329,7 +16329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/035-agent-integration-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_035_agent_integration_schema_spec_ts",
-      "community": 1111
+      "community": 1112
     },
     {
       "label": "034-review-queue-health-snapshot.ts",
@@ -16401,7 +16401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_010_add_core_memory_version_spec_ts",
-      "community": 838
+      "community": 840
     },
     {
       "label": "createBaseSchema()",
@@ -16409,7 +16409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/010-add-core-memory-version.spec.ts",
       "source_location": "L14",
       "id": "010_add_core_memory_version_spec_createbaseschema",
-      "community": 838
+      "community": 840
     },
     {
       "label": "031-soft-delete-fields.ts",
@@ -16537,7 +16537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_007_procedural_memory_enhancement_spec_ts",
-      "community": 839
+      "community": 841
     },
     {
       "label": "createBaseSchema()",
@@ -16545,7 +16545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/007-procedural-memory-enhancement.spec.ts",
       "source_location": "L9",
       "id": "007_procedural_memory_enhancement_spec_createbaseschema",
-      "community": 839
+      "community": 841
     },
     {
       "label": "005-relation-engine-schema.spec.ts",
@@ -16553,7 +16553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_005_relation_engine_schema_spec_ts",
-      "community": 518
+      "community": 519
     },
     {
       "label": "applicableTypesFor()",
@@ -16561,7 +16561,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L12",
       "id": "005_relation_engine_schema_spec_applicabletypesfor",
-      "community": 518
+      "community": 519
     },
     {
       "label": "createBaseSchema()",
@@ -16569,7 +16569,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L21",
       "id": "005_relation_engine_schema_spec_createbaseschema",
-      "community": 518
+      "community": 519
     },
     {
       "label": "createMemoryLinkTable()",
@@ -16577,7 +16577,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/005-relation-engine-schema.spec.ts",
       "source_location": "L122",
       "id": "005_relation_engine_schema_spec_creatememorylinktable",
-      "community": 518
+      "community": 519
     },
     {
       "label": "015-memory-item-owner-id.ts",
@@ -16657,7 +16657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_003_consolidation_score_fields_spec_ts",
-      "community": 840
+      "community": 842
     },
     {
       "label": "createBaseSchema()",
@@ -16665,7 +16665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/003-consolidation-score-fields.spec.ts",
       "source_location": "L9",
       "id": "003_consolidation_score_fields_spec_createbaseschema",
-      "community": 840
+      "community": 842
     },
     {
       "label": "014-procedural-version-indexes.spec.ts",
@@ -16673,7 +16673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_014_procedural_version_indexes_spec_ts",
-      "community": 519
+      "community": 520
     },
     {
       "label": "createMemoryItemWithVersionColumns()",
@@ -16681,7 +16681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L19",
       "id": "014_procedural_version_indexes_spec_creatememoryitemwithversioncolumns",
-      "community": 519
+      "community": 520
     },
     {
       "label": "createSchemaVersionTable()",
@@ -16689,7 +16689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L37",
       "id": "014_procedural_version_indexes_spec_createschemaversiontable",
-      "community": 519
+      "community": 520
     },
     {
       "label": "getIndexNames()",
@@ -16697,7 +16697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/014-procedural-version-indexes.spec.ts",
       "source_location": "L50",
       "id": "014_procedural_version_indexes_spec_getindexnames",
-      "community": 519
+      "community": 520
     },
     {
       "label": "020-process-attribute-table.spec.ts",
@@ -16705,7 +16705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_database_migration_migrations_020_process_attribute_table_spec_ts",
-      "community": 520
+      "community": 521
     },
     {
       "label": "createSchemaWith019()",
@@ -16713,7 +16713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L18",
       "id": "020_process_attribute_table_spec_createschemawith019",
-      "community": 520
+      "community": 521
     },
     {
       "label": "tableExists()",
@@ -16721,7 +16721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L40",
       "id": "020_process_attribute_table_spec_tableexists",
-      "community": 520
+      "community": 521
     },
     {
       "label": "columnExists()",
@@ -16729,7 +16729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/database/migration/migrations/020-process-attribute-table.spec.ts",
       "source_location": "L47",
       "id": "020_process_attribute_table_spec_columnexists",
-      "community": 520
+      "community": 521
     },
     {
       "label": "migration-runner-api-example.spec.ts",
@@ -16881,7 +16881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/adapters/__tests__/sqlite-core-memory-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_adapters_tests_sqlite_core_memory_adapter_spec_ts",
-      "community": 1112
+      "community": 1113
     },
     {
       "label": "sqlite-agent-integration-repository.spec.ts",
@@ -16889,7 +16889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_sqlite_agent_integration_repository_spec_ts",
-      "community": 660
+      "community": 661
     },
     {
       "label": "createSession()",
@@ -16897,7 +16897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L27",
       "id": "sqlite_agent_integration_repository_spec_createsession",
-      "community": 660
+      "community": 661
     },
     {
       "label": "createObservation()",
@@ -16905,7 +16905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/sqlite-agent-integration-repository.spec.ts",
       "source_location": "L59",
       "id": "sqlite_agent_integration_repository_spec_createobservation",
-      "community": 660
+      "community": 661
     },
     {
       "label": "feedback-repository-sqlite.impl.ts",
@@ -17969,7 +17969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/database/repositories/__tests__/core-memory-repository-sqlite.impl.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_database_repositories_tests_core_memory_repository_sqlite_impl_spec_ts",
-      "community": 1113
+      "community": 1114
     },
     {
       "label": "cache-service.ts",
@@ -18297,7 +18297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/cache/__tests__/cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_cache_tests_cache_service_spec_ts",
-      "community": 1114
+      "community": 1115
     },
     {
       "label": "batch-scheduler.ts",
@@ -18689,7 +18689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_internal_helpers_ts",
-      "community": 521
+      "community": 522
     },
     {
       "label": "createEmptyBatchJobResult()",
@@ -18697,7 +18697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L10",
       "id": "batch_scheduler_internal_helpers_createemptybatchjobresult",
-      "community": 521
+      "community": 522
     },
     {
       "label": "finalizeBatchJobTiming()",
@@ -18705,7 +18705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L24",
       "id": "batch_scheduler_internal_helpers_finalizebatchjobtiming",
-      "community": 521
+      "community": 522
     },
     {
       "label": "assertSchedulerDbOpen()",
@@ -18713,7 +18713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-internal-helpers.ts",
       "source_location": "L29",
       "id": "batch_scheduler_internal_helpers_assertschedulerdbopen",
-      "community": 521
+      "community": 522
     },
     {
       "label": "health-checker.ts",
@@ -18769,7 +18769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_default_config_ts",
-      "community": 841
+      "community": 843
     },
     {
       "label": "mergeBatchSchedulerJobConfig()",
@@ -18777,7 +18777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-default-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_default_config_mergebatchschedulerjobconfig",
-      "community": 841
+      "community": 843
     },
     {
       "label": "batch-scheduler-database-stats.ts",
@@ -18785,7 +18785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_database_stats_ts",
-      "community": 842
+      "community": 844
     },
     {
       "label": "collectBatchSchedulerDatabaseStats()",
@@ -18793,7 +18793,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-database-stats.ts",
       "source_location": "L21",
       "id": "batch_scheduler_database_stats_collectbatchschedulerdatabasestats",
-      "community": 842
+      "community": 844
     },
     {
       "label": "memory-review-candidates-run-diagnostics.ts",
@@ -18801,7 +18801,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_memory_review_candidates_run_diagnostics_ts",
-      "community": 661
+      "community": 662
     },
     {
       "label": "readRunDetails()",
@@ -18809,7 +18809,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L15",
       "id": "memory_review_candidates_run_diagnostics_readrundetails",
-      "community": 661
+      "community": 662
     },
     {
       "label": "buildMemoryReviewCandidatesRunDiagnosticsPayload()",
@@ -18817,7 +18817,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/memory-review-candidates-run-diagnostics.ts",
       "source_location": "L46",
       "id": "memory_review_candidates_run_diagnostics_buildmemoryreviewcandidatesrundiagnosticspayload",
-      "community": 661
+      "community": 662
     },
     {
       "label": "relation-validator-executor.ts",
@@ -18873,7 +18873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_types_ts",
-      "community": 1115
+      "community": 1116
     },
     {
       "label": "batch-scheduler-validate-config.ts",
@@ -18881,7 +18881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_validate_config_ts",
-      "community": 843
+      "community": 845
     },
     {
       "label": "validateBatchJobConfig()",
@@ -18889,7 +18889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler-validate-config.ts",
       "source_location": "L6",
       "id": "batch_scheduler_validate_config_validatebatchjobconfig",
-      "community": 843
+      "community": 845
     },
     {
       "label": "retry-manager.ts",
@@ -19105,7 +19105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_job_timeout_resolver_ts",
-      "community": 522
+      "community": 523
     },
     {
       "label": "isTripleExtractionQueueJob()",
@@ -19113,7 +19113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L5",
       "id": "batch_job_timeout_resolver_istripleextractionqueuejob",
-      "community": 522
+      "community": 523
     },
     {
       "label": "isJobTimeoutError()",
@@ -19121,7 +19121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L9",
       "id": "batch_job_timeout_resolver_isjobtimeouterror",
-      "community": 522
+      "community": 523
     },
     {
       "label": "resolveBatchJobTimeout()",
@@ -19129,7 +19129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-job-timeout-resolver.ts",
       "source_location": "L18",
       "id": "batch_job_timeout_resolver_resolvebatchjobtimeout",
-      "community": 522
+      "community": 523
     },
     {
       "label": "job-queue.ts",
@@ -19385,7 +19385,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_spec_ts",
-      "community": 662
+      "community": 663
     },
     {
       "label": "createBaseSchema()",
@@ -19393,7 +19393,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L12",
       "id": "batch_scheduler_review_meta_handlers_spec_createbaseschema",
-      "community": 662
+      "community": 663
     },
     {
       "label": "createContext()",
@@ -19401,7 +19401,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.spec.ts",
       "source_location": "L41",
       "id": "batch_scheduler_review_meta_handlers_spec_createcontext",
-      "community": 662
+      "community": 663
     },
     {
       "label": "batch-scheduler-anchor-handlers.ts",
@@ -19409,15 +19409,23 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
-      "community": 844
+      "community": 664
+    },
+    {
+      "label": "isIsolatedCandidate()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
+      "source_location": "L26",
+      "id": "batch_scheduler_anchor_handlers_isisolatedcandidate",
+      "community": 664
     },
     {
       "label": "runAnchorAutoRefresh()",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
-      "source_location": "L29",
+      "source_location": "L50",
       "id": "batch_scheduler_anchor_handlers_runanchorautorefresh",
-      "community": 844
+      "community": 664
     },
     {
       "label": "batch-scheduler-consolidation-relation-handlers.ts",
@@ -19465,7 +19473,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-run-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_run_context_ts",
-      "community": 1116
+      "community": 1117
     },
     {
       "label": "batch-scheduler-augmentation-handlers.ts",
@@ -19473,7 +19481,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_augmentation_handlers_ts",
-      "community": 663
+      "community": 665
     },
     {
       "label": "runTripleExtractionBatch()",
@@ -19481,7 +19489,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_augmentation_handlers_runtripleextractionbatch",
-      "community": 663
+      "community": 665
     },
     {
       "label": "runQualityMeasurementBatch()",
@@ -19489,7 +19497,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-augmentation-handlers.ts",
       "source_location": "L65",
       "id": "batch_scheduler_augmentation_handlers_runqualitymeasurementbatch",
-      "community": 663
+      "community": 665
     },
     {
       "label": "batch-scheduler-sleep-telemetry-handlers.ts",
@@ -19497,7 +19505,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_sleep_telemetry_handlers_ts",
-      "community": 664
+      "community": 666
     },
     {
       "label": "runTelemetryCleanupBatch()",
@@ -19505,7 +19513,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L6",
       "id": "batch_scheduler_sleep_telemetry_handlers_runtelemetrycleanupbatch",
-      "community": 664
+      "community": 666
     },
     {
       "label": "runSleepConsolidationBatch()",
@@ -19513,7 +19521,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-sleep-telemetry-handlers.ts",
       "source_location": "L18",
       "id": "batch_scheduler_sleep_telemetry_handlers_runsleepconsolidationbatch",
-      "community": 664
+      "community": 666
     },
     {
       "label": "batch-scheduler-review-meta-handlers.ts",
@@ -19521,7 +19529,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_review_meta_handlers_ts",
-      "community": 523
+      "community": 524
     },
     {
       "label": "buildMemoryReviewCandidateUpsertInputs()",
@@ -19529,7 +19537,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L21",
       "id": "batch_scheduler_review_meta_handlers_buildmemoryreviewcandidateupsertinputs",
-      "community": 523
+      "community": 524
     },
     {
       "label": "runMemoryReviewCandidatesJob()",
@@ -19537,7 +19545,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L55",
       "id": "batch_scheduler_review_meta_handlers_runmemoryreviewcandidatesjob",
-      "community": 523
+      "community": 524
     },
     {
       "label": "runMetaMemoryIntrospection()",
@@ -19545,7 +19553,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-review-meta-handlers.ts",
       "source_location": "L143",
       "id": "batch_scheduler_review_meta_handlers_runmetamemoryintrospection",
-      "community": 523
+      "community": 524
     },
     {
       "label": "batch-scheduler-maintenance-handlers.ts",
@@ -19588,12 +19596,52 @@
       "community": 434
     },
     {
+      "label": "batch-scheduler-anchor-handlers.spec.ts",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L1",
+      "id": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "community": 435
+    },
+    {
+      "label": "addRelation()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L19",
+      "id": "batch_scheduler_anchor_handlers_spec_addrelation",
+      "community": 435
+    },
+    {
+      "label": "addEmbedding()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L25",
+      "id": "batch_scheduler_anchor_handlers_spec_addembedding",
+      "community": 435
+    },
+    {
+      "label": "seedStaleAnchor()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L37",
+      "id": "batch_scheduler_anchor_handlers_spec_seedstaleanchor",
+      "community": 435
+    },
+    {
+      "label": "createContext()",
+      "file_type": "code",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L43",
+      "id": "batch_scheduler_anchor_handlers_spec_createcontext",
+      "community": 435
+    },
+    {
       "label": "file-logger.spec.ts",
       "file_type": "code",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/file-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_file_logger_spec_ts",
-      "community": 1117
+      "community": 1118
     },
     {
       "label": "batch-job-execution-coordinator.spec.ts",
@@ -19601,7 +19649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_execution_coordinator_spec_ts",
-      "community": 845
+      "community": 846
     },
     {
       "label": "createCoordinator()",
@@ -19609,7 +19657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-execution-coordinator.spec.ts",
       "source_location": "L7",
       "id": "batch_job_execution_coordinator_spec_createcoordinator",
-      "community": 845
+      "community": 846
     },
     {
       "label": "health-checker.spec.ts",
@@ -19617,7 +19665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/health-checker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_health_checker_spec_ts",
-      "community": 1118
+      "community": 1119
     },
     {
       "label": "retry-manager.spec.ts",
@@ -19625,7 +19673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_retry_manager_spec_ts",
-      "community": 846
+      "community": 847
     },
     {
       "label": "shouldRetry()",
@@ -19633,7 +19681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/retry-manager.spec.ts",
       "source_location": "L126",
       "id": "retry_manager_spec_shouldretry",
-      "community": 846
+      "community": 847
     },
     {
       "label": "memory-review-candidates-run-diagnostics.spec.ts",
@@ -19641,7 +19689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_memory_review_candidates_run_diagnostics_spec_ts",
-      "community": 847
+      "community": 848
     },
     {
       "label": "baseResult()",
@@ -19649,7 +19697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/memory-review-candidates-run-diagnostics.spec.ts",
       "source_location": "L8",
       "id": "memory_review_candidates_run_diagnostics_spec_baseresult",
-      "community": 847
+      "community": 848
     },
     {
       "label": "job-queue.spec.ts",
@@ -19657,7 +19705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_job_queue_spec_ts",
-      "community": 435
+      "community": 436
     },
     {
       "label": "job()",
@@ -19665,7 +19713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L19",
       "id": "job_queue_spec_job",
-      "community": 435
+      "community": 436
     },
     {
       "label": "job1()",
@@ -19673,7 +19721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L98",
       "id": "job_queue_spec_job1",
-      "community": 435
+      "community": 436
     },
     {
       "label": "job2()",
@@ -19681,7 +19729,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L99",
       "id": "job_queue_spec_job2",
-      "community": 435
+      "community": 436
     },
     {
       "label": "job3()",
@@ -19689,7 +19737,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/job-queue.spec.ts",
       "source_location": "L100",
       "id": "job_queue_spec_job3",
-      "community": 435
+      "community": 436
     },
     {
       "label": "relation-validator-executor.spec.ts",
@@ -19697,7 +19745,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/relation-validator-executor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_relation_validator_executor_spec_ts",
-      "community": 1119
+      "community": 1120
     },
     {
       "label": "batch-job-timeout-resolver.spec.ts",
@@ -19705,7 +19753,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-job-timeout-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_job_timeout_resolver_spec_ts",
-      "community": 1120
+      "community": 1121
     },
     {
       "label": "batch-scheduler-consolidation-score.spec.ts",
@@ -19713,7 +19761,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_consolidation_score_spec_ts",
-      "community": 848
+      "community": 849
     },
     {
       "label": "initializeTestDatabase()",
@@ -19721,7 +19769,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler-consolidation-score.spec.ts",
       "source_location": "L15",
       "id": "batch_scheduler_consolidation_score_spec_initializetestdatabase",
-      "community": 848
+      "community": 849
     },
     {
       "label": "maintenance-jobs.spec.ts",
@@ -19729,7 +19777,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/maintenance-jobs.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_maintenance_jobs_spec_ts",
-      "community": 1121
+      "community": 1122
     },
     {
       "label": "error-handling.spec.ts",
@@ -19737,7 +19785,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_error_handling_spec_ts",
-      "community": 1122
+      "community": 1123
     },
     {
       "label": "concurrency-queue.spec.ts",
@@ -19801,7 +19849,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/run-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_run_job_spec_ts",
-      "community": 1123
+      "community": 1124
     },
     {
       "label": "logging.spec.ts",
@@ -19809,7 +19857,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_logging_spec_ts",
-      "community": 1124
+      "community": 1125
     },
     {
       "label": "env-defaults.spec.ts",
@@ -19817,7 +19865,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/env-defaults.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_env_defaults_spec_ts",
-      "community": 1125
+      "community": 1126
     },
     {
       "label": "lifecycle.spec.ts",
@@ -19825,7 +19873,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/lifecycle.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_lifecycle_spec_ts",
-      "community": 1126
+      "community": 1127
     },
     {
       "label": "job-execution-retry.spec.ts",
@@ -19833,7 +19881,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_job_execution_retry_spec_ts",
-      "community": 849
+      "community": 850
     },
     {
       "label": "failingJob()",
@@ -19841,7 +19889,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/job-execution-retry.spec.ts",
       "source_location": "L359",
       "id": "job_execution_retry_spec_failingjob",
-      "community": 849
+      "community": 850
     },
     {
       "label": "status-diagnostics.spec.ts",
@@ -19849,7 +19897,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/status-diagnostics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_status_diagnostics_spec_ts",
-      "community": 1127
+      "community": 1128
     },
     {
       "label": "constructor-config.spec.ts",
@@ -19857,7 +19905,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/constructor-config.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_constructor_config_spec_ts",
-      "community": 1128
+      "community": 1129
     },
     {
       "label": "relation-validation.spec.ts",
@@ -19865,7 +19913,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/relation-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_relation_validation_spec_ts",
-      "community": 1129
+      "community": 1130
     },
     {
       "label": "batch-scheduler.test-setup.ts",
@@ -19873,7 +19921,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_tests_batch_scheduler_batch_scheduler_test_setup_ts",
-      "community": 850
+      "community": 851
     },
     {
       "label": "executionCoordinator()",
@@ -19881,7 +19929,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/__tests__/batch-scheduler/batch-scheduler.test-setup.ts",
       "source_location": "L4",
       "id": "batch_scheduler_test_setup_executioncoordinator",
-      "community": 850
+      "community": 851
     },
     {
       "label": "triple-extraction-batch-job.ts",
@@ -19889,7 +19937,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_ts",
-      "community": 524
+      "community": 525
     },
     {
       "label": "TripleExtractionBatchJob",
@@ -19897,7 +19945,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L31",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob",
-      "community": 524
+      "community": 525
     },
     {
       "label": ".constructor()",
@@ -19905,7 +19953,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_constructor",
-      "community": 524
+      "community": 525
     },
     {
       "label": ".execute()",
@@ -19913,7 +19961,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job.ts",
       "source_location": "L58",
       "id": "triple_extraction_batch_job_tripleextractionbatchjob_execute",
-      "community": 524
+      "community": 525
     },
     {
       "label": "telemetry-cleanup-batch-job.spec.ts",
@@ -19921,7 +19969,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_spec_ts",
-      "community": 1130
+      "community": 1131
     },
     {
       "label": "quality-measurement-batch-job.ts",
@@ -19929,7 +19977,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_quality_measurement_batch_job_ts",
-      "community": 525
+      "community": 526
     },
     {
       "label": "QualityMeasurementBatchJob",
@@ -19937,7 +19985,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L106",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob",
-      "community": 525
+      "community": 526
     },
     {
       "label": ".constructor()",
@@ -19945,7 +19993,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L112",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_constructor",
-      "community": 525
+      "community": 526
     },
     {
       "label": ".execute()",
@@ -19953,7 +20001,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/quality-measurement-batch-job.ts",
       "source_location": "L144",
       "id": "quality_measurement_batch_job_qualitymeasurementbatchjob_execute",
-      "community": 525
+      "community": 526
     },
     {
       "label": "sleep-consolidation-batch-job.spec.ts",
@@ -19961,7 +20009,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_spec_ts",
-      "community": 1131
+      "community": 1132
     },
     {
       "label": "sleep-consolidation-batch-job.ts",
@@ -19969,7 +20017,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_sleep_consolidation_batch_job_ts",
-      "community": 526
+      "community": 527
     },
     {
       "label": "SleepConsolidationBatchJob",
@@ -19977,7 +20025,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L14",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob",
-      "community": 526
+      "community": 527
     },
     {
       "label": ".constructor()",
@@ -19985,7 +20033,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L15",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_constructor",
-      "community": 526
+      "community": 527
     },
     {
       "label": ".execute()",
@@ -19993,7 +20041,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/sleep-consolidation-batch-job.ts",
       "source_location": "L17",
       "id": "sleep_consolidation_batch_job_sleepconsolidationbatchjob_execute",
-      "community": 526
+      "community": 527
     },
     {
       "label": "telemetry-cleanup-batch-job.ts",
@@ -20001,7 +20049,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_telemetry_cleanup_batch_job_ts",
-      "community": 527
+      "community": 528
     },
     {
       "label": "TelemetryCleanupBatchJob",
@@ -20009,7 +20057,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L15",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob",
-      "community": 527
+      "community": 528
     },
     {
       "label": ".constructor()",
@@ -20017,7 +20065,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L16",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_constructor",
-      "community": 527
+      "community": 528
     },
     {
       "label": ".execute()",
@@ -20025,7 +20073,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/telemetry-cleanup-batch-job.ts",
       "source_location": "L18",
       "id": "telemetry_cleanup_batch_job_telemetrycleanupbatchjob_execute",
-      "community": 527
+      "community": 528
     },
     {
       "label": "triple-extraction-batch-job.spec.ts",
@@ -20033,7 +20081,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_triple_extraction_batch_job_spec_ts",
-      "community": 665
+      "community": 667
     },
     {
       "label": "generateId()",
@@ -20041,7 +20089,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L21",
       "id": "triple_extraction_batch_job_spec_generateid",
-      "community": 665
+      "community": 667
     },
     {
       "label": "initializeTestDatabase()",
@@ -20049,7 +20097,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/triple-extraction-batch-job.spec.ts",
       "source_location": "L36",
       "id": "triple_extraction_batch_job_spec_initializetestdatabase",
-      "community": 665
+      "community": 667
     },
     {
       "label": "quality-measurement-batch-job.spec.ts",
@@ -20057,7 +20105,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_quality_measurement_batch_job_spec_ts",
-      "community": 851
+      "community": 852
     },
     {
       "label": "createQualityTables()",
@@ -20065,7 +20113,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/quality-measurement-batch-job.spec.ts",
       "source_location": "L27",
       "id": "quality_measurement_batch_job_spec_createqualitytables",
-      "community": 851
+      "community": 852
     },
     {
       "label": "arigraph-relation-engine-integration.spec.ts",
@@ -20073,7 +20121,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_tests_arigraph_relation_engine_integration_spec_ts",
-      "community": 666
+      "community": 668
     },
     {
       "label": "generateId()",
@@ -20081,7 +20129,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L21",
       "id": "arigraph_relation_engine_integration_spec_generateid",
-      "community": 666
+      "community": 668
     },
     {
       "label": "initializeTestDatabase()",
@@ -20089,7 +20137,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/__tests__/arigraph-relation-engine-integration.spec.ts",
       "source_location": "L36",
       "id": "arigraph_relation_engine_integration_spec_initializetestdatabase",
-      "community": 666
+      "community": 668
     },
     {
       "label": "triple-extraction-batch-job-chunk.ts",
@@ -20097,7 +20145,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_chunk_ts",
-      "community": 667
+      "community": 669
     },
     {
       "label": "splitTripleExtractionIntoChunks()",
@@ -20105,7 +20153,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L25",
       "id": "triple_extraction_batch_job_chunk_splittripleextractionintochunks",
-      "community": 667
+      "community": 669
     },
     {
       "label": "processTripleExtractionChunk()",
@@ -20113,7 +20161,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-chunk.ts",
       "source_location": "L42",
       "id": "triple_extraction_batch_job_chunk_processtripleextractionchunk",
-      "community": 667
+      "community": 669
     },
     {
       "label": "triple-extraction-batch-job.types.ts",
@@ -20121,7 +20169,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_types_ts",
-      "community": 852
+      "community": 853
     },
     {
       "label": "getErrorCode()",
@@ -20129,7 +20177,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job.types.ts",
       "source_location": "L3",
       "id": "triple_extraction_batch_job_types_geterrorcode",
-      "community": 852
+      "community": 853
     },
     {
       "label": "triple-extraction-batch-job-memory-status.ts",
@@ -20137,7 +20185,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_memory_status_ts",
-      "community": 668
+      "community": 670
     },
     {
       "label": "updateTripleExtractionMemoryStatus()",
@@ -20145,7 +20193,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L8",
       "id": "triple_extraction_batch_job_memory_status_updatetripleextractionmemorystatus",
-      "community": 668
+      "community": 670
     },
     {
       "label": "calculateTripleExtractionAverageConfidence()",
@@ -20153,7 +20201,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-memory-status.ts",
       "source_location": "L43",
       "id": "triple_extraction_batch_job_memory_status_calculatetripleextractionaverageconfidence",
-      "community": 668
+      "community": 670
     },
     {
       "label": "triple-extraction-batch-job-retry.ts",
@@ -20161,7 +20209,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_jobs_triple_extraction_batch_job_triple_extraction_batch_job_retry_ts",
-      "community": 528
+      "community": 529
     },
     {
       "label": "getTripleExtractionRetryCount()",
@@ -20169,7 +20217,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L12",
       "id": "triple_extraction_batch_job_retry_gettripleextractionretrycount",
-      "community": 528
+      "community": 529
     },
     {
       "label": "shouldRetryTripleExtraction()",
@@ -20177,7 +20225,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L35",
       "id": "triple_extraction_batch_job_retry_shouldretrytripleextraction",
-      "community": 528
+      "community": 529
     },
     {
       "label": "getTripleExtractionTargetMemories()",
@@ -20185,7 +20233,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/jobs/triple-extraction-batch-job/triple-extraction-batch-job-retry.ts",
       "source_location": "L81",
       "id": "triple_extraction_batch_job_retry_gettripleextractiontargetmemories",
-      "community": 528
+      "community": 529
     },
     {
       "label": "batch-scheduler-job-control.ts",
@@ -20241,7 +20289,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_context_ts",
-      "community": 529
+      "community": 530
     },
     {
       "label": "createMutableJobRef()",
@@ -20249,7 +20297,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L72",
       "id": "batch_scheduler_context_createmutablejobref",
-      "community": 529
+      "community": 530
     },
     {
       "label": "buildBatchSchedulerRunContext()",
@@ -20257,7 +20305,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L86",
       "id": "batch_scheduler_context_buildbatchschedulerruncontext",
-      "community": 529
+      "community": 530
     },
     {
       "label": "buildBatchRecurringScheduleContext()",
@@ -20265,7 +20313,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-context.ts",
       "source_location": "L124",
       "id": "batch_scheduler_context_buildbatchrecurringschedulecontext",
-      "community": 529
+      "community": 530
     },
     {
       "label": "batch-scheduler-diagnostics.ts",
@@ -20273,7 +20321,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_diagnostics_ts",
-      "community": 669
+      "community": 671
     },
     {
       "label": "writeBatchSchedulerDiagnosticsEvent()",
@@ -20281,7 +20329,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L6",
       "id": "batch_scheduler_diagnostics_writebatchschedulerdiagnosticsevent",
-      "community": 669
+      "community": 671
     },
     {
       "label": "emitMemoryReviewCandidatesRunRecord()",
@@ -20289,7 +20337,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-diagnostics.ts",
       "source_location": "L28",
       "id": "batch_scheduler_diagnostics_emitmemoryreviewcandidatesrunrecord",
-      "community": 669
+      "community": 671
     },
     {
       "label": "batch-scheduler-job-processor.ts",
@@ -20361,7 +20409,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_singleton_ts",
-      "community": 530
+      "community": 531
     },
     {
       "label": "getBatchScheduler()",
@@ -20369,7 +20417,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L6",
       "id": "batch_scheduler_singleton_getbatchscheduler",
-      "community": 530
+      "community": 531
     },
     {
       "label": "createBatchScheduler()",
@@ -20377,7 +20425,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L13",
       "id": "batch_scheduler_singleton_createbatchscheduler",
-      "community": 530
+      "community": 531
     },
     {
       "label": "resetBatchScheduler()",
@@ -20385,7 +20433,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-singleton.ts",
       "source_location": "L17",
       "id": "batch_scheduler_singleton_resetbatchscheduler",
-      "community": 530
+      "community": 531
     },
     {
       "label": "batch-scheduler-logging.ts",
@@ -20393,7 +20441,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_logging_ts",
-      "community": 853
+      "community": 854
     },
     {
       "label": "logBatchSchedulerMessage()",
@@ -20401,7 +20449,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-logging.ts",
       "source_location": "L18",
       "id": "batch_scheduler_logging_logbatchschedulermessage",
-      "community": 853
+      "community": 854
     },
     {
       "label": "batch-scheduler-health.ts",
@@ -20409,7 +20457,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_health_ts",
-      "community": 854
+      "community": 855
     },
     {
       "label": "checkBatchSchedulerHealth()",
@@ -20417,7 +20465,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-health.ts",
       "source_location": "L17",
       "id": "batch_scheduler_health_checkbatchschedulerhealth",
-      "community": 854
+      "community": 855
     },
     {
       "label": "batch-scheduler-status.ts",
@@ -20593,7 +20641,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_lifecycle_ts",
-      "community": 670
+      "community": 672
     },
     {
       "label": "startBatchScheduler()",
@@ -20601,7 +20649,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L30",
       "id": "batch_scheduler_lifecycle_startbatchscheduler",
-      "community": 670
+      "community": 672
     },
     {
       "label": "stopBatchScheduler()",
@@ -20609,7 +20657,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-lifecycle.ts",
       "source_location": "L76",
       "id": "batch_scheduler_lifecycle_stopbatchscheduler",
-      "community": 670
+      "community": 672
     },
     {
       "label": "batch-scheduler-stats.ts",
@@ -20617,7 +20665,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_stats_ts",
-      "community": 855
+      "community": 856
     },
     {
       "label": "getBatchSchedulerDetailedStats()",
@@ -20625,7 +20673,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-stats.ts",
       "source_location": "L18",
       "id": "batch_scheduler_stats_getbatchschedulerdetailedstats",
-      "community": 855
+      "community": 856
     },
     {
       "label": "batch-scheduler-interval.ts",
@@ -20633,7 +20681,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_interval_ts",
-      "community": 671
+      "community": 673
     },
     {
       "label": "scheduleBatchJob()",
@@ -20641,7 +20689,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L16",
       "id": "batch_scheduler_interval_schedulebatchjob",
-      "community": 671
+      "community": 673
     },
     {
       "label": "waitForRunningBatchJobs()",
@@ -20649,7 +20697,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-interval.ts",
       "source_location": "L36",
       "id": "batch_scheduler_interval_waitforrunningbatchjobs",
-      "community": 671
+      "community": 673
     },
     {
       "label": "batch-scheduler-job-runners.ts",
@@ -20657,7 +20705,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_infrastructure_scheduler_batch_scheduler_batch_scheduler_job_runners_ts",
-      "community": 672
+      "community": 674
     },
     {
       "label": "createBatchSchedulerJobRunners()",
@@ -20665,7 +20713,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L39",
       "id": "batch_scheduler_job_runners_createbatchschedulerjobrunners",
-      "community": 672
+      "community": 674
     },
     {
       "label": "runManualBatchSchedulerJob()",
@@ -20673,7 +20721,7 @@
       "source_file": "packages/memento-core/src/infrastructure/scheduler/batch-scheduler/batch-scheduler-job-runners.ts",
       "source_location": "L61",
       "id": "batch_scheduler_job_runners_runmanualbatchschedulerjob",
-      "community": 672
+      "community": 674
     },
     {
       "label": "reflection-notes-schema.spec.ts",
@@ -20681,7 +20729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_spec_ts",
-      "community": 1132
+      "community": 1133
     },
     {
       "label": "owner-scope-mode.ts",
@@ -20689,7 +20737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_ts",
-      "community": 856
+      "community": 857
     },
     {
       "label": "parseOwnerScopeMode()",
@@ -20697,7 +20745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.ts",
       "source_location": "L11",
       "id": "owner_scope_mode_parseownerscopemode",
-      "community": 856
+      "community": 857
     },
     {
       "label": "jsonl-rotation.ts",
@@ -20705,7 +20753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_jsonl_rotation_ts",
-      "community": 857
+      "community": 858
     },
     {
       "label": "rotateJsonlIfNeeded()",
@@ -20713,7 +20761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/jsonl-rotation.ts",
       "source_location": "L3",
       "id": "jsonl_rotation_rotatejsonlifneeded",
-      "community": 857
+      "community": 858
     },
     {
       "label": "external-api-retry-logging.ts",
@@ -20721,7 +20769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_external_api_retry_logging_ts",
-      "community": 673
+      "community": 675
     },
     {
       "label": "isTransientCapacityError()",
@@ -20729,7 +20777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L21",
       "id": "external_api_retry_logging_istransientcapacityerror",
-      "community": 673
+      "community": 675
     },
     {
       "label": "logExternalApiRetry()",
@@ -20737,7 +20785,7 @@
       "source_file": "packages/memento-core/src/shared/utils/external-api-retry-logging.ts",
       "source_location": "L26",
       "id": "external_api_retry_logging_logexternalapiretry",
-      "community": 673
+      "community": 675
     },
     {
       "label": "stopwords.spec.ts",
@@ -20745,7 +20793,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_spec_ts",
-      "community": 1133
+      "community": 1134
     },
     {
       "label": "type-guards.ts",
@@ -20825,7 +20873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_ts",
-      "community": 674
+      "community": 676
     },
     {
       "label": "RuleBasedProceduralExtractor",
@@ -20833,7 +20881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L39",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor",
-      "community": 674
+      "community": 676
     },
     {
       "label": ".extract()",
@@ -20841,7 +20889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.ts",
       "source_location": "L40",
       "id": "procedural_memory_extractor_rulebasedproceduralextractor_extract",
-      "community": 674
+      "community": 676
     },
     {
       "label": "sql-security-validator.ts",
@@ -20849,7 +20897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_sql_security_validator_ts",
-      "community": 675
+      "community": 677
     },
     {
       "label": "validateTableName()",
@@ -20857,7 +20905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L18",
       "id": "sql_security_validator_validatetablename",
-      "community": 675
+      "community": 677
     },
     {
       "label": "getVectorTableName()",
@@ -20865,7 +20913,7 @@
       "source_file": "packages/memento-core/src/shared/utils/sql-security-validator.ts",
       "source_location": "L67",
       "id": "sql_security_validator_getvectortablename",
-      "community": 675
+      "community": 677
     },
     {
       "label": "embedding-provider-diagnostics.ts",
@@ -20873,7 +20921,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_embedding_provider_diagnostics_ts",
-      "community": 858
+      "community": 859
     },
     {
       "label": "emitTfidfFallbackWarningIfNeeded()",
@@ -20881,7 +20929,7 @@
       "source_file": "packages/memento-core/src/shared/utils/embedding-provider-diagnostics.ts",
       "source_location": "L21",
       "id": "embedding_provider_diagnostics_emittfidffallbackwarningifneeded",
-      "community": 858
+      "community": 859
     },
     {
       "label": "environment-check.ts",
@@ -20889,7 +20937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_ts",
-      "community": 531
+      "community": 532
     },
     {
       "label": "isTestEnvironment()",
@@ -20897,7 +20945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L8",
       "id": "environment_check_istestenvironment",
-      "community": 531
+      "community": 532
     },
     {
       "label": "isValidationDisabled()",
@@ -20905,7 +20953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L12",
       "id": "environment_check_isvalidationdisabled",
-      "community": 531
+      "community": 532
     },
     {
       "label": "isValidConfigurationEnvironment()",
@@ -20913,7 +20961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.ts",
       "source_location": "L20",
       "id": "environment_check_isvalidconfigurationenvironment",
-      "community": 531
+      "community": 532
     },
     {
       "label": "db-path.spec.ts",
@@ -20921,7 +20969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_spec_ts",
-      "community": 1134
+      "community": 1135
     },
     {
       "label": "fts5-migration-status.spec.ts",
@@ -20929,7 +20977,7 @@
       "source_file": "packages/memento-core/src/shared/utils/fts5-migration-status.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_fts5_migration_status_spec_ts",
-      "community": 1135
+      "community": 1136
     },
     {
       "label": "reflection-notes-normalize.ts",
@@ -20993,7 +21041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_relation_type_converter_ts",
-      "community": 436
+      "community": 437
     },
     {
       "label": "toDbRelationType()",
@@ -21001,7 +21049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L57",
       "id": "relation_type_converter_todbrelationtype",
-      "community": 436
+      "community": 437
     },
     {
       "label": "fromDbRelationType()",
@@ -21009,7 +21057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L77",
       "id": "relation_type_converter_fromdbrelationtype",
-      "community": 436
+      "community": 437
     },
     {
       "label": "isValidDbRelationType()",
@@ -21017,7 +21065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L95",
       "id": "relation_type_converter_isvaliddbrelationtype",
-      "community": 436
+      "community": 437
     },
     {
       "label": "isMemoryLinkSupported()",
@@ -21025,7 +21073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/relation-type-converter.ts",
       "source_location": "L119",
       "id": "relation_type_converter_ismemorylinksupported",
-      "community": 436
+      "community": 437
     },
     {
       "label": "memento-resource-uri.ts",
@@ -21033,7 +21081,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_memento_resource_uri_ts",
-      "community": 437
+      "community": 438
     },
     {
       "label": "formatMementoResourceUri()",
@@ -21041,7 +21089,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L21",
       "id": "memento_resource_uri_formatmementoresourceuri",
-      "community": 437
+      "community": 438
     },
     {
       "label": "parseMementoResourceUri()",
@@ -21049,7 +21097,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L40",
       "id": "memento_resource_uri_parsemementoresourceuri",
-      "community": 437
+      "community": 438
     },
     {
       "label": "isMementoResourceKind()",
@@ -21057,7 +21105,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L68",
       "id": "memento_resource_uri_ismementoresourcekind",
-      "community": 437
+      "community": 438
     },
     {
       "label": "memoryItemResourceKind()",
@@ -21065,7 +21113,7 @@
       "source_file": "packages/memento-core/src/shared/utils/memento-resource-uri.ts",
       "source_location": "L72",
       "id": "memento_resource_uri_memoryitemresourcekind",
-      "community": 437
+      "community": 438
     },
     {
       "label": "db-path.ts",
@@ -21073,7 +21121,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_db_path_ts",
-      "community": 859
+      "community": 860
     },
     {
       "label": "validateAndNormalizeDbPath()",
@@ -21081,7 +21129,7 @@
       "source_file": "packages/memento-core/src/shared/utils/db-path.ts",
       "source_location": "L20",
       "id": "db_path_validateandnormalizedbpath",
-      "community": 859
+      "community": 860
     },
     {
       "label": "error-handling.spec.ts",
@@ -21089,7 +21137,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_spec_ts",
-      "community": 860
+      "community": 861
     },
     {
       "label": "operation()",
@@ -21097,7 +21145,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.spec.ts",
       "source_location": "L24",
       "id": "error_handling_spec_operation",
-      "community": 860
+      "community": 861
     },
     {
       "label": "procedural-memory-change-detector.ts",
@@ -21337,7 +21385,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-extractor.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_extractor_types_ts",
-      "community": 1136
+      "community": 1137
     },
     {
       "label": "relation-visualizer.ts",
@@ -21697,7 +21745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_ts",
-      "community": 676
+      "community": 678
     },
     {
       "label": "issue()",
@@ -21705,7 +21753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L42",
       "id": "configuration_validator_issue",
-      "community": 676
+      "community": 678
     },
     {
       "label": "validateConfiguration()",
@@ -21713,7 +21761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.ts",
       "source_location": "L46",
       "id": "configuration_validator_validateconfiguration",
-      "community": 676
+      "community": 678
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -21721,7 +21769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_type_param_validator_spec_ts",
-      "community": 1137
+      "community": 1138
     },
     {
       "label": "owner-scope-mode.spec.ts",
@@ -21729,7 +21777,7 @@
       "source_file": "packages/memento-core/src/shared/utils/owner-scope-mode.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_owner_scope_mode_spec_ts",
-      "community": 1138
+      "community": 1139
     },
     {
       "label": "cache-key-generator.ts",
@@ -21785,7 +21833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_spec_ts",
-      "community": 677
+      "community": 679
     },
     {
       "label": "transactionFn()",
@@ -21793,7 +21841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L178",
       "id": "database_spec_transactionfn",
-      "community": 677
+      "community": 679
     },
     {
       "label": "outerTransaction()",
@@ -21801,7 +21849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database.spec.ts",
       "source_location": "L221",
       "id": "database_spec_outertransaction",
-      "community": 677
+      "community": 679
     },
     {
       "label": "write-coalescing.ts",
@@ -21889,7 +21937,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_schema_ts",
-      "community": 532
+      "community": 533
     },
     {
       "label": "validateReflectionNote()",
@@ -21897,7 +21945,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L109",
       "id": "reflection_notes_schema_validatereflectionnote",
-      "community": 532
+      "community": 533
     },
     {
       "label": "validateReflectionNotes()",
@@ -21905,7 +21953,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L148",
       "id": "reflection_notes_schema_validatereflectionnotes",
-      "community": 532
+      "community": 533
     },
     {
       "label": "formatValidationErrors()",
@@ -21913,7 +21961,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-schema.ts",
       "source_location": "L240",
       "id": "reflection_notes_schema_formatvalidationerrors",
-      "community": 532
+      "community": 533
     },
     {
       "label": "environment-check.spec.ts",
@@ -21921,7 +21969,7 @@
       "source_file": "packages/memento-core/src/shared/utils/environment-check.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_environment_check_spec_ts",
-      "community": 1139
+      "community": 1140
     },
     {
       "label": "path-validator.ts",
@@ -21985,7 +22033,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_memory_review_candidate_schema_ts",
-      "community": 861
+      "community": 862
     },
     {
       "label": "ensureMemoryReviewCandidateSchema()",
@@ -21993,7 +22041,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-memory-review-candidate-schema.ts",
       "source_location": "L7",
       "id": "ensure_memory_review_candidate_schema_ensurememoryreviewcandidateschema",
-      "community": 861
+      "community": 862
     },
     {
       "label": "error-handling.ts",
@@ -22001,7 +22049,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_error_handling_ts",
-      "community": 862
+      "community": 863
     },
     {
       "label": "withErrorHandling()",
@@ -22009,7 +22057,7 @@
       "source_file": "packages/memento-core/src/shared/utils/error-handling.ts",
       "source_location": "L58",
       "id": "error_handling_witherrorhandling",
-      "community": 862
+      "community": 863
     },
     {
       "label": "write-coalescing.spec.ts",
@@ -22017,7 +22065,7 @@
       "source_file": "packages/memento-core/src/shared/utils/write-coalescing.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_write_coalescing_spec_ts",
-      "community": 1140
+      "community": 1141
     },
     {
       "label": "configuration-validator.spec.ts",
@@ -22025,7 +22073,7 @@
       "source_file": "packages/memento-core/src/shared/utils/configuration-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_configuration_validator_spec_ts",
-      "community": 1141
+      "community": 1142
     },
     {
       "label": "reflection-notes-merge.ts",
@@ -22233,7 +22281,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_meta_memory_stats_schema_ts",
-      "community": 863
+      "community": 864
     },
     {
       "label": "ensureMetaMemoryStatsSchema()",
@@ -22241,7 +22289,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-meta-memory-stats-schema.ts",
       "source_location": "L8",
       "id": "ensure_meta_memory_stats_schema_ensuremetamemorystatsschema",
-      "community": 863
+      "community": 864
     },
     {
       "label": "reflection-notes-merge.spec.ts",
@@ -22249,7 +22297,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_reflection_notes_merge_spec_ts",
-      "community": 678
+      "community": 680
     },
     {
       "label": "createValidReflectionNote()",
@@ -22257,7 +22305,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L11",
       "id": "reflection_notes_merge_spec_createvalidreflectionnote",
-      "community": 678
+      "community": 680
     },
     {
       "label": "createLargeNote()",
@@ -22265,7 +22313,7 @@
       "source_file": "packages/memento-core/src/shared/utils/reflection-notes-merge.spec.ts",
       "source_location": "L277",
       "id": "reflection_notes_merge_spec_createlargenote",
-      "community": 678
+      "community": 680
     },
     {
       "label": "procedural-memory-change-detector.spec.ts",
@@ -22273,7 +22321,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_procedural_memory_change_detector_spec_ts",
-      "community": 864
+      "community": 865
     },
     {
       "label": "initializeTestDatabase()",
@@ -22281,7 +22329,7 @@
       "source_file": "packages/memento-core/src/shared/utils/procedural-memory-change-detector.spec.ts",
       "source_location": "L20",
       "id": "procedural_memory_change_detector_spec_initializetestdatabase",
-      "community": 864
+      "community": 865
     },
     {
       "label": "ensure-quality-assurance-schema.ts",
@@ -22289,7 +22337,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_ensure_quality_assurance_schema_ts",
-      "community": 865
+      "community": 866
     },
     {
       "label": "ensureQualityAssuranceSchema()",
@@ -22297,7 +22345,7 @@
       "source_file": "packages/memento-core/src/shared/utils/ensure-quality-assurance-schema.ts",
       "source_location": "L8",
       "id": "ensure_quality_assurance_schema_ensurequalityassuranceschema",
-      "community": 865
+      "community": 866
     },
     {
       "label": "procedural-memory-field-extractors.ts",
@@ -22441,7 +22489,7 @@
       "source_file": "packages/memento-core/src/shared/utils/logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_logger_spec_ts",
-      "community": 1142
+      "community": 1143
     },
     {
       "label": "pii-masker.ts",
@@ -22513,7 +22561,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_stopwords_ts",
-      "community": 438
+      "community": 439
     },
     {
       "label": "getStopWords()",
@@ -22521,7 +22569,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L106",
       "id": "stopwords_getstopwords",
-      "community": 438
+      "community": 439
     },
     {
       "label": "getEnglishStopWords()",
@@ -22529,7 +22577,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L114",
       "id": "stopwords_getenglishstopwords",
-      "community": 438
+      "community": 439
     },
     {
       "label": "getKoreanStopWords()",
@@ -22537,7 +22585,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L118",
       "id": "stopwords_getkoreanstopwords",
-      "community": 438
+      "community": 439
     },
     {
       "label": "isStopWord()",
@@ -22545,7 +22593,7 @@
       "source_file": "packages/memento-core/src/shared/utils/stopwords.ts",
       "source_location": "L125",
       "id": "stopwords_isstopword",
-      "community": 438
+      "community": 439
     },
     {
       "label": "relation-type-converter.spec.ts",
@@ -22553,7 +22601,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/relation-type-converter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_relation_type_converter_spec_ts",
-      "community": 1143
+      "community": 1144
     },
     {
       "label": "sql-security-validator.spec.ts",
@@ -22561,7 +22609,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/sql-security-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_sql_security_validator_spec_ts",
-      "community": 1144
+      "community": 1145
     },
     {
       "label": "pii-masker-api-key.spec.ts",
@@ -22569,7 +22617,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-api-key.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_api_key_spec_ts",
-      "community": 1145
+      "community": 1146
     },
     {
       "label": "path-validator.spec.ts",
@@ -22577,7 +22625,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/path-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_path_validator_spec_ts",
-      "community": 1146
+      "community": 1147
     },
     {
       "label": "triple-cache.spec.ts",
@@ -22585,7 +22633,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/triple-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_triple_cache_spec_ts",
-      "community": 1147
+      "community": 1148
     },
     {
       "label": "memento-resource-uri.spec.ts",
@@ -22593,7 +22641,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/memento-resource-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_memento_resource_uri_spec_ts",
-      "community": 1148
+      "community": 1149
     },
     {
       "label": "jsonl-rotation.spec.ts",
@@ -22601,7 +22649,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/jsonl-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_jsonl_rotation_spec_ts",
-      "community": 1149
+      "community": 1150
     },
     {
       "label": "type-param-validator.spec.ts",
@@ -22609,7 +22657,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/type-param-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_type_param_validator_spec_ts",
-      "community": 1150
+      "community": 1151
     },
     {
       "label": "external-api-retry-logging.spec.ts",
@@ -22617,7 +22665,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/external-api-retry-logging.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_external_api_retry_logging_spec_ts",
-      "community": 1151
+      "community": 1152
     },
     {
       "label": "logger-schema-validation.spec.ts",
@@ -22625,7 +22673,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_validation_spec_ts",
-      "community": 1152
+      "community": 1153
     },
     {
       "label": "logging-rate-limiter.spec.ts",
@@ -22633,7 +22681,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-rate-limiter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_rate_limiter_spec_ts",
-      "community": 1153
+      "community": 1154
     },
     {
       "label": "logger-schema.spec.ts",
@@ -22641,7 +22689,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logger-schema.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logger_schema_spec_ts",
-      "community": 1154
+      "community": 1155
     },
     {
       "label": "pii-masker-env-control.spec.ts",
@@ -22649,7 +22697,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-env-control.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_env_control_spec_ts",
-      "community": 1155
+      "community": 1156
     },
     {
       "label": "procedural-memory-extractor.spec.ts",
@@ -22657,7 +22705,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_procedural_memory_extractor_spec_ts",
-      "community": 866
+      "community": 867
     },
     {
       "label": "initializeTestDatabase()",
@@ -22665,7 +22713,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/procedural-memory-extractor.spec.ts",
       "source_location": "L25",
       "id": "procedural_memory_extractor_spec_initializetestdatabase",
-      "community": 866
+      "community": 867
     },
     {
       "label": "logging-helpers.spec.ts",
@@ -22673,7 +22721,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/logging-helpers.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_logging_helpers_spec_ts",
-      "community": 1156
+      "community": 1157
     },
     {
       "label": "pii-masker-integration.spec.ts",
@@ -22681,7 +22729,7 @@
       "source_file": "packages/memento-core/src/shared/utils/__tests__/pii-masker-integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_tests_pii_masker_integration_spec_ts",
-      "community": 1157
+      "community": 1158
     },
     {
       "label": "database-error-helpers.ts",
@@ -22689,7 +22737,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_database_error_helpers_ts",
-      "community": 439
+      "community": 440
     },
     {
       "label": "log()",
@@ -22697,7 +22745,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L3",
       "id": "database_error_helpers_log",
-      "community": 439
+      "community": 440
     },
     {
       "label": "getSqliteErrorCode()",
@@ -22705,7 +22753,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L9",
       "id": "database_error_helpers_getsqliteerrorcode",
-      "community": 439
+      "community": 440
     },
     {
       "label": "getErrorMessage()",
@@ -22713,7 +22761,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L18",
       "id": "database_error_helpers_geterrormessage",
-      "community": 439
+      "community": 440
     },
     {
       "label": "getErrorName()",
@@ -22721,7 +22769,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/database-error-helpers.ts",
       "source_location": "L27",
       "id": "database_error_helpers_geterrorname",
-      "community": 439
+      "community": 440
     },
     {
       "label": "transaction-helpers.ts",
@@ -22777,7 +22825,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_query_helpers_ts",
-      "community": 440
+      "community": 441
     },
     {
       "label": "runQuery()",
@@ -22785,7 +22833,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L5",
       "id": "query_helpers_runquery",
-      "community": 440
+      "community": 441
     },
     {
       "label": "getQuery()",
@@ -22793,7 +22841,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L36",
       "id": "query_helpers_getquery",
-      "community": 440
+      "community": 441
     },
     {
       "label": "allQuery()",
@@ -22801,7 +22849,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L67",
       "id": "query_helpers_allquery",
-      "community": 440
+      "community": 441
     },
     {
       "label": "execQuery()",
@@ -22809,7 +22857,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/query-helpers.ts",
       "source_location": "L98",
       "id": "query_helpers_execquery",
-      "community": 440
+      "community": 441
     },
     {
       "label": "wal-and-status.ts",
@@ -22817,7 +22865,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_wal_and_status_ts",
-      "community": 533
+      "community": 534
     },
     {
       "label": "isDatabaseOpen()",
@@ -22825,7 +22873,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L7",
       "id": "wal_and_status_isdatabaseopen",
-      "community": 533
+      "community": 534
     },
     {
       "label": "checkpointWAL()",
@@ -22833,7 +22881,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L23",
       "id": "wal_and_status_checkpointwal",
-      "community": 533
+      "community": 534
     },
     {
       "label": "getDatabaseStatus()",
@@ -22841,7 +22889,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/wal-and-status.ts",
       "source_location": "L33",
       "id": "wal_and_status_getdatabasestatus",
-      "community": 533
+      "community": 534
     },
     {
       "label": "schema-initialization.ts",
@@ -22849,7 +22897,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_utils_database_schema_initialization_ts",
-      "community": 867
+      "community": 868
     },
     {
       "label": "initializeDatabase()",
@@ -22857,7 +22905,7 @@
       "source_file": "packages/memento-core/src/shared/utils/database/schema-initialization.ts",
       "source_location": "L8",
       "id": "schema_initialization_initializedatabase",
-      "community": 867
+      "community": 868
     },
     {
       "label": "benchmark.types.ts",
@@ -22865,7 +22913,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_benchmark_types_ts",
-      "community": 868
+      "community": 869
     },
     {
       "label": "assertMacroCategory()",
@@ -22873,7 +22921,7 @@
       "source_file": "packages/memento-core/src/shared/types/benchmark.types.ts",
       "source_location": "L28",
       "id": "benchmark_types_assertmacrocategory",
-      "community": 868
+      "community": 869
     },
     {
       "label": "migration.types.ts",
@@ -22881,7 +22929,7 @@
       "source_file": "packages/memento-core/src/shared/types/migration.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_migration_types_ts",
-      "community": 1158
+      "community": 1159
     },
     {
       "label": "consolidation-score.types.ts",
@@ -22889,7 +22937,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation-score.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_score_types_ts",
-      "community": 1159
+      "community": 1160
     },
     {
       "label": "consolidation.types.ts",
@@ -22897,7 +22945,7 @@
       "source_file": "packages/memento-core/src/shared/types/consolidation.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_consolidation_types_ts",
-      "community": 1160
+      "community": 1161
     },
     {
       "label": "vector-search.types.ts",
@@ -22905,7 +22953,7 @@
       "source_file": "packages/memento-core/src/shared/types/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_vector_search_types_ts",
-      "community": 1161
+      "community": 1162
     },
     {
       "label": "spaced-repetition.types.ts",
@@ -22913,7 +22961,7 @@
       "source_file": "packages/memento-core/src/shared/types/spaced-repetition.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_spaced_repetition_types_ts",
-      "community": 1162
+      "community": 1163
     },
     {
       "label": "procedural-versioning.ts",
@@ -22921,7 +22969,7 @@
       "source_file": "packages/memento-core/src/shared/types/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_procedural_versioning_ts",
-      "community": 1163
+      "community": 1164
     },
     {
       "label": "triple-extraction.ts",
@@ -22929,7 +22977,7 @@
       "source_file": "packages/memento-core/src/shared/types/triple-extraction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_triple_extraction_ts",
-      "community": 1164
+      "community": 1165
     },
     {
       "label": "feedback.types.ts",
@@ -22937,7 +22985,7 @@
       "source_file": "packages/memento-core/src/shared/types/feedback.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_feedback_types_ts",
-      "community": 1165
+      "community": 1166
     },
     {
       "label": "embedding.types.ts",
@@ -22945,7 +22993,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_types_ts",
-      "community": 1166
+      "community": 1167
     },
     {
       "label": "relation-graph.ts",
@@ -22953,7 +23001,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_graph_ts",
-      "community": 1167
+      "community": 1168
     },
     {
       "label": "failure-event.ts",
@@ -22961,7 +23009,7 @@
       "source_file": "packages/memento-core/src/shared/types/failure-event.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_failure_event_ts",
-      "community": 1168
+      "community": 1169
     },
     {
       "label": "index.ts",
@@ -22969,7 +23017,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_ts",
-      "community": 679
+      "community": 681
     },
     {
       "label": "isMemoryItemType()",
@@ -22977,7 +23025,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L15",
       "id": "index_ismemoryitemtype",
-      "community": 679
+      "community": 681
     },
     {
       "label": "isFullMemoryItemTypeSet()",
@@ -22985,7 +23033,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.ts",
       "source_location": "L23",
       "id": "index_isfullmemoryitemtypeset",
-      "community": 679
+      "community": 681
     },
     {
       "label": "error-types.ts",
@@ -22993,7 +23041,7 @@
       "source_file": "packages/memento-core/src/shared/types/error-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_error_types_ts",
-      "community": 1169
+      "community": 1170
     },
     {
       "label": "ranking.types.ts",
@@ -23001,7 +23049,7 @@
       "source_file": "packages/memento-core/src/shared/types/ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_ranking_types_ts",
-      "community": 1170
+      "community": 1171
     },
     {
       "label": "alerts.types.ts",
@@ -23009,7 +23057,7 @@
       "source_file": "packages/memento-core/src/shared/types/alerts.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_alerts_types_ts",
-      "community": 1171
+      "community": 1172
     },
     {
       "label": "relation.ts",
@@ -23017,7 +23065,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_relation_ts",
-      "community": 534
+      "community": 535
     },
     {
       "label": "isApplicableRelationType()",
@@ -23025,7 +23073,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L155",
       "id": "relation_isapplicablerelationtype",
-      "community": 534
+      "community": 535
     },
     {
       "label": "getRelationCategory()",
@@ -23033,7 +23081,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L165",
       "id": "relation_getrelationcategory",
-      "community": 534
+      "community": 535
     },
     {
       "label": "getRelationBoost()",
@@ -23041,7 +23089,7 @@
       "source_file": "packages/memento-core/src/shared/types/relation.ts",
       "source_location": "L172",
       "id": "relation_getrelationboost",
-      "community": 534
+      "community": 535
     },
     {
       "label": "search.types.ts",
@@ -23049,7 +23097,7 @@
       "source_file": "packages/memento-core/src/shared/types/search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_search_types_ts",
-      "community": 1172
+      "community": 1173
     },
     {
       "label": "index.spec.ts",
@@ -23057,7 +23105,7 @@
       "source_file": "packages/memento-core/src/shared/types/index.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_index_spec_ts",
-      "community": 1173
+      "community": 1174
     },
     {
       "label": "embedding-provider-monitoring.types.ts",
@@ -23065,7 +23113,7 @@
       "source_file": "packages/memento-core/src/shared/types/embedding-provider-monitoring.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_types_embedding_provider_monitoring_types_ts",
-      "community": 1174
+      "community": 1175
     },
     {
       "label": "constants.ts",
@@ -23073,7 +23121,7 @@
       "source_file": "packages/memento-core/src/shared/config/constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_constants_ts",
-      "community": 1175
+      "community": 1176
     },
     {
       "label": "environment.ts",
@@ -23217,7 +23265,7 @@
       "source_file": "packages/memento-core/src/shared/config/vector-search.config.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_vector_search_config_ts",
-      "community": 1176
+      "community": 1177
     },
     {
       "label": "retry-options-loader.ts",
@@ -23273,7 +23321,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_llm_model_resolver_ts",
-      "community": 680
+      "community": 682
     },
     {
       "label": "resolveProviderDefaultModel()",
@@ -23281,7 +23329,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L28",
       "id": "llm_model_resolver_resolveproviderdefaultmodel",
-      "community": 680
+      "community": 682
     },
     {
       "label": "resolveLlmModel()",
@@ -23289,7 +23337,7 @@
       "source_file": "packages/memento-core/src/shared/config/llm-model-resolver.ts",
       "source_location": "L51",
       "id": "llm_model_resolver_resolvellmmodel",
-      "community": 680
+      "community": 682
     },
     {
       "label": "index.ts",
@@ -23297,7 +23345,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_index_ts",
-      "community": 869
+      "community": 870
     },
     {
       "label": "validateConfig()",
@@ -23305,7 +23353,7 @@
       "source_file": "packages/memento-core/src/shared/config/index.ts",
       "source_location": "L170",
       "id": "index_validateconfig",
-      "community": 869
+      "community": 870
     },
     {
       "label": "config-loader-utils.ts",
@@ -23377,7 +23425,7 @@
       "source_file": "packages/memento-core/src/shared/config/ranking-weights-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_ranking_weights_loader_spec_ts",
-      "community": 1177
+      "community": 1178
     },
     {
       "label": "constants.spec.ts",
@@ -23385,7 +23433,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/constants.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_constants_spec_ts",
-      "community": 1178
+      "community": 1179
     },
     {
       "label": "llm-model-resolver.spec.ts",
@@ -23393,7 +23441,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/llm-model-resolver.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_llm_model_resolver_spec_ts",
-      "community": 1179
+      "community": 1180
     },
     {
       "label": "config-validation.spec.ts",
@@ -23401,7 +23449,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-validation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_validation_spec_ts",
-      "community": 1180
+      "community": 1181
     },
     {
       "label": "retry-options-loader.spec.ts",
@@ -23409,7 +23457,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/retry-options-loader.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_retry_options_loader_spec_ts",
-      "community": 1181
+      "community": 1182
     },
     {
       "label": "environment-paths.spec.ts",
@@ -23417,7 +23465,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/environment-paths.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_environment_paths_spec_ts",
-      "community": 1182
+      "community": 1183
     },
     {
       "label": "config-loader-utils.spec.ts",
@@ -23425,7 +23473,7 @@
       "source_file": "packages/memento-core/src/shared/config/__tests__/config-loader-utils.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_config_tests_config_loader_utils_spec_ts",
-      "community": 1183
+      "community": 1184
     },
     {
       "label": "schema-version.ts",
@@ -23433,7 +23481,7 @@
       "source_file": "packages/memento-core/src/shared/constants/schema-version.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_schema_version_ts",
-      "community": 1184
+      "community": 1185
     },
     {
       "label": "relation-constants.ts",
@@ -23441,7 +23489,7 @@
       "source_file": "packages/memento-core/src/shared/constants/relation-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_relation_constants_ts",
-      "community": 1185
+      "community": 1186
     },
     {
       "label": "introspection-constants.ts",
@@ -23449,7 +23497,7 @@
       "source_file": "packages/memento-core/src/shared/constants/introspection-constants.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_constants_introspection_constants_ts",
-      "community": 1186
+      "community": 1187
     },
     {
       "label": "http-bind-policy.spec.ts",
@@ -23457,7 +23505,7 @@
       "source_file": "packages/memento-core/src/shared/http/http-bind-policy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_http_http_bind_policy_spec_ts",
-      "community": 1187
+      "community": 1188
     },
     {
       "label": "http-bind-policy.ts",
@@ -23537,7 +23585,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/reflexion-worker.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_reflexion_worker_interface_ts",
-      "community": 1188
+      "community": 1189
     },
     {
       "label": "retry-manager.interface.ts",
@@ -23545,7 +23593,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/retry-manager.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_retry_manager_interface_ts",
-      "community": 1189
+      "community": 1190
     },
     {
       "label": "cache.interface.ts",
@@ -23553,7 +23601,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/cache.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_cache_interface_ts",
-      "community": 1190
+      "community": 1191
     },
     {
       "label": "async-task-queue.interface.ts",
@@ -23561,7 +23609,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/async-task-queue.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_async_task_queue_interface_ts",
-      "community": 1191
+      "community": 1192
     },
     {
       "label": "error-logging.interface.ts",
@@ -23569,7 +23617,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/error-logging.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_error_logging_interface_ts",
-      "community": 1192
+      "community": 1193
     },
     {
       "label": "spaced-repetition.interface.ts",
@@ -23577,7 +23625,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/spaced-repetition.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_spaced_repetition_interface_ts",
-      "community": 1193
+      "community": 1194
     },
     {
       "label": "consolidation-score.interface.ts",
@@ -23585,7 +23633,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/consolidation-score.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_consolidation_score_interface_ts",
-      "community": 1194
+      "community": 1195
     },
     {
       "label": "database.interface.ts",
@@ -23593,7 +23641,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_interface_ts",
-      "community": 1195
+      "community": 1196
     },
     {
       "label": "database-optimizer.interface.ts",
@@ -23601,7 +23649,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/database-optimizer.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_database_optimizer_interface_ts",
-      "community": 1196
+      "community": 1197
     },
     {
       "label": "batch-scheduler.interface.ts",
@@ -23609,7 +23657,7 @@
       "source_file": "packages/memento-core/src/shared/interfaces/batch-scheduler.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_interfaces_batch_scheduler_interface_ts",
-      "community": 1197
+      "community": 1198
     },
     {
       "label": "llm-client-initializer.ts",
@@ -23617,7 +23665,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_ts",
-      "community": 441
+      "community": 442
     },
     {
       "label": "LLMClientInitializer",
@@ -23625,7 +23673,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L32",
       "id": "llm_client_initializer_llmclientinitializer",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".constructor()",
@@ -23633,7 +23681,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L39",
       "id": "llm_client_initializer_llmclientinitializer_constructor",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".initialize()",
@@ -23641,7 +23689,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L60",
       "id": "llm_client_initializer_llmclientinitializer_initialize",
-      "community": 441
+      "community": 442
     },
     {
       "label": ".validateApiKeys()",
@@ -23649,7 +23697,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer.ts",
       "source_location": "L106",
       "id": "llm_client_initializer_llmclientinitializer_validateapikeys",
-      "community": 441
+      "community": 442
     },
     {
       "label": "llm-client-initializer.test-setup.ts",
@@ -23657,7 +23705,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_client_initializer_test_setup_ts",
-      "community": 681
+      "community": 683
     },
     {
       "label": "getMockMementoConfig()",
@@ -23665,7 +23713,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L21",
       "id": "llm_client_initializer_test_setup_getmockmementoconfig",
-      "community": 681
+      "community": 683
     },
     {
       "label": "resetLlmClientInitializerTestEnv()",
@@ -23673,7 +23721,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-client-initializer.test-setup.ts",
       "source_location": "L50",
       "id": "llm_client_initializer_test_setup_resetllmclientinitializertestenv",
-      "community": 681
+      "community": 683
     },
     {
       "label": "initialize.spec.ts",
@@ -23681,7 +23729,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/initialize.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_initialize_spec_ts",
-      "community": 1198
+      "community": 1199
     },
     {
       "label": "openai-client.spec.ts",
@@ -23689,7 +23737,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/openai-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_openai_client_spec_ts",
-      "community": 1199
+      "community": 1200
     },
     {
       "label": "llm-provider-fallback-ollama.spec.ts",
@@ -23697,7 +23745,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_ollama_spec_ts",
-      "community": 1200
+      "community": 1201
     },
     {
       "label": "llm-provider-fallback-gemini.spec.ts",
@@ -23705,7 +23753,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_gemini_spec_ts",
-      "community": 1201
+      "community": 1202
     },
     {
       "label": "ollama-connection.spec.ts",
@@ -23713,7 +23761,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/ollama-connection.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_ollama_connection_spec_ts",
-      "community": 1202
+      "community": 1203
     },
     {
       "label": "llm-provider-fallback-auto.spec.ts",
@@ -23721,7 +23769,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_auto_spec_ts",
-      "community": 1203
+      "community": 1204
     },
     {
       "label": "llm-provider-fallback-openai.spec.ts",
@@ -23729,7 +23777,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/llm-provider-fallback-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_llm_provider_fallback_openai_spec_ts",
-      "community": 1204
+      "community": 1205
     },
     {
       "label": "environment-priority.spec.ts",
@@ -23737,7 +23785,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/environment-priority.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_environment_priority_spec_ts",
-      "community": 1205
+      "community": 1206
     },
     {
       "label": "validate-api-keys.spec.ts",
@@ -23745,7 +23793,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/validate-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_validate_api_keys_spec_ts",
-      "community": 1206
+      "community": 1207
     },
     {
       "label": "gemini-client.spec.ts",
@@ -23753,7 +23801,7 @@
       "source_file": "packages/memento-core/src/shared/services/__tests__/llm-client-initializer/gemini-client.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_tests_llm_client_initializer_gemini_client_spec_ts",
-      "community": 1207
+      "community": 1208
     },
     {
       "label": "provider-resolution.ts",
@@ -23809,7 +23857,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_types_ts",
-      "community": 1208
+      "community": 1209
     },
     {
       "label": "shared-helpers.ts",
@@ -23873,7 +23921,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_gemini_ts",
-      "community": 870
+      "community": 871
     },
     {
       "label": "initializeGemini()",
@@ -23881,7 +23929,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/gemini.ts",
       "source_location": "L18",
       "id": "gemini_initializegemini",
-      "community": 870
+      "community": 871
     },
     {
       "label": "ollama.ts",
@@ -23889,7 +23937,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_ollama_ts",
-      "community": 442
+      "community": 443
     },
     {
       "label": "handleOllamaResponse()",
@@ -23897,7 +23945,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L12",
       "id": "ollama_handleollamaresponse",
-      "community": 442
+      "community": 443
     },
     {
       "label": "shouldRetryOllamaConnection()",
@@ -23905,7 +23953,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L57",
       "id": "ollama_shouldretryollamaconnection",
-      "community": 442
+      "community": 443
     },
     {
       "label": "getOllamaErrorMessage()",
@@ -23913,7 +23961,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L76",
       "id": "ollama_getollamaerrormessage",
-      "community": 442
+      "community": 443
     },
     {
       "label": "testOllamaConnection()",
@@ -23921,7 +23969,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/ollama.ts",
       "source_location": "L94",
       "id": "ollama_testollamaconnection",
-      "community": 442
+      "community": 443
     },
     {
       "label": "openai.ts",
@@ -23929,7 +23977,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_services_llm_client_initializer_openai_ts",
-      "community": 871
+      "community": 872
     },
     {
       "label": "initializeOpenAI()",
@@ -23937,7 +23985,7 @@
       "source_file": "packages/memento-core/src/shared/services/llm-client-initializer/openai.ts",
       "source_location": "L14",
       "id": "openai_initializeopenai",
-      "community": 871
+      "community": 872
     },
     {
       "label": "source-uri.ts",
@@ -23945,7 +23993,7 @@
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_source_uri_ts",
-      "community": 872
+      "community": 873
     },
     {
       "label": "validateSource()",
@@ -23953,7 +24001,7 @@
       "source_file": "packages/memento-core/src/shared/validation/source-uri.ts",
       "source_location": "L39",
       "id": "source_uri_validatesource",
-      "community": 872
+      "community": 873
     },
     {
       "label": "source-uri.spec.ts",
@@ -23961,7 +24009,7 @@
       "source_file": "packages/memento-core/src/shared/validation/__tests__/source-uri.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_shared_validation_tests_source_uri_spec_ts",
-      "community": 1209
+      "community": 1210
     },
     {
       "label": "search-local-tool.ts",
@@ -23969,7 +24017,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_search_local_tool_ts",
-      "community": 535
+      "community": 536
     },
     {
       "label": "SearchLocalTool",
@@ -23977,7 +24025,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L21",
       "id": "search_local_tool_searchlocaltool",
-      "community": 535
+      "community": 536
     },
     {
       "label": ".constructor()",
@@ -23985,7 +24033,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L22",
       "id": "search_local_tool_searchlocaltool_constructor",
-      "community": 535
+      "community": 536
     },
     {
       "label": ".handle()",
@@ -23993,7 +24041,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/search-local-tool.ts",
       "source_location": "L74",
       "id": "search_local_tool_searchlocaltool_handle",
-      "community": 535
+      "community": 536
     },
     {
       "label": "get-anchor-tool.ts",
@@ -24001,7 +24049,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_get_anchor_tool_ts",
-      "community": 536
+      "community": 537
     },
     {
       "label": "GetAnchorTool",
@@ -24009,7 +24057,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L14",
       "id": "get_anchor_tool_getanchortool",
-      "community": 536
+      "community": 537
     },
     {
       "label": ".constructor()",
@@ -24017,7 +24065,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L15",
       "id": "get_anchor_tool_getanchortool_constructor",
-      "community": 536
+      "community": 537
     },
     {
       "label": ".handle()",
@@ -24025,7 +24073,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/get-anchor-tool.ts",
       "source_location": "L38",
       "id": "get_anchor_tool_getanchortool_handle",
-      "community": 536
+      "community": 537
     },
     {
       "label": "set-anchor-tool.ts",
@@ -24033,7 +24081,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_set_anchor_tool_ts",
-      "community": 537
+      "community": 538
     },
     {
       "label": "SetAnchorTool",
@@ -24041,7 +24089,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L17",
       "id": "set_anchor_tool_setanchortool",
-      "community": 537
+      "community": 538
     },
     {
       "label": ".constructor()",
@@ -24049,7 +24097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L18",
       "id": "set_anchor_tool_setanchortool_constructor",
-      "community": 537
+      "community": 538
     },
     {
       "label": ".handle()",
@@ -24057,7 +24105,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/set-anchor-tool.ts",
       "source_location": "L45",
       "id": "set_anchor_tool_setanchortool_handle",
-      "community": 537
+      "community": 538
     },
     {
       "label": "clear-anchor-tool.ts",
@@ -24065,7 +24113,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_clear_anchor_tool_ts",
-      "community": 538
+      "community": 539
     },
     {
       "label": "ClearAnchorTool",
@@ -24073,7 +24121,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L14",
       "id": "clear_anchor_tool_clearanchortool",
-      "community": 538
+      "community": 539
     },
     {
       "label": ".constructor()",
@@ -24081,7 +24129,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L15",
       "id": "clear_anchor_tool_clearanchortool_constructor",
-      "community": 538
+      "community": 539
     },
     {
       "label": ".handle()",
@@ -24089,7 +24137,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/clear-anchor-tool.ts",
       "source_location": "L38",
       "id": "clear_anchor_tool_clearanchortool_handle",
-      "community": 538
+      "community": 539
     },
     {
       "label": "restore-anchors-tool.ts",
@@ -24097,7 +24145,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_restore_anchors_tool_ts",
-      "community": 539
+      "community": 540
     },
     {
       "label": "RestoreAnchorsTool",
@@ -24105,7 +24153,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L14",
       "id": "restore_anchors_tool_restoreanchorstool",
-      "community": 539
+      "community": 540
     },
     {
       "label": ".constructor()",
@@ -24113,7 +24161,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L15",
       "id": "restore_anchors_tool_restoreanchorstool_constructor",
-      "community": 539
+      "community": 540
     },
     {
       "label": ".handle()",
@@ -24121,7 +24169,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/restore-anchors-tool.ts",
       "source_location": "L33",
       "id": "restore_anchors_tool_restoreanchorstool_handle",
-      "community": 539
+      "community": 540
     },
     {
       "label": "clear-anchor-tool.spec.ts",
@@ -24129,7 +24177,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_clear_anchor_tool_spec_ts",
-      "community": 443
+      "community": 444
     },
     {
       "label": "initializeTestDatabase()",
@@ -24137,7 +24185,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "clear_anchor_tool_spec_initializetestdatabase",
-      "community": 443
+      "community": 444
     },
     {
       "label": "createMockEmbeddingService()",
@@ -24145,7 +24193,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "clear_anchor_tool_spec_createmockembeddingservice",
-      "community": 443
+      "community": 444
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -24153,7 +24201,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "clear_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 443
+      "community": 444
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -24161,7 +24209,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/clear-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "clear_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 443
+      "community": 444
     },
     {
       "label": "get-anchor-tool.spec.ts",
@@ -24169,7 +24217,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_get_anchor_tool_spec_ts",
-      "community": 444
+      "community": 445
     },
     {
       "label": "initializeTestDatabase()",
@@ -24177,7 +24225,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L37",
       "id": "get_anchor_tool_spec_initializetestdatabase",
-      "community": 444
+      "community": 445
     },
     {
       "label": "createMockEmbeddingService()",
@@ -24185,7 +24233,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L70",
       "id": "get_anchor_tool_spec_createmockembeddingservice",
-      "community": 444
+      "community": 445
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -24193,7 +24241,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L79",
       "id": "get_anchor_tool_spec_createmockhybridsearchengine",
-      "community": 444
+      "community": 445
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -24201,7 +24249,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/get-anchor-tool.spec.ts",
       "source_location": "L86",
       "id": "get_anchor_tool_spec_createmockvectorsearchengine",
-      "community": 444
+      "community": 445
     },
     {
       "label": "restore-anchors-tool.spec.ts",
@@ -24209,7 +24257,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_restore_anchors_tool_spec_ts",
-      "community": 445
+      "community": 446
     },
     {
       "label": "initializeTestDatabase()",
@@ -24217,7 +24265,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L37",
       "id": "restore_anchors_tool_spec_initializetestdatabase",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createMockEmbeddingService()",
@@ -24225,7 +24273,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L70",
       "id": "restore_anchors_tool_spec_createmockembeddingservice",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createMockHybridSearchEngine()",
@@ -24233,7 +24281,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L79",
       "id": "restore_anchors_tool_spec_createmockhybridsearchengine",
-      "community": 445
+      "community": 446
     },
     {
       "label": "createMockVectorSearchEngine()",
@@ -24241,7 +24289,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/restore-anchors-tool.spec.ts",
       "source_location": "L86",
       "id": "restore_anchors_tool_spec_createmockvectorsearchengine",
-      "community": 445
+      "community": 446
     },
     {
       "label": "set-anchor-tool.spec.ts",
@@ -24249,7 +24297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_set_anchor_tool_spec_ts",
-      "community": 873
+      "community": 874
     },
     {
       "label": "initializeTestDatabase()",
@@ -24257,7 +24305,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/set-anchor-tool.spec.ts",
       "source_location": "L42",
       "id": "set_anchor_tool_spec_initializetestdatabase",
-      "community": 873
+      "community": 874
     },
     {
       "label": "search-local-tool.spec.ts",
@@ -24265,7 +24313,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_tools_tests_search_local_tool_spec_ts",
-      "community": 874
+      "community": 875
     },
     {
       "label": "initializeTestDatabase()",
@@ -24273,7 +24321,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/tools/__tests__/search-local-tool.spec.ts",
       "source_location": "L51",
       "id": "search_local_tool_spec_initializetestdatabase",
-      "community": 874
+      "community": 875
     },
     {
       "label": "fallback-search-service.spec.ts",
@@ -24281,7 +24329,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_spec_ts",
-      "community": 1210
+      "community": 1211
     },
     {
       "label": "query-filter-strategy.ts",
@@ -24289,7 +24337,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_ts",
-      "community": 446
+      "community": 447
     },
     {
       "label": "QueryFilterStrategy",
@@ -24297,7 +24345,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L13",
       "id": "query_filter_strategy_queryfilterstrategy",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".constructor()",
@@ -24305,7 +24353,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L17",
       "id": "query_filter_strategy_queryfilterstrategy_constructor",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".filter()",
@@ -24313,7 +24361,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L27",
       "id": "query_filter_strategy_queryfilterstrategy_filter",
-      "community": 446
+      "community": 447
     },
     {
       "label": ".execute()",
@@ -24321,7 +24369,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.ts",
       "source_location": "L38",
       "id": "query_filter_strategy_queryfilterstrategy_execute",
-      "community": 446
+      "community": 447
     },
     {
       "label": "anchor-manager.spec.ts",
@@ -24329,7 +24377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_manager_spec_ts",
-      "community": 1211
+      "community": 1212
     },
     {
       "label": "anchor-search-service.spec.ts",
@@ -24337,7 +24385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_search_service_spec_ts",
-      "community": 1212
+      "community": 1213
     },
     {
       "label": "local-search-service.ts",
@@ -24409,7 +24457,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_service_spec_ts",
-      "community": 1213
+      "community": 1214
     },
     {
       "label": "anchor-cache-service.spec.ts",
@@ -24417,7 +24465,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/anchor-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_anchor_cache_service_spec_ts",
-      "community": 1214
+      "community": 1215
     },
     {
       "label": "anchor-interfaces.ts",
@@ -24545,7 +24593,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/search-strategy-interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_search_strategy_interfaces_ts",
-      "community": 1215
+      "community": 1216
     },
     {
       "label": "anchor-reanchor-service.ts",
@@ -24625,7 +24673,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_vector_search_engine_types_ts",
-      "community": 875
+      "community": 876
     },
     {
       "label": "isInitializableVectorSearchEngine()",
@@ -24633,7 +24681,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/vector-search-engine-types.ts",
       "source_location": "L20",
       "id": "vector_search_engine_types_isinitializablevectorsearchengine",
-      "community": 875
+      "community": 876
     },
     {
       "label": "embedding-types.ts",
@@ -24641,7 +24689,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/embedding-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_embedding_types_ts",
-      "community": 1216
+      "community": 1217
     },
     {
       "label": "n-hop-search-strategy.spec.ts",
@@ -24649,7 +24697,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_spec_ts",
-      "community": 1217
+      "community": 1218
     },
     {
       "label": "n-hop-search-strategy.ts",
@@ -24657,7 +24705,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_strategy_ts",
-      "community": 447
+      "community": 448
     },
     {
       "label": "NHopSearchStrategy",
@@ -24665,7 +24713,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L13",
       "id": "n_hop_search_strategy_nhopsearchstrategy",
-      "community": 447
+      "community": 448
     },
     {
       "label": ".constructor()",
@@ -24673,7 +24721,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L17",
       "id": "n_hop_search_strategy_nhopsearchstrategy_constructor",
-      "community": 447
+      "community": 448
     },
     {
       "label": ".search()",
@@ -24681,7 +24729,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L27",
       "id": "n_hop_search_strategy_nhopsearchstrategy_search",
-      "community": 447
+      "community": 448
     },
     {
       "label": ".execute()",
@@ -24689,7 +24737,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-strategy.ts",
       "source_location": "L50",
       "id": "n_hop_search_strategy_nhopsearchstrategy_execute",
-      "community": 447
+      "community": 448
     },
     {
       "label": "query-filter-service.ts",
@@ -24841,7 +24889,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_search_service_ts",
-      "community": 448
+      "community": 449
     },
     {
       "label": "FallbackSearchService",
@@ -24849,7 +24897,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L28",
       "id": "fallback_search_service_fallbacksearchservice",
-      "community": 448
+      "community": 449
     },
     {
       "label": ".setDatabase()",
@@ -24857,7 +24905,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L35",
       "id": "fallback_search_service_fallbacksearchservice_setdatabase",
-      "community": 448
+      "community": 449
     },
     {
       "label": ".setHybridSearchEngine()",
@@ -24865,7 +24913,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L45",
       "id": "fallback_search_service_fallbacksearchservice_sethybridsearchengine",
-      "community": 448
+      "community": 449
     },
     {
       "label": ".fallbackToGlobalSearch()",
@@ -24873,7 +24921,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-search-service.ts",
       "source_location": "L55",
       "id": "fallback_search_service_fallbacksearchservice_fallbacktoglobalsearch",
-      "community": 448
+      "community": 449
     },
     {
       "label": "index.ts",
@@ -24881,7 +24929,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_index_ts",
-      "community": 1218
+      "community": 1219
     },
     {
       "label": "fallback-strategy.ts",
@@ -24889,7 +24937,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_fallback_strategy_ts",
-      "community": 449
+      "community": 450
     },
     {
       "label": "FallbackStrategy",
@@ -24897,7 +24945,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L14",
       "id": "fallback_strategy_fallbackstrategy",
-      "community": 449
+      "community": 450
     },
     {
       "label": ".constructor()",
@@ -24905,7 +24953,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L18",
       "id": "fallback_strategy_fallbackstrategy_constructor",
-      "community": 449
+      "community": 450
     },
     {
       "label": ".fallback()",
@@ -24913,7 +24961,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L28",
       "id": "fallback_strategy_fallbackstrategy_fallback",
-      "community": 449
+      "community": 450
     },
     {
       "label": ".execute()",
@@ -24921,7 +24969,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/fallback-strategy.ts",
       "source_location": "L39",
       "id": "fallback_strategy_fallbackstrategy_execute",
-      "community": 449
+      "community": 450
     },
     {
       "label": "anchor-search-service.ts",
@@ -25049,7 +25097,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/query-filter-strategy.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_query_filter_strategy_spec_ts",
-      "community": 1219
+      "community": 1220
     },
     {
       "label": "anchor-cache-service.ts",
@@ -25249,7 +25297,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/database-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_database_types_ts",
-      "community": 1220
+      "community": 1221
     },
     {
       "label": "n-hop-linked-memory-service.ts",
@@ -25329,7 +25377,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/local-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_local_search_service_spec_ts",
-      "community": 1221
+      "community": 1222
     },
     {
       "label": "n-hop-search-service.spec.ts",
@@ -25337,7 +25385,7 @@
       "source_file": "packages/memento-core/src/domains/anchor/services/anchor/n-hop-search-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_anchor_services_anchor_n_hop_search_service_spec_ts",
-      "community": 1222
+      "community": 1223
     },
     {
       "label": "evolution-demo.spec.ts",
@@ -25345,7 +25393,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/evolution-demo.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_evolution_demo_spec_ts",
-      "community": 1223
+      "community": 1224
     },
     {
       "label": "store.ts",
@@ -25353,7 +25401,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_store_ts",
-      "community": 540
+      "community": 541
     },
     {
       "label": "key()",
@@ -25361,7 +25409,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L13",
       "id": "store_key",
-      "community": 540
+      "community": 541
     },
     {
       "label": "buildSnapshotsFromFixture()",
@@ -25369,7 +25417,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L38",
       "id": "store_buildsnapshotsfromfixture",
-      "community": 540
+      "community": 541
     },
     {
       "label": "getFixtureSnapshot()",
@@ -25377,7 +25425,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/store.ts",
       "source_location": "L172",
       "id": "store_getfixturesnapshot",
-      "community": 540
+      "community": 541
     },
     {
       "label": "types.ts",
@@ -25385,7 +25433,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_types_ts",
-      "community": 1224
+      "community": 1225
     },
     {
       "label": "index.ts",
@@ -25393,7 +25441,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_index_ts",
-      "community": 1225
+      "community": 1226
     },
     {
       "label": "getters.ts",
@@ -25401,7 +25449,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_getters_ts",
-      "community": 450
+      "community": 451
     },
     {
       "label": "EvolutionDemoNotFoundError",
@@ -25409,7 +25457,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L44",
       "id": "getters_evolutiondemonotfounderror",
-      "community": 450
+      "community": 451
     },
     {
       "label": ".constructor()",
@@ -25417,7 +25465,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L45",
       "id": "getters_evolutiondemonotfounderror_constructor",
-      "community": 450
+      "community": 451
     },
     {
       "label": "listEvolutionDemoScenarios()",
@@ -25425,7 +25473,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L55",
       "id": "getters_listevolutiondemoscenarios",
-      "community": 450
+      "community": 451
     },
     {
       "label": "getEvolutionDemoSnapshot()",
@@ -25433,7 +25481,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/getters.ts",
       "source_location": "L61",
       "id": "getters_getevolutiondemosnapshot",
-      "community": 450
+      "community": 451
     },
     {
       "label": "spec.ts",
@@ -25441,7 +25489,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_spec_ts",
-      "community": 1226
+      "community": 1227
     },
     {
       "label": "forgetting-policy.snapshots.ts",
@@ -25449,7 +25497,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/forgetting-policy.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_forgetting_policy_snapshots_ts",
-      "community": 1227
+      "community": 1228
     },
     {
       "label": "answer-over-time.snapshots.ts",
@@ -25457,7 +25505,7 @@
       "source_file": "packages/memento-core/src/domains/evolution-demo/fixtures/answer-over-time.snapshots.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_evolution_demo_fixtures_answer_over_time_snapshots_ts",
-      "community": 1228
+      "community": 1229
     },
     {
       "label": "vector-search.factory.ts",
@@ -25585,7 +25633,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_hybrid_search_factory_spec_ts",
-      "community": 876
+      "community": 877
     },
     {
       "label": "resolveRepoRankingProfile()",
@@ -25593,7 +25641,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/hybrid-search.factory.spec.ts",
       "source_location": "L16",
       "id": "hybrid_search_factory_spec_resolvereporankingprofile",
-      "community": 876
+      "community": 877
     },
     {
       "label": "vector-search.factory.spec.ts",
@@ -25601,7 +25649,7 @@
       "source_file": "packages/memento-core/src/domains/search/factories/__tests__/vector-search.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_factories_tests_vector_search_factory_spec_ts",
-      "community": 1229
+      "community": 1230
     },
     {
       "label": "search-result-combiner.ts",
@@ -25609,7 +25657,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_result_combiner_ts",
-      "community": 541
+      "community": 542
     },
     {
       "label": "SearchResultCombiner",
@@ -25617,7 +25665,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L24",
       "id": "search_result_combiner_searchresultcombiner",
-      "community": 541
+      "community": 542
     },
     {
       "label": ".combine()",
@@ -25625,7 +25673,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L36",
       "id": "search_result_combiner_searchresultcombiner_combine",
-      "community": 541
+      "community": 542
     },
     {
       "label": ".generateHybridReason()",
@@ -25633,7 +25681,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-result-combiner.ts",
       "source_location": "L109",
       "id": "search_result_combiner_searchresultcombiner_generatehybridreason",
-      "community": 541
+      "community": 542
     },
     {
       "label": "hybrid-result-ranker.ts",
@@ -25881,7 +25929,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_adaptive_weight_calculator_ts",
-      "community": 451
+      "community": 452
     },
     {
       "label": "AdaptiveWeightCalculator",
@@ -25889,7 +25937,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L4",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator",
-      "community": 451
+      "community": 452
     },
     {
       "label": ".calculateWeights()",
@@ -25897,7 +25945,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L7",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_calculateweights",
-      "community": 451
+      "community": 452
     },
     {
       "label": ".analyzeQuery()",
@@ -25905,7 +25953,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L57",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_analyzequery",
-      "community": 451
+      "community": 452
     },
     {
       "label": ".normalizeQuery()",
@@ -25913,7 +25961,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/adaptive-weight-calculator.ts",
       "source_location": "L71",
       "id": "adaptive_weight_calculator_adaptiveweightcalculator_normalizequery",
-      "community": 451
+      "community": 452
     },
     {
       "label": "hybrid-vector-search-executor.ts",
@@ -26057,7 +26105,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_provider_parallel_ts",
-      "community": 542
+      "community": 543
     },
     {
       "label": "runSingleProviderVectorSearch()",
@@ -26065,7 +26113,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L75",
       "id": "hybrid_search_provider_parallel_runsingleprovidervectorsearch",
-      "community": 542
+      "community": 543
     },
     {
       "label": "createProviderVectorSearchTask()",
@@ -26073,7 +26121,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L145",
       "id": "hybrid_search_provider_parallel_createprovidervectorsearchtask",
-      "community": 542
+      "community": 543
     },
     {
       "label": "executeProviderSearchesWithOverallTimeout()",
@@ -26081,7 +26129,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-provider-parallel.ts",
       "source_location": "L185",
       "id": "hybrid_search_provider_parallel_executeprovidersearcheswithoveralltimeout",
-      "community": 542
+      "community": 543
     },
     {
       "label": "search-ranking.ts",
@@ -26497,7 +26545,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_outcome_utils_ts",
-      "community": 877
+      "community": 878
     },
     {
       "label": "normalizeSearchBySimilarityOutcome()",
@@ -26505,7 +26553,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-outcome-utils.ts",
       "source_location": "L9",
       "id": "hybrid_search_outcome_utils_normalizesearchbysimilarityoutcome",
-      "community": 877
+      "community": 878
     },
     {
       "label": "vector-search-engine.spec.ts",
@@ -26561,7 +26609,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/hybrid-search-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_hybrid_search_types_ts",
-      "community": 1230
+      "community": 1231
     },
     {
       "label": "search-error.ts",
@@ -26569,7 +26617,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_error_ts",
-      "community": 682
+      "community": 684
     },
     {
       "label": "SearchError",
@@ -26577,7 +26625,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L11",
       "id": "search_error_searcherror",
-      "community": 682
+      "community": 684
     },
     {
       "label": ".constructor()",
@@ -26585,7 +26633,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-error.ts",
       "source_location": "L12",
       "id": "search_error_searcherror_constructor",
-      "community": 682
+      "community": 684
     },
     {
       "label": "search-logger.ts",
@@ -26713,7 +26761,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_process_attribute_fit_ts",
-      "community": 543
+      "community": 544
     },
     {
       "label": "normalize()",
@@ -26721,7 +26769,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L14",
       "id": "process_attribute_fit_normalize",
-      "community": 543
+      "community": 544
     },
     {
       "label": "toSet()",
@@ -26729,7 +26777,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L18",
       "id": "process_attribute_fit_toset",
-      "community": 543
+      "community": 544
     },
     {
       "label": "computeProcessAttributeFit()",
@@ -26737,7 +26785,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/process-attribute-fit.ts",
       "source_location": "L28",
       "id": "process_attribute_fit_computeprocessattributefit",
-      "community": 543
+      "community": 544
     },
     {
       "label": "search-ranking.types.ts",
@@ -26745,7 +26793,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-ranking/search-ranking.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_ranking_search_ranking_types_ts",
-      "community": 1231
+      "community": 1232
     },
     {
       "label": "search-ranking-composite.ts",
@@ -27009,7 +27057,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/procedural-memory-matcher.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_procedural_memory_matcher_spec_ts",
-      "community": 1232
+      "community": 1233
     },
     {
       "label": "search-ranking.spec.ts",
@@ -27017,7 +27065,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_ranking_spec_ts",
-      "community": 1233
+      "community": 1234
     },
     {
       "label": "search-engine-reflection-notes.spec.ts",
@@ -27025,7 +27073,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_reflection_notes_spec_ts",
-      "community": 683
+      "community": 685
     },
     {
       "label": "initializeTestDatabase()",
@@ -27033,7 +27081,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L17",
       "id": "search_engine_reflection_notes_spec_initializetestdatabase",
-      "community": 683
+      "community": 685
     },
     {
       "label": "createValidReflectionNote()",
@@ -27041,7 +27089,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine-reflection-notes.spec.ts",
       "source_location": "L92",
       "id": "search_engine_reflection_notes_spec_createvalidreflectionnote",
-      "community": 683
+      "community": 685
     },
     {
       "label": "hybrid-search-engine.spec.ts",
@@ -27121,7 +27169,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/hybrid-search-engine-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_hybrid_search_engine_consolidation_spec_ts",
-      "community": 1234
+      "community": 1235
     },
     {
       "label": "process-attribute-fit.spec.ts",
@@ -27129,7 +27177,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/process-attribute-fit.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_process_attribute_fit_spec_ts",
-      "community": 1235
+      "community": 1236
     },
     {
       "label": "search-engine.spec.ts",
@@ -27137,7 +27185,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_engine_spec_ts",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createCountingSearchDb()",
@@ -27145,7 +27193,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L11",
       "id": "search_engine_spec_createcountingsearchdb",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createRecoverableSearchDb()",
@@ -27153,7 +27201,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L104",
       "id": "search_engine_spec_createrecoverablesearchdb",
-      "community": 544
+      "community": 545
     },
     {
       "label": "createSearchRows()",
@@ -27161,7 +27209,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-engine.spec.ts",
       "source_location": "L178",
       "id": "search_engine_spec_createsearchrows",
-      "community": 544
+      "community": 545
     },
     {
       "label": "search-result-combiner-consolidation.spec.ts",
@@ -27169,7 +27217,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/__tests__/search-result-combiner-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_tests_search_result_combiner_consolidation_spec_ts",
-      "community": 1236
+      "community": 1237
     },
     {
       "label": "search-engine-ranking.ts",
@@ -27177,7 +27225,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_ranking_ts",
-      "community": 452
+      "community": 453
     },
     {
       "label": "attachBreakdownToDisplayTotal()",
@@ -27185,7 +27233,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L12",
       "id": "search_engine_ranking_attachbreakdowntodisplaytotal",
-      "community": 452
+      "community": 453
     },
     {
       "label": "calculateFactMetadataBoost()",
@@ -27193,7 +27241,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L29",
       "id": "search_engine_ranking_calculatefactmetadataboost",
-      "community": 452
+      "community": 453
     },
     {
       "label": "generateRecallReason()",
@@ -27201,7 +27249,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L38",
       "id": "search_engine_ranking_generaterecallreason",
-      "community": 452
+      "community": 453
     },
     {
       "label": "applyRanking()",
@@ -27209,7 +27257,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-ranking.ts",
       "source_location": "L66",
       "id": "search_engine_ranking_applyranking",
-      "community": 452
+      "community": 453
     },
     {
       "label": "search-engine-fts-query.ts",
@@ -27217,7 +27265,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_fts_query_ts",
-      "community": 545
+      "community": 546
     },
     {
       "label": "buildFTSQuery()",
@@ -27225,7 +27273,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L9",
       "id": "search_engine_fts_query_buildftsquery",
-      "community": 545
+      "community": 546
     },
     {
       "label": "preprocessQuery()",
@@ -27233,7 +27281,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L38",
       "id": "search_engine_fts_query_preprocessquery",
-      "community": 545
+      "community": 546
     },
     {
       "label": "makeFTSSafe()",
@@ -27241,7 +27289,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-fts-query.ts",
       "source_location": "L53",
       "id": "search_engine_fts_query_makeftssafe",
-      "community": 545
+      "community": 546
     },
     {
       "label": "search-engine.types.ts",
@@ -27249,7 +27297,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_types_ts",
-      "community": 1237
+      "community": 1238
     },
     {
       "label": "search-engine-sql-builder.ts",
@@ -27257,7 +27305,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_algorithms_search_engine_search_engine_sql_builder_ts",
-      "community": 878
+      "community": 879
     },
     {
       "label": "buildSearchStatement()",
@@ -27265,7 +27313,7 @@
       "source_file": "packages/memento-core/src/domains/search/algorithms/search-engine/search-engine-sql-builder.ts",
       "source_location": "L7",
       "id": "search_engine_sql_builder_buildsearchstatement",
-      "community": 878
+      "community": 879
     },
     {
       "label": "search-engine-fts-availability.ts",
@@ -27513,7 +27561,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-performance.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_performance_repository_spec_ts",
-      "community": 1238
+      "community": 1239
     },
     {
       "label": "vector-search.repository.spec.ts",
@@ -27521,7 +27569,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_tests_vector_search_repository_spec_ts",
-      "community": 879
+      "community": 880
     },
     {
       "label": "seedScopedHybridMemories()",
@@ -27529,7 +27577,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/__tests__/vector-search.repository.spec.ts",
       "source_location": "L407",
       "id": "vector_search_repository_spec_seedscopedhybridmemories",
-      "community": 879
+      "community": 880
     },
     {
       "label": "vector-search.types.ts",
@@ -27537,7 +27585,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_types_ts",
-      "community": 1239
+      "community": 1240
     },
     {
       "label": "vector-search-result-mapper.ts",
@@ -27593,7 +27641,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_knn_query_ts",
-      "community": 546
+      "community": 547
     },
     {
       "label": "buildScopeParams()",
@@ -27601,7 +27649,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L25",
       "id": "vector_search_knn_query_buildscopeparams",
-      "community": 546
+      "community": 547
     },
     {
       "label": "buildOuterWhereSql()",
@@ -27609,7 +27657,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L38",
       "id": "vector_search_knn_query_buildouterwheresql",
-      "community": 546
+      "community": 547
     },
     {
       "label": "executeKnnQuery()",
@@ -27617,7 +27665,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-knn-query.ts",
       "source_location": "L54",
       "id": "vector_search_knn_query_executeknnquery",
-      "community": 546
+      "community": 547
     },
     {
       "label": "vector-search-runtime-context.ts",
@@ -27689,7 +27737,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_availability_ts",
-      "community": 453
+      "community": 454
     },
     {
       "label": "isVecTableRegistered()",
@@ -27697,7 +27745,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L11",
       "id": "vector_search_availability_isvectableregistered",
-      "community": 453
+      "community": 454
     },
     {
       "label": "checkVecAvailability()",
@@ -27705,7 +27753,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L26",
       "id": "vector_search_availability_checkvecavailability",
-      "community": 453
+      "community": 454
     },
     {
       "label": "getIndexStatus()",
@@ -27713,7 +27761,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L104",
       "id": "vector_search_availability_getindexstatus",
-      "community": 453
+      "community": 454
     },
     {
       "label": "rebuildIndex()",
@@ -27721,7 +27769,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-availability.ts",
       "source_location": "L162",
       "id": "vector_search_availability_rebuildindex",
-      "community": 453
+      "community": 454
     },
     {
       "label": "vector-search-scope.ts",
@@ -27729,7 +27777,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_scope_ts",
-      "community": 880
+      "community": 881
     },
     {
       "label": "parseVectorSearchScope()",
@@ -27737,7 +27785,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-scope.ts",
       "source_location": "L8",
       "id": "vector_search_scope_parsevectorsearchscope",
-      "community": 880
+      "community": 881
     },
     {
       "label": "vector-search-result-mapper.spec.ts",
@@ -27745,7 +27793,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_result_mapper_spec_ts",
-      "community": 881
+      "community": 882
     },
     {
       "label": "rawResult()",
@@ -27753,7 +27801,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-result-mapper.spec.ts",
       "source_location": "L23",
       "id": "vector_search_result_mapper_spec_rawresult",
-      "community": 881
+      "community": 882
     },
     {
       "label": "vector-search-hybrid-query.ts",
@@ -27761,7 +27809,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_repositories_vector_search_vector_search_hybrid_query_ts",
-      "community": 454
+      "community": 455
     },
     {
       "label": "buildScopeParams()",
@@ -27769,7 +27817,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L26",
       "id": "vector_search_hybrid_query_buildscopeparams",
-      "community": 454
+      "community": 455
     },
     {
       "label": "buildItemScopeClause()",
@@ -27777,7 +27825,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L39",
       "id": "vector_search_hybrid_query_builditemscopeclause",
-      "community": 454
+      "community": 455
     },
     {
       "label": "buildItemWhereSql()",
@@ -27785,7 +27833,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L52",
       "id": "vector_search_hybrid_query_builditemwheresql",
-      "community": 454
+      "community": 455
     },
     {
       "label": "executeHybridQuery()",
@@ -27793,7 +27841,7 @@
       "source_file": "packages/memento-core/src/domains/search/repositories/vector-search/vector-search-hybrid-query.ts",
       "source_location": "L68",
       "id": "vector_search_hybrid_query_executehybridquery",
-      "community": 454
+      "community": 455
     },
     {
       "label": "vector-search.service.ts",
@@ -27889,7 +27937,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_performance_tester_spec_ts",
-      "community": 882
+      "community": 883
     },
     {
       "label": "createMockPerformanceRepository()",
@@ -27897,7 +27945,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-performance-tester.spec.ts",
       "source_location": "L11",
       "id": "vector_performance_tester_spec_createmockperformancerepository",
-      "community": 882
+      "community": 883
     },
     {
       "label": "vector-performance-tester.ts",
@@ -27961,7 +28009,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_service_spec_ts",
-      "community": 883
+      "community": 884
     },
     {
       "label": "createMockRepository()",
@@ -27969,7 +28017,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search.service.spec.ts",
       "source_location": "L26",
       "id": "vector_search_service_spec_createmockrepository",
-      "community": 883
+      "community": 884
     },
     {
       "label": "vector-index-manager.ts",
@@ -28233,7 +28281,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_ts",
-      "community": 455
+      "community": 456
     },
     {
       "label": "selectScore()",
@@ -28241,7 +28289,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L8",
       "id": "vector_search_result_normalizer_selectscore",
-      "community": 455
+      "community": 456
     },
     {
       "label": "computeNormalizationRange()",
@@ -28249,7 +28297,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L27",
       "id": "vector_search_result_normalizer_computenormalizationrange",
-      "community": 455
+      "community": 456
     },
     {
       "label": "VectorSearchResultNormalizer",
@@ -28257,7 +28305,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L37",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer",
-      "community": 455
+      "community": 456
     },
     {
       "label": ".normalize()",
@@ -28265,7 +28313,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.ts",
       "source_location": "L38",
       "id": "vector_search_result_normalizer_vectorsearchresultnormalizer_normalize",
-      "community": 455
+      "community": 456
     },
     {
       "label": "vector-search-facade.spec.ts",
@@ -28273,7 +28321,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_facade_spec_ts",
-      "community": 884
+      "community": 885
     },
     {
       "label": "createMockRepositories()",
@@ -28281,7 +28329,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-facade.spec.ts",
       "source_location": "L35",
       "id": "vector_search_facade_spec_createmockrepositories",
-      "community": 884
+      "community": 885
     },
     {
       "label": "vector-search-result-normalizer.spec.ts",
@@ -28289,7 +28337,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-search-result-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_search_result_normalizer_spec_ts",
-      "community": 1240
+      "community": 1241
     },
     {
       "label": "vector-index-manager.spec.ts",
@@ -28297,7 +28345,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_search_services_vector_search_vector_index_manager_spec_ts",
-      "community": 885
+      "community": 886
     },
     {
       "label": "createMockIndexRepository()",
@@ -28305,7 +28353,7 @@
       "source_file": "packages/memento-core/src/domains/search/services/vector-search/vector-index-manager.spec.ts",
       "source_location": "L11",
       "id": "vector_index_manager_spec_createmockindexrepository",
-      "community": 885
+      "community": 886
     },
     {
       "label": "forgetting-event-log.spec.ts",
@@ -28313,7 +28361,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/__tests__/forgetting-event-log.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tests_forgetting_event_log_spec_ts",
-      "community": 1241
+      "community": 1242
     },
     {
       "label": "spaced-repetition.factory.ts",
@@ -28489,7 +28537,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/factories/__tests__/spaced-repetition.factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_factories_tests_spaced_repetition_factory_spec_ts",
-      "community": 1242
+      "community": 1243
     },
     {
       "label": "spaced-repetition-refactored.spec.ts",
@@ -28497,7 +28545,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition-refactored.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_refactored_spec_ts",
-      "community": 1243
+      "community": 1244
     },
     {
       "label": "spaced-repetition.spec.ts",
@@ -28505,7 +28553,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/spaced-repetition.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_spaced_repetition_spec_ts",
-      "community": 1244
+      "community": 1245
     },
     {
       "label": "spaced-repetition.ts",
@@ -28833,7 +28881,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/algorithms/__tests__/forgetting-algorithm.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_algorithms_tests_forgetting_algorithm_spec_ts",
-      "community": 1245
+      "community": 1246
     },
     {
       "label": "forgetting-event-repository.ts",
@@ -28897,7 +28945,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_forgetting_stats_tool_ts",
-      "community": 547
+      "community": 548
     },
     {
       "label": "ForgettingStatsTool",
@@ -28905,7 +28953,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L11",
       "id": "forgetting_stats_tool_forgettingstatstool",
-      "community": 547
+      "community": 548
     },
     {
       "label": ".constructor()",
@@ -28913,7 +28961,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L12",
       "id": "forgetting_stats_tool_forgettingstatstool_constructor",
-      "community": 547
+      "community": 548
     },
     {
       "label": ".handle()",
@@ -28921,7 +28969,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/forgetting-stats-tool.ts",
       "source_location": "L23",
       "id": "forgetting_stats_tool_forgettingstatstool_handle",
-      "community": 547
+      "community": 548
     },
     {
       "label": "forgetting-stats-tool.spec.ts",
@@ -28929,7 +28977,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/tools/__tests__/forgetting-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_tools_tests_forgetting_stats_tool_spec_ts",
-      "community": 1246
+      "community": 1247
     },
     {
       "label": "forgetting-policy-service.ts",
@@ -29065,7 +29113,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/__tests__/forgetting-policy-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_tests_forgetting_policy_service_spec_ts",
-      "community": 1247
+      "community": 1248
     },
     {
       "label": "review-scheduling.service.spec.ts",
@@ -29073,7 +29121,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/review-scheduling.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_review_scheduling_service_spec_ts",
-      "community": 1248
+      "community": 1249
     },
     {
       "label": "priority-calculation.service.ts",
@@ -29953,7 +30001,7 @@
       "source_file": "packages/memento-core/src/domains/forgetting/services/spaced-repetition/interval-calculation.service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_forgetting_services_spaced_repetition_interval_calculation_service_spec_ts",
-      "community": 1249
+      "community": 1250
     },
     {
       "label": "recall-probability.service.ts",
@@ -30057,7 +30105,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_index_ts",
-      "community": 1250
+      "community": 1251
     },
     {
       "label": "telemetry.types.ts",
@@ -30065,7 +30113,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/types/telemetry.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_types_telemetry_types_ts",
-      "community": 1251
+      "community": 1252
     },
     {
       "label": "telemetry-system-metrics-query.ts",
@@ -30073,7 +30121,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_system_metrics_query_ts",
-      "community": 548
+      "community": 549
     },
     {
       "label": "toolBucketFromEvents()",
@@ -30081,7 +30129,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L15",
       "id": "telemetry_system_metrics_query_toolbucketfromevents",
-      "community": 548
+      "community": 549
     },
     {
       "label": "mapJob()",
@@ -30089,7 +30137,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L65",
       "id": "telemetry_system_metrics_query_mapjob",
-      "community": 548
+      "community": 549
     },
     {
       "label": "querySystemMetrics()",
@@ -30097,7 +30145,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-system-metrics-query.ts",
       "source_location": "L81",
       "id": "telemetry_system_metrics_query_querysystemmetrics",
-      "community": 548
+      "community": 549
     },
     {
       "label": "telemetry-feedback-quality-query.ts",
@@ -30105,7 +30153,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_ts",
-      "community": 886
+      "community": 887
     },
     {
       "label": "queryFeedbackQuality()",
@@ -30113,7 +30161,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.ts",
       "source_location": "L6",
       "id": "telemetry_feedback_quality_query_queryfeedbackquality",
-      "community": 886
+      "community": 887
     },
     {
       "label": "telemetry-feedback-quality-query.spec.ts",
@@ -30121,7 +30169,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-feedback-quality-query.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_feedback_quality_query_spec_ts",
-      "community": 1252
+      "community": 1253
     },
     {
       "label": "telemetry-repository.spec.ts",
@@ -30129,7 +30177,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_spec_ts",
-      "community": 887
+      "community": 888
     },
     {
       "label": "openTelemetryDb()",
@@ -30137,7 +30185,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository.spec.ts",
       "source_location": "L7",
       "id": "telemetry_repository_spec_opentelemetrydb",
-      "community": 887
+      "community": 888
     },
     {
       "label": "telemetry-search-quality-query.ts",
@@ -30145,7 +30193,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_search_quality_query_ts",
-      "community": 684
+      "community": 686
     },
     {
       "label": "avgCandidateCountForPeriod()",
@@ -30153,7 +30201,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L11",
       "id": "telemetry_search_quality_query_avgcandidatecountforperiod",
-      "community": 684
+      "community": 686
     },
     {
       "label": "querySearchQuality()",
@@ -30161,7 +30209,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-search-quality-query.ts",
       "source_location": "L37",
       "id": "telemetry_search_quality_query_querysearchquality",
-      "community": 684
+      "community": 686
     },
     {
       "label": "telemetry-repository.ts",
@@ -30289,7 +30337,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_repository_utils_ts",
-      "community": 549
+      "community": 550
     },
     {
       "label": "periodCutoffIso()",
@@ -30297,7 +30345,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L3",
       "id": "telemetry_repository_utils_periodcutoffiso",
-      "community": 549
+      "community": 550
     },
     {
       "label": "rolling24hCutoffIso()",
@@ -30305,7 +30353,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L15",
       "id": "telemetry_repository_utils_rolling24hcutoffiso",
-      "community": 549
+      "community": 550
     },
     {
       "label": "percentile95Sorted()",
@@ -30313,7 +30361,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-repository-utils.ts",
       "source_location": "L22",
       "id": "telemetry_repository_utils_percentile95sorted",
-      "community": 549
+      "community": 550
     },
     {
       "label": "telemetry-memory-quality-query.ts",
@@ -30321,7 +30369,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_repositories_telemetry_memory_quality_query_ts",
-      "community": 685
+      "community": 687
     },
     {
       "label": "queryMemoryQuality()",
@@ -30329,7 +30377,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L8",
       "id": "telemetry_memory_quality_query_querymemoryquality",
-      "community": 685
+      "community": 687
     },
     {
       "label": "queryConsolidationQuality()",
@@ -30337,7 +30385,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/repositories/telemetry-memory-quality-query.ts",
       "source_location": "L82",
       "id": "telemetry_memory_quality_query_queryconsolidationquality",
-      "community": 685
+      "community": 687
     },
     {
       "label": "get-telemetry-summary-tool.spec.ts",
@@ -30393,7 +30441,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_tools_get_telemetry_summary_tool_ts",
-      "community": 550
+      "community": 551
     },
     {
       "label": "GetTelemetrySummaryTool",
@@ -30401,7 +30449,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L26",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool",
-      "community": 550
+      "community": 551
     },
     {
       "label": ".constructor()",
@@ -30409,7 +30457,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L27",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_constructor",
-      "community": 550
+      "community": 551
     },
     {
       "label": ".handle()",
@@ -30417,7 +30465,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/tools/get-telemetry-summary-tool.ts",
       "source_location": "L35",
       "id": "get_telemetry_summary_tool_gettelemetrysummarytool_handle",
-      "community": 550
+      "community": 551
     },
     {
       "label": "audit-hash-chain-service.ts",
@@ -30545,7 +30593,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/audit-hash-chain-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_audit_hash_chain_service_spec_ts",
-      "community": 1253
+      "community": 1254
     },
     {
       "label": "telemetry-service.spec.ts",
@@ -30553,7 +30601,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/telemetry-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_telemetry_service_spec_ts",
-      "community": 1254
+      "community": 1255
     },
     {
       "label": "event-outbox-service.ts",
@@ -30761,7 +30809,7 @@
       "source_file": "packages/memento-core/src/domains/telemetry/services/event-outbox-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_telemetry_services_event_outbox_service_spec_ts",
-      "community": 1255
+      "community": 1256
     },
     {
       "label": "index.ts",
@@ -30769,7 +30817,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_index_ts",
-      "community": 1256
+      "community": 1257
     },
     {
       "label": "knowledge-candidate-extractor.spec.ts",
@@ -30777,7 +30825,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_spec_ts",
-      "community": 1257
+      "community": 1258
     },
     {
       "label": "knowledge-candidate-text-ambiguity.spec.ts",
@@ -30785,7 +30833,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_spec_ts",
-      "community": 1258
+      "community": 1259
     },
     {
       "label": "knowledge-candidate-text-ambiguity.ts",
@@ -30793,7 +30841,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_text_ambiguity_ts",
-      "community": 888
+      "community": 889
     },
     {
       "label": "isAmbiguousUserMessage()",
@@ -30801,7 +30849,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-text-ambiguity.ts",
       "source_location": "L5",
       "id": "knowledge_candidate_text_ambiguity_isambiguoususermessage",
-      "community": 888
+      "community": 889
     },
     {
       "label": "knowledge-candidate-extractor.ts",
@@ -30809,7 +30857,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_extractors_knowledge_candidate_extractor_ts",
-      "community": 551
+      "community": 552
     },
     {
       "label": "baseTags()",
@@ -30817,7 +30865,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L10",
       "id": "knowledge_candidate_extractor_basetags",
-      "community": 551
+      "community": 552
     },
     {
       "label": "pushUnique()",
@@ -30825,7 +30873,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L21",
       "id": "knowledge_candidate_extractor_pushunique",
-      "community": 551
+      "community": 552
     },
     {
       "label": "extractKnowledgeCandidates()",
@@ -30833,7 +30881,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/extractors/knowledge-candidate-extractor.ts",
       "source_location": "L30",
       "id": "knowledge_candidate_extractor_extractknowledgecandidates",
-      "community": 551
+      "community": 552
     },
     {
       "label": "personal-agent-llm-error.ts",
@@ -30841,7 +30889,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_ts",
-      "community": 552
+      "community": 553
     },
     {
       "label": "PersonalAgentLlmError",
@@ -30849,7 +30897,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L12",
       "id": "personal_agent_llm_error_personalagentllmerror",
-      "community": 552
+      "community": 553
     },
     {
       "label": ".constructor()",
@@ -30857,7 +30905,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L15",
       "id": "personal_agent_llm_error_personalagentllmerror_constructor",
-      "community": 552
+      "community": 553
     },
     {
       "label": "isPersonalAgentLlmError()",
@@ -30865,7 +30913,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.ts",
       "source_location": "L22",
       "id": "personal_agent_llm_error_ispersonalagentllmerror",
-      "community": 552
+      "community": 553
     },
     {
       "label": "personal-agent-llm-error.spec.ts",
@@ -30873,7 +30921,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/errors/personal-agent-llm-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_errors_personal_agent_llm_error_spec_ts",
-      "community": 1259
+      "community": 1260
     },
     {
       "label": "llm-port.ts",
@@ -30881,7 +30929,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_llm_port_ts",
-      "community": 1260
+      "community": 1261
     },
     {
       "label": "persistence-port.ts",
@@ -30889,7 +30937,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/persistence-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_persistence_port_ts",
-      "community": 1261
+      "community": 1262
     },
     {
       "label": "context-port.ts",
@@ -30897,7 +30945,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/ports/context-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_ports_context_port_ts",
-      "community": 1262
+      "community": 1263
     },
     {
       "label": "agent-types.ts",
@@ -30905,7 +30953,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/types/agent-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_types_agent_types_ts",
-      "community": 1263
+      "community": 1264
     },
     {
       "label": "personal-agent-llm-env.ts",
@@ -30913,7 +30961,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_ts",
-      "community": 686
+      "community": 688
     },
     {
       "label": "readProviderToken()",
@@ -30921,7 +30969,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L21",
       "id": "personal_agent_llm_env_readprovidertoken",
-      "community": 686
+      "community": 688
     },
     {
       "label": "parsePersonalAgentLlmEnv()",
@@ -30929,7 +30977,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.ts",
       "source_location": "L33",
       "id": "personal_agent_llm_env_parsepersonalagentllmenv",
-      "community": 686
+      "community": 688
     },
     {
       "label": "personal-agent-llm-env.spec.ts",
@@ -30937,7 +30985,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/config/personal-agent-llm-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_config_personal_agent_llm_env_spec_ts",
-      "community": 1264
+      "community": 1265
     },
     {
       "label": "tool-context-remember-persistence-adapter.spec.ts",
@@ -30945,7 +30993,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_spec_ts",
-      "community": 1265
+      "community": 1266
     },
     {
       "label": "tool-context-remember-persistence-adapter.ts",
@@ -30953,7 +31001,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_remember_persistence_adapter_ts",
-      "community": 456
+      "community": 457
     },
     {
       "label": "parseRememberSuccess()",
@@ -30961,7 +31009,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L11",
       "id": "tool_context_remember_persistence_adapter_parseremembersuccess",
-      "community": 456
+      "community": 457
     },
     {
       "label": "ToolContextRememberPersistenceAdapter",
@@ -30969,7 +31017,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L40",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter",
-      "community": 456
+      "community": 457
     },
     {
       "label": ".constructor()",
@@ -30977,7 +31025,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_constructor",
-      "community": 456
+      "community": 457
     },
     {
       "label": ".persistApproved()",
@@ -30985,7 +31033,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-remember-persistence-adapter.ts",
       "source_location": "L45",
       "id": "tool_context_remember_persistence_adapter_toolcontextrememberpersistenceadapter_persistapproved",
-      "community": 456
+      "community": 457
     },
     {
       "label": "openai-chat-llm-adapter.ts",
@@ -30993,7 +31041,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_ts",
-      "community": 553
+      "community": 554
     },
     {
       "label": "OpenAiChatLlmAdapter",
@@ -31001,7 +31049,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L11",
       "id": "openai_chat_llm_adapter_openaichatllmadapter",
-      "community": 553
+      "community": 554
     },
     {
       "label": ".constructor()",
@@ -31009,7 +31057,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_constructor",
-      "community": 553
+      "community": 554
     },
     {
       "label": ".complete()",
@@ -31017,7 +31065,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "openai_chat_llm_adapter_openaichatllmadapter_complete",
-      "community": 553
+      "community": 554
     },
     {
       "label": "openai-chat-llm-adapter.spec.ts",
@@ -31025,7 +31073,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/openai-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_openai_chat_llm_adapter_spec_ts",
-      "community": 1266
+      "community": 1267
     },
     {
       "label": "ollama-chat-llm-adapter.ts",
@@ -31033,7 +31081,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_ts",
-      "community": 554
+      "community": 555
     },
     {
       "label": "OllamaChatLlmAdapter",
@@ -31041,7 +31089,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L15",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".constructor()",
@@ -31049,7 +31097,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L20",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_constructor",
-      "community": 554
+      "community": 555
     },
     {
       "label": ".complete()",
@@ -31057,7 +31105,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.ts",
       "source_location": "L27",
       "id": "ollama_chat_llm_adapter_ollamachatllmadapter_complete",
-      "community": 554
+      "community": 555
     },
     {
       "label": "gemini-chat-llm-adapter.ts",
@@ -31065,7 +31113,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_ts",
-      "community": 555
+      "community": 556
     },
     {
       "label": "GeminiChatLlmAdapter",
@@ -31073,7 +31121,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L10",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".constructor()",
@@ -31081,7 +31129,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L14",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_constructor",
-      "community": 555
+      "community": 556
     },
     {
       "label": ".complete()",
@@ -31089,7 +31137,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.ts",
       "source_location": "L19",
       "id": "gemini_chat_llm_adapter_geminichatllmadapter_complete",
-      "community": 555
+      "community": 556
     },
     {
       "label": "tool-context-knowledge-context-adapter.ts",
@@ -31097,7 +31145,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_tool_context_knowledge_context_adapter_ts",
-      "community": 457
+      "community": 458
     },
     {
       "label": "ToolContextKnowledgeContextAdapter",
@@ -31105,7 +31153,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L14",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter",
-      "community": 457
+      "community": 458
     },
     {
       "label": ".constructor()",
@@ -31113,7 +31161,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L15",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_constructor",
-      "community": 457
+      "community": 458
     },
     {
       "label": ".buildContext()",
@@ -31121,7 +31169,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L17",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_buildcontext",
-      "community": 457
+      "community": 458
     },
     {
       "label": ".proposeCandidates()",
@@ -31129,7 +31177,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/tool-context-knowledge-context-adapter.ts",
       "source_location": "L43",
       "id": "tool_context_knowledge_context_adapter_toolcontextknowledgecontextadapter_proposecandidates",
-      "community": 457
+      "community": 458
     },
     {
       "label": "deterministic-mock-llm-adapter.ts",
@@ -31137,7 +31185,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_ts",
-      "community": 458
+      "community": 459
     },
     {
       "label": "DeterministicMockLlmAdapter",
@@ -31145,7 +31193,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L13",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".constructor()",
@@ -31153,7 +31201,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L17",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_constructor",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".complete()",
@@ -31161,7 +31209,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L22",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_complete",
-      "community": 458
+      "community": 459
     },
     {
       "label": ".createRequestId()",
@@ -31169,7 +31217,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.ts",
       "source_location": "L37",
       "id": "deterministic_mock_llm_adapter_deterministicmockllmadapter_createrequestid",
-      "community": 458
+      "community": 459
     },
     {
       "label": "gemini-chat-llm-adapter.spec.ts",
@@ -31177,7 +31225,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/gemini-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_gemini_chat_llm_adapter_spec_ts",
-      "community": 1267
+      "community": 1268
     },
     {
       "label": "ollama-chat-llm-adapter.spec.ts",
@@ -31185,7 +31233,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/ollama-chat-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_ollama_chat_llm_adapter_spec_ts",
-      "community": 1268
+      "community": 1269
     },
     {
       "label": "deterministic-mock-llm-adapter.spec.ts",
@@ -31193,7 +31241,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/adapters/deterministic-mock-llm-adapter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_adapters_deterministic_mock_llm_adapter_spec_ts",
-      "community": 1269
+      "community": 1270
     },
     {
       "label": "knowledge-candidate-to-remember-params.spec.ts",
@@ -31201,7 +31249,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_spec_ts",
-      "community": 889
+      "community": 890
     },
     {
       "label": "baseCandidate()",
@@ -31209,7 +31257,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.spec.ts",
       "source_location": "L8",
       "id": "knowledge_candidate_to_remember_params_spec_basecandidate",
-      "community": 889
+      "community": 890
     },
     {
       "label": "knowledge-candidate-to-remember-params.ts",
@@ -31217,7 +31265,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_mappers_knowledge_candidate_to_remember_params_ts",
-      "community": 459
+      "community": 460
     },
     {
       "label": "normalizeOwnerId()",
@@ -31225,7 +31273,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L15",
       "id": "knowledge_candidate_to_remember_params_normalizeownerid",
-      "community": 459
+      "community": 460
     },
     {
       "label": "buildProceduralStepsJson()",
@@ -31233,7 +31281,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L22",
       "id": "knowledge_candidate_to_remember_params_buildproceduralstepsjson",
-      "community": 459
+      "community": 460
     },
     {
       "label": "assertUnreachable()",
@@ -31241,7 +31289,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L34",
       "id": "knowledge_candidate_to_remember_params_assertunreachable",
-      "community": 459
+      "community": 460
     },
     {
       "label": "mapKnowledgeCandidateToRememberParams()",
@@ -31249,7 +31297,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/mappers/knowledge-candidate-to-remember-params.ts",
       "source_location": "L42",
       "id": "knowledge_candidate_to_remember_params_mapknowledgecandidatetorememberparams",
-      "community": 459
+      "community": 460
     },
     {
       "label": "create-personal-agent-llm-port.spec.ts",
@@ -31257,7 +31305,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_spec_ts",
-      "community": 1270
+      "community": 1271
     },
     {
       "label": "personal-knowledge-agent-service.spec.ts",
@@ -31265,7 +31313,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_spec_ts",
-      "community": 890
+      "community": 891
     },
     {
       "label": "makeDeps()",
@@ -31273,7 +31321,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.spec.ts",
       "source_location": "L18",
       "id": "personal_knowledge_agent_service_spec_makedeps",
-      "community": 890
+      "community": 891
     },
     {
       "label": "personal-knowledge-agent-service.ts",
@@ -31281,7 +31329,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_personal_knowledge_agent_service_ts",
-      "community": 460
+      "community": 461
     },
     {
       "label": "PersonalKnowledgeAgentService",
@@ -31289,7 +31337,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L20",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".constructor()",
@@ -31297,7 +31345,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L21",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_constructor",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".runOneTurn()",
@@ -31305,7 +31353,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L23",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_runoneturn",
-      "community": 460
+      "community": 461
     },
     {
       "label": ".persistApprovedCandidates()",
@@ -31313,7 +31361,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/personal-knowledge-agent-service.ts",
       "source_location": "L64",
       "id": "personal_knowledge_agent_service_personalknowledgeagentservice_persistapprovedcandidates",
-      "community": 460
+      "community": 461
     },
     {
       "label": "create-personal-agent-llm-port.ts",
@@ -31321,7 +31369,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_personal_agent_services_create_personal_agent_llm_port_ts",
-      "community": 891
+      "community": 892
     },
     {
       "label": "createPersonalAgentLlmPort()",
@@ -31329,7 +31377,7 @@
       "source_file": "packages/memento-core/src/domains/personal-agent/services/create-personal-agent-llm-port.ts",
       "source_location": "L12",
       "id": "create_personal_agent_llm_port_createpersonalagentllmport",
-      "community": 891
+      "community": 892
     },
     {
       "label": "normalize-memory-types-for-item-search.ts",
@@ -31337,7 +31385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_utils_normalize_memory_types_for_item_search_ts",
-      "community": 892
+      "community": 893
     },
     {
       "label": "normalizeMemoryTypesForHybridItemSearch()",
@@ -31345,7 +31393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/utils/normalize-memory-types-for-item-search.ts",
       "source_location": "L7",
       "id": "normalize_memory_types_for_item_search_normalizememorytypesforhybriditemsearch",
-      "community": 892
+      "community": 893
     },
     {
       "label": "core-memory-database.interface.ts",
@@ -31353,7 +31401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-database.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_database_interface_ts",
-      "community": 1271
+      "community": 1272
     },
     {
       "label": "knowledge-vault-repository.interface.ts",
@@ -31361,7 +31409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/knowledge-vault-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_knowledge_vault_repository_interface_ts",
-      "community": 1272
+      "community": 1273
     },
     {
       "label": "feedback-repository.interface.ts",
@@ -31369,7 +31417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_feedback_repository_interface_ts",
-      "community": 893
+      "community": 894
     },
     {
       "label": "sigmoidNormalizedNet()",
@@ -31377,7 +31425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/feedback-repository.interface.ts",
       "source_location": "L9",
       "id": "feedback_repository_interface_sigmoidnormalizednet",
-      "community": 893
+      "community": 894
     },
     {
       "label": "core-memory-repository.interface.ts",
@@ -31385,7 +31433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/core-memory-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_core_memory_repository_interface_ts",
-      "community": 1273
+      "community": 1274
     },
     {
       "label": "kg-triple-repository.interface.ts",
@@ -31393,7 +31441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/kg-triple-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_kg_triple_repository_interface_ts",
-      "community": 1274
+      "community": 1275
     },
     {
       "label": "process-attribute-repository.interface.ts",
@@ -31401,7 +31449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/process-attribute-repository.interface.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_process_attribute_repository_interface_ts",
-      "community": 1275
+      "community": 1276
     },
     {
       "label": "kg-triple-repository.spec.ts",
@@ -31409,7 +31457,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_kg_triple_repository_spec_ts",
-      "community": 894
+      "community": 895
     },
     {
       "label": "createKgTripleTable()",
@@ -31417,7 +31465,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/kg-triple-repository.spec.ts",
       "source_location": "L16",
       "id": "kg_triple_repository_spec_createkgtripletable",
-      "community": 894
+      "community": 895
     },
     {
       "label": "process-attribute-repository.spec.ts",
@@ -31425,7 +31473,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_process_attribute_repository_spec_ts",
-      "community": 895
+      "community": 896
     },
     {
       "label": "createProcessAttributeTable()",
@@ -31433,7 +31481,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/process-attribute-repository.spec.ts",
       "source_location": "L18",
       "id": "process_attribute_repository_spec_createprocessattributetable",
-      "community": 895
+      "community": 896
     },
     {
       "label": "knowledge-vault-repository.spec.ts",
@@ -31441,7 +31489,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_knowledge_vault_repository_spec_ts",
-      "community": 896
+      "community": 897
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -31449,7 +31497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/knowledge-vault-repository.spec.ts",
       "source_location": "L8",
       "id": "knowledge_vault_repository_spec_createknowledgevaulttable",
-      "community": 896
+      "community": 897
     },
     {
       "label": "feedback-repository.spec.ts",
@@ -31457,7 +31505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/feedback-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_feedback_repository_spec_ts",
-      "community": 1276
+      "community": 1277
     },
     {
       "label": "core-memory-repository.spec.ts",
@@ -31465,7 +31513,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_repositories_tests_core_memory_repository_spec_ts",
-      "community": 897
+      "community": 898
     },
     {
       "label": "createCoreMemoryTable()",
@@ -31473,7 +31521,7 @@
       "source_file": "packages/memento-core/src/domains/memory/repositories/__tests__/core-memory-repository.spec.ts",
       "source_location": "L9",
       "id": "core_memory_repository_spec_createcorememorytable",
-      "community": 897
+      "community": 898
     },
     {
       "label": "recall-tool-host.ts",
@@ -31481,7 +31529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_host_ts",
-      "community": 1277
+      "community": 1278
     },
     {
       "label": "remember-tool-memory-item.ts",
@@ -31489,7 +31537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_memory_item_ts",
-      "community": 556
+      "community": 557
     },
     {
       "label": "buildSimilarityWarning()",
@@ -31497,7 +31545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L39",
       "id": "remember_tool_memory_item_buildsimilaritywarning",
-      "community": 556
+      "community": 557
     },
     {
       "label": "persistMemoryItem()",
@@ -31505,7 +31553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L71",
       "id": "remember_tool_memory_item_persistmemoryitem",
-      "community": 556
+      "community": 557
     },
     {
       "label": "handleMemoryItem()",
@@ -31513,7 +31561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-memory-item.ts",
       "source_location": "L195",
       "id": "remember_tool_memory_item_handlememoryitem",
-      "community": 556
+      "community": 557
     },
     {
       "label": "recall-tool-definition.ts",
@@ -31521,7 +31569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-definition.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_definition_ts",
-      "community": 1278
+      "community": 1279
     },
     {
       "label": "remember-tool-schema.ts",
@@ -31529,7 +31577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_schema_ts",
-      "community": 1279
+      "community": 1280
     },
     {
       "label": "remember-tool-reflection.ts",
@@ -31537,7 +31585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_reflection_ts",
-      "community": 461
+      "community": 462
     },
     {
       "label": "validateReflectionNotesJson()",
@@ -31545,7 +31593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L19",
       "id": "remember_tool_reflection_validatereflectionnotesjson",
-      "community": 461
+      "community": 462
     },
     {
       "label": "parseReflectionNotes()",
@@ -31553,7 +31601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L27",
       "id": "remember_tool_reflection_parsereflectionnotes",
-      "community": 461
+      "community": 462
     },
     {
       "label": "getExistingReflectionNotes()",
@@ -31561,7 +31609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L53",
       "id": "remember_tool_reflection_getexistingreflectionnotes",
-      "community": 461
+      "community": 462
     },
     {
       "label": "prepareReflectionNotes()",
@@ -31569,7 +31617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-reflection.ts",
       "source_location": "L82",
       "id": "remember_tool_reflection_preparereflectionnotes",
-      "community": 461
+      "community": 462
     },
     {
       "label": "remember-tool.ts",
@@ -31577,7 +31625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_ts",
-      "community": 557
+      "community": 558
     },
     {
       "label": "RememberTool",
@@ -31585,7 +31633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L27",
       "id": "remember_tool_remembertool",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".constructor()",
@@ -31593,7 +31641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L28",
       "id": "remember_tool_remembertool_constructor",
-      "community": 557
+      "community": 558
     },
     {
       "label": ".handle()",
@@ -31601,7 +31649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool.ts",
       "source_location": "L129",
       "id": "remember_tool_remembertool_handle",
-      "community": 557
+      "community": 558
     },
     {
       "label": "remember-tool-vault.ts",
@@ -31609,7 +31657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_vault_ts",
-      "community": 898
+      "community": 899
     },
     {
       "label": "handleVaultMemory()",
@@ -31617,7 +31665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-vault.ts",
       "source_location": "L20",
       "id": "remember_tool_vault_handlevaultmemory",
-      "community": 898
+      "community": 899
     },
     {
       "label": "recall-tool-validation.ts",
@@ -31625,7 +31673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_validation_ts",
-      "community": 687
+      "community": 689
     },
     {
       "label": "validateRecallQuery()",
@@ -31633,7 +31681,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L7",
       "id": "recall_tool_validation_validaterecallquery",
-      "community": 687
+      "community": 689
     },
     {
       "label": "validateRecallFilters()",
@@ -31641,7 +31689,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-validation.ts",
       "source_location": "L29",
       "id": "recall_tool_validation_validaterecallfilters",
-      "community": 687
+      "community": 689
     },
     {
       "label": "recall-tool-schema.ts",
@@ -31649,7 +31697,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_schema_ts",
-      "community": 899
+      "community": 900
     },
     {
       "label": "normalizeProviderFilter()",
@@ -31657,7 +31705,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-schema.ts",
       "source_location": "L19",
       "id": "recall_tool_schema_normalizeproviderfilter",
-      "community": 899
+      "community": 900
     },
     {
       "label": "remember-tool-db-helpers.ts",
@@ -31665,7 +31713,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_db_helpers_ts",
-      "community": 558
+      "community": 559
     },
     {
       "label": "findExistingProceduralMemory()",
@@ -31673,7 +31721,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L11",
       "id": "remember_tool_db_helpers_findexistingproceduralmemory",
-      "community": 558
+      "community": 559
     },
     {
       "label": "getExistingMemoriesForRelationExtraction()",
@@ -31681,7 +31729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L78",
       "id": "remember_tool_db_helpers_getexistingmemoriesforrelationextraction",
-      "community": 558
+      "community": 559
     },
     {
       "label": "getMemoryById()",
@@ -31689,7 +31737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-db-helpers.ts",
       "source_location": "L119",
       "id": "remember_tool_db_helpers_getmemorybyid",
-      "community": 558
+      "community": 559
     },
     {
       "label": "memory-injection-prompt.ts",
@@ -31697,7 +31745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_memory_injection_prompt_ts",
-      "community": 559
+      "community": 560
     },
     {
       "label": "MemoryInjectionPrompt",
@@ -31705,7 +31753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L30",
       "id": "memory_injection_prompt_memoryinjectionprompt",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".constructor()",
@@ -31713,7 +31761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L31",
       "id": "memory_injection_prompt_memoryinjectionprompt_constructor",
-      "community": 559
+      "community": 560
     },
     {
       "label": ".handle()",
@@ -31721,7 +31769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/memory-injection-prompt.ts",
       "source_location": "L84",
       "id": "memory_injection_prompt_memoryinjectionprompt_handle",
-      "community": 559
+      "community": 560
     },
     {
       "label": "get-memory-neighbors-tool.ts",
@@ -31729,7 +31777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_memory_neighbors_tool_ts",
-      "community": 560
+      "community": 561
     },
     {
       "label": "GetMemoryNeighborsTool",
@@ -31737,7 +31785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L23",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool",
-      "community": 560
+      "community": 561
     },
     {
       "label": ".constructor()",
@@ -31745,7 +31793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L24",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_constructor",
-      "community": 560
+      "community": 561
     },
     {
       "label": ".handle()",
@@ -31753,7 +31801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-memory-neighbors-tool.ts",
       "source_location": "L55",
       "id": "get_memory_neighbors_tool_getmemoryneighborstool_handle",
-      "community": 560
+      "community": 561
     },
     {
       "label": "procedural-rollback-tool.ts",
@@ -31761,7 +31809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_rollback_tool_ts",
-      "community": 561
+      "community": 562
     },
     {
       "label": "ProceduralRollbackTool",
@@ -31769,7 +31817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L9",
       "id": "procedural_rollback_tool_proceduralrollbacktool",
-      "community": 561
+      "community": 562
     },
     {
       "label": ".constructor()",
@@ -31777,7 +31825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_proceduralrollbacktool_constructor",
-      "community": 561
+      "community": 562
     },
     {
       "label": ".handle()",
@@ -31785,7 +31833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-rollback-tool.ts",
       "source_location": "L36",
       "id": "procedural_rollback_tool_proceduralrollbacktool_handle",
-      "community": 561
+      "community": 562
     },
     {
       "label": "feedback-tool.ts",
@@ -31849,7 +31897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_cleanup_memory_tool_ts",
-      "community": 562
+      "community": 563
     },
     {
       "label": "CleanupMemoryTool",
@@ -31857,7 +31905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L14",
       "id": "cleanup_memory_tool_cleanupmemorytool",
-      "community": 562
+      "community": 563
     },
     {
       "label": ".constructor()",
@@ -31865,7 +31913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L15",
       "id": "cleanup_memory_tool_cleanupmemorytool_constructor",
-      "community": 562
+      "community": 563
     },
     {
       "label": ".handle()",
@@ -31873,7 +31921,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/cleanup-memory-tool.ts",
       "source_location": "L32",
       "id": "cleanup_memory_tool_cleanupmemorytool_handle",
-      "community": 562
+      "community": 563
     },
     {
       "label": "recall-tool-filters.ts",
@@ -31881,7 +31929,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_filters_ts",
-      "community": 688
+      "community": 690
     },
     {
       "label": "filterRecallItemsByTriggerConditions()",
@@ -31889,7 +31937,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L14",
       "id": "recall_tool_filters_filterrecallitemsbytriggerconditions",
-      "community": 688
+      "community": 690
     },
     {
       "label": "getAppliedRecallFilters()",
@@ -31897,7 +31945,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-filters.ts",
       "source_location": "L104",
       "id": "recall_tool_filters_getappliedrecallfilters",
-      "community": 688
+      "community": 690
     },
     {
       "label": "convert-episodic-to-semantic-tool.ts",
@@ -32001,7 +32049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-host.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_host_ts",
-      "community": 1280
+      "community": 1281
     },
     {
       "label": "recall-tool-search-execution.ts",
@@ -32009,7 +32057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_search_execution_ts",
-      "community": 900
+      "community": 901
     },
     {
       "label": "executeHybridOrTextSearchForMemoryItem()",
@@ -32017,7 +32065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-search-execution.ts",
       "source_location": "L19",
       "id": "recall_tool_search_execution_executehybridortextsearchformemoryitem",
-      "community": 900
+      "community": 901
     },
     {
       "label": "pin-tool.ts",
@@ -32193,7 +32241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_neighbors_fetch_ts",
-      "community": 901
+      "community": 902
     },
     {
       "label": "handleIncludeNeighbors()",
@@ -32201,7 +32249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-neighbors-fetch.ts",
       "source_location": "L16",
       "id": "recall_tool_neighbors_fetch_handleincludeneighbors",
-      "community": 901
+      "community": 902
     },
     {
       "label": "recall-tool-anchor-rotation.ts",
@@ -32209,7 +32257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_anchor_rotation_ts",
-      "community": 902
+      "community": 903
     },
     {
       "label": "handleAutoSetAnchor()",
@@ -32217,7 +32265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-anchor-rotation.ts",
       "source_location": "L12",
       "id": "recall_tool_anchor_rotation_handleautosetanchor",
-      "community": 902
+      "community": 903
     },
     {
       "label": "procedural-diff-tool.ts",
@@ -32225,7 +32273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_procedural_diff_tool_ts",
-      "community": 563
+      "community": 564
     },
     {
       "label": "ProceduralDiffTool",
@@ -32233,7 +32281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L9",
       "id": "procedural_diff_tool_proceduraldifftool",
-      "community": 563
+      "community": 564
     },
     {
       "label": ".constructor()",
@@ -32241,7 +32289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_proceduraldifftool_constructor",
-      "community": 563
+      "community": 564
     },
     {
       "label": ".handle()",
@@ -32249,7 +32297,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/procedural-diff-tool.ts",
       "source_location": "L36",
       "id": "procedural_diff_tool_proceduraldifftool_handle",
-      "community": 563
+      "community": 564
     },
     {
       "label": "remember-tool-types.ts",
@@ -32257,7 +32305,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_types_ts",
-      "community": 1281
+      "community": 1282
     },
     {
       "label": "recall-tool-direct.ts",
@@ -32265,7 +32313,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_direct_ts",
-      "community": 689
+      "community": 691
     },
     {
       "label": "recallCoreMemoryDirect()",
@@ -32273,7 +32321,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L13",
       "id": "recall_tool_direct_recallcorememorydirect",
-      "community": 689
+      "community": 691
     },
     {
       "label": "recallVaultMemoryDirect()",
@@ -32281,7 +32329,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-direct.ts",
       "source_location": "L67",
       "id": "recall_tool_direct_recallvaultmemorydirect",
-      "community": 689
+      "community": 691
     },
     {
       "label": "unpin-tool.ts",
@@ -32481,7 +32529,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_get_introspection_summary_tool_ts",
-      "community": 564
+      "community": 565
     },
     {
       "label": "GetIntrospectionSummaryTool",
@@ -32489,7 +32537,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L13",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".constructor()",
@@ -32497,7 +32545,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L14",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_constructor",
-      "community": 564
+      "community": 565
     },
     {
       "label": ".handle()",
@@ -32505,7 +32553,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/get-introspection-summary-tool.ts",
       "source_location": "L22",
       "id": "get_introspection_summary_tool_getintrospectionsummarytool_handle",
-      "community": 564
+      "community": 565
     },
     {
       "label": "remember-procedure-tool.ts",
@@ -32513,7 +32561,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_procedure_tool_ts",
-      "community": 565
+      "community": 566
     },
     {
       "label": "RememberProcedureTool",
@@ -32521,7 +32569,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L34",
       "id": "remember_procedure_tool_rememberproceduretool",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".constructor()",
@@ -32529,7 +32577,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L37",
       "id": "remember_procedure_tool_rememberproceduretool_constructor",
-      "community": 565
+      "community": 566
     },
     {
       "label": ".handle()",
@@ -32537,7 +32585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-procedure-tool.ts",
       "source_location": "L96",
       "id": "remember_procedure_tool_rememberproceduretool_handle",
-      "community": 565
+      "community": 566
     },
     {
       "label": "recall-tool-envelope.ts",
@@ -32545,7 +32593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_envelope_ts",
-      "community": 690
+      "community": 692
     },
     {
       "label": "getMetaStatsForResults()",
@@ -32553,7 +32601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L35",
       "id": "recall_tool_envelope_getmetastatsforresults",
-      "community": 690
+      "community": 692
     },
     {
       "label": "finalizeMemoryItemRecallEnvelope()",
@@ -32561,7 +32609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-envelope.ts",
       "source_location": "L79",
       "id": "recall_tool_envelope_finalizememoryitemrecallenvelope",
-      "community": 690
+      "community": 692
     },
     {
       "label": "recall-tool-telemetry.ts",
@@ -32569,7 +32617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_telemetry_ts",
-      "community": 462
+      "community": 463
     },
     {
       "label": "recallTelemetryRetrievalStrategy()",
@@ -32577,7 +32625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L12",
       "id": "recall_tool_telemetry_recalltelemetryretrievalstrategy",
-      "community": 462
+      "community": 463
     },
     {
       "label": "recallSearchRequestedExtra()",
@@ -32585,7 +32633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L24",
       "id": "recall_tool_telemetry_recallsearchrequestedextra",
-      "community": 462
+      "community": 463
     },
     {
       "label": "recallQueryCorrelationExtra()",
@@ -32593,7 +32641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L42",
       "id": "recall_tool_telemetry_recallquerycorrelationextra",
-      "community": 462
+      "community": 463
     },
     {
       "label": "buildQueryEmbeddingMetadataFields()",
@@ -32601,7 +32649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-telemetry.ts",
       "source_location": "L51",
       "id": "recall_tool_telemetry_buildqueryembeddingmetadatafields",
-      "community": 462
+      "community": 463
     },
     {
       "label": "export-memories-tool.ts",
@@ -32681,7 +32729,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_results_ts",
-      "community": 903
+      "community": 904
     },
     {
       "label": "mapRecallSearchItemsToResultItems()",
@@ -32689,7 +32737,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-results.ts",
       "source_location": "L12",
       "id": "recall_tool_results_maprecallsearchitemstoresultitems",
-      "community": 903
+      "community": 904
     },
     {
       "label": "recall-tool.ts",
@@ -32761,7 +32809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/recall-tool-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_recall_tool_types_ts",
-      "community": 1282
+      "community": 1283
     },
     {
       "label": "forget-tool.ts",
@@ -32905,7 +32953,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_remember_tool_core_ts",
-      "community": 904
+      "community": 905
     },
     {
       "label": "handleCoreMemory()",
@@ -32913,7 +32961,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/remember-tool-core.ts",
       "source_location": "L19",
       "id": "remember_tool_core_handlecorememory",
-      "community": 904
+      "community": 905
     },
     {
       "label": "recall-tool-anchor-rotation.spec.ts",
@@ -32921,7 +32969,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_anchor_rotation_spec_ts",
-      "community": 905
+      "community": 906
     },
     {
       "label": "createAnchorTable()",
@@ -32929,7 +32977,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool-anchor-rotation.spec.ts",
       "source_location": "L10",
       "id": "recall_tool_anchor_rotation_spec_createanchortable",
-      "community": 905
+      "community": 906
     },
     {
       "label": "procedural-diff-tool.spec.ts",
@@ -32937,7 +32985,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_diff_tool_spec_ts",
-      "community": 906
+      "community": 907
     },
     {
       "label": "createSchema()",
@@ -32945,7 +32993,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-diff-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_diff_tool_spec_createschema",
-      "community": 906
+      "community": 907
     },
     {
       "label": "get-memory-neighbors-tool.spec.ts",
@@ -32953,7 +33001,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-memory-neighbors-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_memory_neighbors_tool_spec_ts",
-      "community": 1283
+      "community": 1284
     },
     {
       "label": "remember-tool.spec.ts",
@@ -32961,7 +33009,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_spec_ts",
-      "community": 691
+      "community": 693
     },
     {
       "label": "initializeTestDatabase()",
@@ -32969,7 +33017,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L19",
       "id": "remember_tool_spec_initializetestdatabase",
-      "community": 691
+      "community": 693
     },
     {
       "label": "createValidReflectionNote()",
@@ -32977,7 +33025,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool.spec.ts",
       "source_location": "L848",
       "id": "remember_tool_spec_createvalidreflectionnote",
-      "community": 691
+      "community": 693
     },
     {
       "label": "remember-tool-relation-persist.spec.ts",
@@ -32985,7 +33033,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_persist_spec_ts",
-      "community": 692
+      "community": 694
     },
     {
       "label": "initializeSchema()",
@@ -32993,7 +33041,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
       "source_location": "L12",
       "id": "remember_tool_relation_persist_spec_initializeschema",
-      "community": 692
+      "community": 694
     },
     {
       "label": "createHost()",
@@ -33001,7 +33049,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-persist.spec.ts",
       "source_location": "L44",
       "id": "remember_tool_relation_persist_spec_createhost",
-      "community": 692
+      "community": 694
     },
     {
       "label": "telemetry-instrumentation.integration.spec.ts",
@@ -33009,7 +33057,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/telemetry-instrumentation.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_telemetry_instrumentation_integration_spec_ts",
-      "community": 1284
+      "community": 1285
     },
     {
       "label": "procedural-rollback-tool.spec.ts",
@@ -33017,7 +33065,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_procedural_rollback_tool_spec_ts",
-      "community": 907
+      "community": 908
     },
     {
       "label": "createSchema()",
@@ -33025,7 +33073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/procedural-rollback-tool.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_tool_spec_createschema",
-      "community": 907
+      "community": 908
     },
     {
       "label": "export-memories-tool.spec.ts",
@@ -33033,7 +33081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_export_memories_tool_spec_ts",
-      "community": 908
+      "community": 909
     },
     {
       "label": "initializeTestDatabase()",
@@ -33041,7 +33089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/export-memories-tool.spec.ts",
       "source_location": "L6",
       "id": "export_memories_tool_spec_initializetestdatabase",
-      "community": 908
+      "community": 909
     },
     {
       "label": "convert-episodic-to-semantic-tool.spec.ts",
@@ -33049,7 +33097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_convert_episodic_to_semantic_tool_spec_ts",
-      "community": 566
+      "community": 567
     },
     {
       "label": "generateId()",
@@ -33057,7 +33105,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L18",
       "id": "convert_episodic_to_semantic_tool_spec_generateid",
-      "community": 566
+      "community": 567
     },
     {
       "label": "initializeTestDatabase()",
@@ -33065,7 +33113,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L27",
       "id": "convert_episodic_to_semantic_tool_spec_initializetestdatabase",
-      "community": 566
+      "community": 567
     },
     {
       "label": "createTestEpisodicMemory()",
@@ -33073,7 +33121,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/convert-episodic-to-semantic-tool.spec.ts",
       "source_location": "L100",
       "id": "convert_episodic_to_semantic_tool_spec_createtestepisodicmemory",
-      "community": 566
+      "community": 567
     },
     {
       "label": "forget-tool.spec.ts",
@@ -33081,7 +33129,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/forget-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_forget_tool_spec_ts",
-      "community": 1285
+      "community": 1286
     },
     {
       "label": "cleanup-memory-tool.spec.ts",
@@ -33089,7 +33137,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/cleanup-memory-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_cleanup_memory_tool_spec_ts",
-      "community": 1286
+      "community": 1287
     },
     {
       "label": "remember-procedure-tool.spec.ts",
@@ -33097,7 +33145,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_procedure_tool_spec_ts",
-      "community": 909
+      "community": 910
     },
     {
       "label": "initializeTestDatabase()",
@@ -33105,7 +33153,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-procedure-tool.spec.ts",
       "source_location": "L18",
       "id": "remember_procedure_tool_spec_initializetestdatabase",
-      "community": 909
+      "community": 910
     },
     {
       "label": "feedback-tool.spec.ts",
@@ -33113,7 +33161,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_feedback_tool_spec_ts",
-      "community": 910
+      "community": 911
     },
     {
       "label": "parseData()",
@@ -33121,7 +33169,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/feedback-tool.spec.ts",
       "source_location": "L7",
       "id": "feedback_tool_spec_parsedata",
-      "community": 910
+      "community": 911
     },
     {
       "label": "get-introspection-summary-tool.spec.ts",
@@ -33129,7 +33177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/get-introspection-summary-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_get_introspection_summary_tool_spec_ts",
-      "community": 1287
+      "community": 1288
     },
     {
       "label": "recall-tool.spec.ts",
@@ -33137,7 +33185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_recall_tool_spec_ts",
-      "community": 693
+      "community": 695
     },
     {
       "label": "initializeTestDatabase()",
@@ -33145,7 +33193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L18",
       "id": "recall_tool_spec_initializetestdatabase",
-      "community": 693
+      "community": 695
     },
     {
       "label": "createValidReflectionNote()",
@@ -33153,7 +33201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/recall-tool.spec.ts",
       "source_location": "L1508",
       "id": "recall_tool_spec_createvalidreflectionnote",
-      "community": 693
+      "community": 695
     },
     {
       "label": "memory-injection-prompt.spec.ts",
@@ -33161,7 +33209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/memory-injection-prompt.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_memory_injection_prompt_spec_ts",
-      "community": 1288
+      "community": 1289
     },
     {
       "label": "remember-tool-relation-load.spec.ts",
@@ -33169,7 +33217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_remember_tool_relation_load_spec_ts",
-      "community": 694
+      "community": 696
     },
     {
       "label": "initializeProductionLikeSchema()",
@@ -33177,7 +33225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L15",
       "id": "remember_tool_relation_load_spec_initializeproductionlikeschema",
-      "community": 694
+      "community": 696
     },
     {
       "label": "createHost()",
@@ -33185,7 +33233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/remember-tool-relation-load.spec.ts",
       "source_location": "L33",
       "id": "remember_tool_relation_load_spec_createhost",
-      "community": 694
+      "community": 696
     },
     {
       "label": "unpin-tool.spec.ts",
@@ -33193,7 +33241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/unpin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_unpin_tool_spec_ts",
-      "community": 1289
+      "community": 1290
     },
     {
       "label": "pin-tool.spec.ts",
@@ -33201,7 +33249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/tools/__tests__/pin-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_tools_tests_pin_tool_spec_ts",
-      "community": 1290
+      "community": 1291
     },
     {
       "label": "meta-memory-service.ts",
@@ -33329,7 +33377,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_memory_diff_ts",
-      "community": 567
+      "community": 568
     },
     {
       "label": "fieldDiff()",
@@ -33337,7 +33385,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L16",
       "id": "procedural_memory_diff_fielddiff",
-      "community": 567
+      "community": 568
     },
     {
       "label": "parseStepsJson()",
@@ -33345,7 +33393,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L22",
       "id": "procedural_memory_diff_parsestepsjson",
-      "community": 567
+      "community": 568
     },
     {
       "label": "computeProceduralDiff()",
@@ -33353,7 +33401,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-memory-diff.ts",
       "source_location": "L38",
       "id": "procedural_memory_diff_computeproceduraldiff",
-      "community": 567
+      "community": 568
     },
     {
       "label": "memory-review-candidate-persistence-error.ts",
@@ -33361,7 +33409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_error_ts",
-      "community": 463
+      "community": 464
     },
     {
       "label": "MemoryReviewCandidateError",
@@ -33369,7 +33417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L6",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".constructor()",
@@ -33377,7 +33425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L11",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_constructor",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".notFound()",
@@ -33385,7 +33433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L18",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notfound",
-      "community": 463
+      "community": 464
     },
     {
       "label": ".notActionable()",
@@ -33393,7 +33441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-error.ts",
       "source_location": "L26",
       "id": "memory_review_candidate_persistence_error_memoryreviewcandidateerror_notactionable",
-      "community": 463
+      "community": 464
     },
     {
       "label": "memory-review-candidate-selection-env.ts",
@@ -33449,7 +33497,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_service_spec_ts",
-      "community": 911
+      "community": 912
     },
     {
       "label": "createBaseSchema()",
@@ -33457,7 +33505,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence-service.spec.ts",
       "source_location": "L24",
       "id": "memory_review_candidate_persistence_service_spec_createbaseschema",
-      "community": 911
+      "community": 912
     },
     {
       "label": "procedural-llm-extractor.ts",
@@ -33537,7 +33585,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_scoring_spec_ts",
-      "community": 912
+      "community": 913
     },
     {
       "label": "baseRow()",
@@ -33545,7 +33593,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-scoring.spec.ts",
       "source_location": "L16",
       "id": "memory_review_candidate_selection_scoring_spec_baserow",
-      "community": 912
+      "community": 913
     },
     {
       "label": "procedural-versioning.ts",
@@ -33553,7 +33601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_versioning_ts",
-      "community": 568
+      "community": 569
     },
     {
       "label": "getVersionChain()",
@@ -33561,7 +33609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L16",
       "id": "procedural_versioning_getversionchain",
-      "community": 568
+      "community": 569
     },
     {
       "label": "getLatestVersionInSeries()",
@@ -33569,7 +33617,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L53",
       "id": "procedural_versioning_getlatestversioninseries",
-      "community": 568
+      "community": 569
     },
     {
       "label": "getNextVersionNumber()",
@@ -33577,7 +33625,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-versioning.ts",
       "source_location": "L74",
       "id": "procedural_versioning_getnextversionnumber",
-      "community": 568
+      "community": 569
     },
     {
       "label": "meta-memory-introspection-service.ts",
@@ -33585,7 +33633,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_introspection_service_ts",
-      "community": 695
+      "community": 697
     },
     {
       "label": "MetaMemoryIntrospectionService",
@@ -33593,7 +33641,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L39",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice",
-      "community": 695
+      "community": 697
     },
     {
       "label": ".runScan()",
@@ -33601,7 +33649,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-introspection-service.ts",
       "source_location": "L47",
       "id": "meta_memory_introspection_service_metamemoryintrospectionservice_runscan",
-      "community": 695
+      "community": 697
     },
     {
       "label": "procedural-rollback-service.ts",
@@ -33609,7 +33657,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_procedural_rollback_service_ts",
-      "community": 696
+      "community": 698
     },
     {
       "label": "generateMemoryId()",
@@ -33617,7 +33665,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_generatememoryid",
-      "community": 696
+      "community": 698
     },
     {
       "label": "rollbackToVersion()",
@@ -33625,7 +33673,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/procedural-rollback-service.ts",
       "source_location": "L20",
       "id": "procedural_rollback_service_rollbacktoversion",
-      "community": 696
+      "community": 698
     },
     {
       "label": "memory-neighbor-service.ts",
@@ -33697,7 +33745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_ts",
-      "community": 697
+      "community": 699
     },
     {
       "label": "selectionWindowLimit()",
@@ -33705,7 +33753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L47",
       "id": "memory_review_candidate_selection_service_selectionwindowlimit",
-      "community": 697
+      "community": 699
     },
     {
       "label": "selectMemoryReviewCandidates()",
@@ -33713,7 +33761,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.ts",
       "source_location": "L51",
       "id": "memory_review_candidate_selection_service_selectmemoryreviewcandidates",
-      "community": 697
+      "community": 699
     },
     {
       "label": "introspection-scan-cache.ts",
@@ -33721,7 +33769,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_introspection_scan_cache_ts",
-      "community": 464
+      "community": 465
     },
     {
       "label": "IntrospectionScanCache",
@@ -33729,7 +33777,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L16",
       "id": "introspection_scan_cache_introspectionscancache",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".set()",
@@ -33737,7 +33785,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L19",
       "id": "introspection_scan_cache_introspectionscancache_set",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".get()",
@@ -33745,7 +33793,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L23",
       "id": "introspection_scan_cache_introspectionscancache_get",
-      "community": 464
+      "community": 465
     },
     {
       "label": ".clear()",
@@ -33753,7 +33801,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/introspection-scan-cache.ts",
       "source_location": "L27",
       "id": "introspection_scan_cache_introspectionscancache_clear",
-      "community": 464
+      "community": 465
     },
     {
       "label": "memory-review-queue-health-service.spec.ts",
@@ -33761,7 +33809,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-queue-health-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_queue_health_service_spec_ts",
-      "community": 1291
+      "community": 1292
     },
     {
       "label": "repetition-meta-update-service.ts",
@@ -33769,7 +33817,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_repetition_meta_update_service_ts",
-      "community": 913
+      "community": 914
     },
     {
       "label": "updateRepresentativeRepetitionMeta()",
@@ -33777,7 +33825,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/repetition-meta-update-service.ts",
       "source_location": "L33",
       "id": "repetition_meta_update_service_updaterepresentativerepetitionmeta",
-      "community": 913
+      "community": 914
     },
     {
       "label": "admin-memory-item-preview-service.spec.ts",
@@ -33785,7 +33833,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_spec_ts",
-      "community": 914
+      "community": 915
     },
     {
       "label": "openDb()",
@@ -33793,7 +33841,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.spec.ts",
       "source_location": "L8",
       "id": "admin_memory_item_preview_service_spec_opendb",
-      "community": 914
+      "community": 915
     },
     {
       "label": "knowledge-vault-service.ts",
@@ -34553,7 +34601,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_service_spec_ts",
-      "community": 915
+      "community": 916
     },
     {
       "label": "createBaseSchema()",
@@ -34561,7 +34609,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-service.spec.ts",
       "source_location": "L13",
       "id": "memory_review_candidate_selection_service_spec_createbaseschema",
-      "community": 915
+      "community": 916
     },
     {
       "label": "knowledge-context-bundle-builder.ts",
@@ -34825,7 +34873,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-persistence.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_persistence_types_ts",
-      "community": 1292
+      "community": 1293
     },
     {
       "label": "admin-memory-item-preview-service.ts",
@@ -34833,7 +34881,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_admin_memory_item_preview_service_ts",
-      "community": 698
+      "community": 700
     },
     {
       "label": "parseAdminMemoryItemIdParam()",
@@ -34841,7 +34889,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L22",
       "id": "admin_memory_item_preview_service_parseadminmemoryitemidparam",
-      "community": 698
+      "community": 700
     },
     {
       "label": "getAdminMemoryItemPreviewById()",
@@ -34849,7 +34897,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/admin-memory-item-preview-service.ts",
       "source_location": "L33",
       "id": "admin_memory_item_preview_service_getadminmemoryitempreviewbyid",
-      "community": 698
+      "community": 700
     },
     {
       "label": "memory-review-candidate-selection.types.ts",
@@ -34857,7 +34905,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection.types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_types_ts",
-      "community": 1293
+      "community": 1294
     },
     {
       "label": "memory-review-candidate-selection-env.spec.ts",
@@ -34865,7 +34913,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/memory-review-candidate-selection-env.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_memory_review_candidate_selection_env_spec_ts",
-      "community": 1294
+      "community": 1295
     },
     {
       "label": "core-memory-service.ts",
@@ -35025,7 +35073,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_meta_memory_service_spec_ts",
-      "community": 916
+      "community": 917
     },
     {
       "label": "createBaseSchema()",
@@ -35033,7 +35081,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/meta-memory-service.spec.ts",
       "source_location": "L15",
       "id": "meta_memory_service_spec_createbaseschema",
-      "community": 916
+      "community": 917
     },
     {
       "label": "knowledge-vault-service.spec.ts",
@@ -35041,7 +35089,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_vault_service_spec_ts",
-      "community": 917
+      "community": 918
     },
     {
       "label": "createKnowledgeVaultTable()",
@@ -35049,7 +35097,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-vault-service.spec.ts",
       "source_location": "L9",
       "id": "knowledge_vault_service_spec_createknowledgevaulttable",
-      "community": 917
+      "community": 918
     },
     {
       "label": "memory-embedding-service.integration.spec.ts",
@@ -35129,7 +35177,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-llm-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_llm_extractor_spec_ts",
-      "community": 1295
+      "community": 1296
     },
     {
       "label": "introspection-scan-cache.spec.ts",
@@ -35137,7 +35185,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/introspection-scan-cache.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_introspection_scan_cache_spec_ts",
-      "community": 1296
+      "community": 1297
     },
     {
       "label": "procedural-rollback-service.spec.ts",
@@ -35145,7 +35193,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_rollback_service_spec_ts",
-      "community": 918
+      "community": 919
     },
     {
       "label": "createSchema()",
@@ -35153,7 +35201,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-rollback-service.spec.ts",
       "source_location": "L10",
       "id": "procedural_rollback_service_spec_createschema",
-      "community": 918
+      "community": 919
     },
     {
       "label": "repetition-meta-update-service.spec.ts",
@@ -35161,7 +35209,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/repetition-meta-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_repetition_meta_update_service_spec_ts",
-      "community": 1297
+      "community": 1298
     },
     {
       "label": "procedural-versioning.spec.ts",
@@ -35169,7 +35217,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_versioning_spec_ts",
-      "community": 919
+      "community": 920
     },
     {
       "label": "createSchema()",
@@ -35177,7 +35225,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-versioning.spec.ts",
       "source_location": "L14",
       "id": "procedural_versioning_spec_createschema",
-      "community": 919
+      "community": 920
     },
     {
       "label": "knowledge-context-bundle-builder.spec.ts",
@@ -35185,7 +35233,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/knowledge-context-bundle-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_knowledge_context_bundle_builder_spec_ts",
-      "community": 1298
+      "community": 1299
     },
     {
       "label": "meta-memory-introspection-service.spec.ts",
@@ -35193,7 +35241,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_meta_memory_introspection_service_spec_ts",
-      "community": 920
+      "community": 921
     },
     {
       "label": "createBaseSchema()",
@@ -35201,7 +35249,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/meta-memory-introspection-service.spec.ts",
       "source_location": "L13",
       "id": "meta_memory_introspection_service_spec_createbaseschema",
-      "community": 920
+      "community": 921
     },
     {
       "label": "memory-neighbor-service.spec.ts",
@@ -35209,7 +35257,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-neighbor-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_neighbor_service_spec_ts",
-      "community": 1299
+      "community": 1300
     },
     {
       "label": "procedural-memory-diff.spec.ts",
@@ -35217,7 +35265,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_procedural_memory_diff_spec_ts",
-      "community": 921
+      "community": 922
     },
     {
       "label": "createSchema()",
@@ -35225,7 +35273,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/procedural-memory-diff.spec.ts",
       "source_location": "L10",
       "id": "procedural_memory_diff_spec_createschema",
-      "community": 921
+      "community": 922
     },
     {
       "label": "memory-embedding-service.spec.ts",
@@ -35233,7 +35281,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/memory-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_memory_embedding_service_spec_ts",
-      "community": 1300
+      "community": 1301
     },
     {
       "label": "core-memory-cache-service.spec.ts",
@@ -35241,7 +35289,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/__tests__/core-memory-cache-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_tests_core_memory_cache_service_spec_ts",
-      "community": 1301
+      "community": 1302
     },
     {
       "label": "core-memory-service.spec.ts",
@@ -35361,7 +35409,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_service_spec_ts",
-      "community": 1302
+      "community": 1303
     },
     {
       "label": "semantic-memory-crud.ts",
@@ -35369,7 +35417,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_crud_ts",
-      "community": 465
+      "community": 466
     },
     {
       "label": "SemanticMemoryCrud",
@@ -35377,7 +35425,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L16",
       "id": "semantic_memory_crud_semanticmemorycrud",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".constructor()",
@@ -35385,7 +35433,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L17",
       "id": "semantic_memory_crud_semanticmemorycrud_constructor",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".createSemanticMemory()",
@@ -35393,7 +35441,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L23",
       "id": "semantic_memory_crud_semanticmemorycrud_createsemanticmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": ".updateExistingSemanticMemory()",
@@ -35401,7 +35449,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-crud.ts",
       "source_location": "L79",
       "id": "semantic_memory_crud_semanticmemorycrud_updateexistingsemanticmemory",
-      "community": 465
+      "community": 466
     },
     {
       "label": "semantic-memory-update-pipeline.ts",
@@ -35697,7 +35745,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_memory_services_semantic_memory_semantic_memory_update_types_ts",
-      "community": 922
+      "community": 923
     },
     {
       "label": "generateSemanticMemoryId()",
@@ -35705,7 +35753,7 @@
       "source_file": "packages/memento-core/src/domains/memory/services/semantic-memory/semantic-memory-update-types.ts",
       "source_location": "L14",
       "id": "semantic_memory_update_types_generatesemanticmemoryid",
-      "community": 922
+      "community": 923
     },
     {
       "label": "semantic-memory-update-service.ts",
@@ -35761,7 +35809,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/index.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_index_ts",
-      "community": 1303
+      "community": 1304
     },
     {
       "label": "consolidation-test-schema.ts",
@@ -35769,7 +35817,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_tests_consolidation_test_schema_ts",
-      "community": 923
+      "community": 924
     },
     {
       "label": "applyConsolidationTestSchema()",
@@ -35777,7 +35825,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/__tests__/consolidation-test-schema.ts",
       "source_location": "L10",
       "id": "consolidation_test_schema_applyconsolidationtestschema",
-      "community": 923
+      "community": 924
     },
     {
       "label": "consolidation-repository.spec.ts",
@@ -35785,7 +35833,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/repositories/consolidation-repository.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_repositories_consolidation_repository_spec_ts",
-      "community": 1304
+      "community": 1305
     },
     {
       "label": "consolidation-repository.ts",
@@ -36025,7 +36073,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_summarization_service_spec_ts",
-      "community": 924
+      "community": 925
     },
     {
       "label": "row()",
@@ -36033,7 +36081,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/summarization-service.spec.ts",
       "source_location": "L5",
       "id": "summarization_service_spec_row",
-      "community": 924
+      "community": 925
     },
     {
       "label": "consolidation-outbox-worker.ts",
@@ -36041,7 +36089,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_ts",
-      "community": 466
+      "community": 467
     },
     {
       "label": "ConsolidationOutboxWorker",
@@ -36049,7 +36097,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L19",
       "id": "consolidation_outbox_worker_consolidationoutboxworker",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".constructor()",
@@ -36057,7 +36105,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L22",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_constructor",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".publish()",
@@ -36065,7 +36113,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L26",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_publish",
-      "community": 466
+      "community": 467
     },
     {
       "label": ".handled()",
@@ -36073,7 +36121,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.ts",
       "source_location": "L38",
       "id": "consolidation_outbox_worker_consolidationoutboxworker_handled",
-      "community": 466
+      "community": 467
     },
     {
       "label": "summarization-service.ts",
@@ -36129,7 +36177,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_sleep_consolidation_service_spec_ts",
-      "community": 467
+      "community": 468
     },
     {
       "label": "insertEpisodic()",
@@ -36137,7 +36185,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L12",
       "id": "sleep_consolidation_service_spec_insertepisodic",
-      "community": 467
+      "community": 468
     },
     {
       "label": "insertEmbedding()",
@@ -36145,7 +36193,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L27",
       "id": "sleep_consolidation_service_spec_insertembedding",
-      "community": 467
+      "community": 468
     },
     {
       "label": "FailingRepo",
@@ -36153,7 +36201,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L104",
       "id": "sleep_consolidation_service_spec_failingrepo",
-      "community": 467
+      "community": 468
     },
     {
       "label": ".insertSemanticMemory()",
@@ -36161,7 +36209,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/sleep-consolidation-service.spec.ts",
       "source_location": "L105",
       "id": "sleep_consolidation_service_spec_failingrepo_insertsemanticmemory",
-      "community": 467
+      "community": 468
     },
     {
       "label": "consolidation-outbox-worker.spec.ts",
@@ -36169,7 +36217,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_consolidation_outbox_worker_spec_ts",
-      "community": 699
+      "community": 701
     },
     {
       "label": "insertEpisodic()",
@@ -36177,7 +36225,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L10",
       "id": "consolidation_outbox_worker_spec_insertepisodic",
-      "community": 699
+      "community": 701
     },
     {
       "label": "insertEmbedding()",
@@ -36185,7 +36233,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/consolidation-outbox-worker.spec.ts",
       "source_location": "L18",
       "id": "consolidation_outbox_worker_spec_insertembedding",
-      "community": 699
+      "community": 701
     },
     {
       "label": "clustering-service.spec.ts",
@@ -36193,7 +36241,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_consolidation_services_clustering_service_spec_ts",
-      "community": 925
+      "community": 926
     },
     {
       "label": "ep()",
@@ -36201,7 +36249,7 @@
       "source_file": "packages/memento-core/src/domains/consolidation/services/clustering-service.spec.ts",
       "source_location": "L5",
       "id": "clustering_service_spec_ep",
-      "community": 925
+      "community": 926
     },
     {
       "label": "relation-graph.port.ts",
@@ -36209,7 +36257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/ports/relation-graph.port.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_ports_relation_graph_port_ts",
-      "community": 1305
+      "community": 1306
     },
     {
       "label": "get-relations-tool.ts",
@@ -36273,7 +36321,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_triples_tool_spec_ts",
-      "community": 926
+      "community": 927
     },
     {
       "label": "createMemoryDbWithKgTriple()",
@@ -36281,7 +36329,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-triples-tool.spec.ts",
       "source_location": "L32",
       "id": "extract_triples_tool_spec_creatememorydbwithkgtriple",
-      "community": 926
+      "community": 927
     },
     {
       "label": "visualize-relations-tool.ts",
@@ -36289,7 +36337,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_visualize_relations_tool_ts",
-      "community": 569
+      "community": 570
     },
     {
       "label": "VisualizeRelationsTool",
@@ -36297,7 +36345,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L23",
       "id": "visualize_relations_tool_visualizerelationstool",
-      "community": 569
+      "community": 570
     },
     {
       "label": ".constructor()",
@@ -36305,7 +36353,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L24",
       "id": "visualize_relations_tool_visualizerelationstool_constructor",
-      "community": 569
+      "community": 570
     },
     {
       "label": ".handle()",
@@ -36313,7 +36361,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/visualize-relations-tool.ts",
       "source_location": "L88",
       "id": "visualize_relations_tool_visualizerelationstool_handle",
-      "community": 569
+      "community": 570
     },
     {
       "label": "remove-relation-tool.ts",
@@ -36321,7 +36369,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_remove_relation_tool_ts",
-      "community": 570
+      "community": 571
     },
     {
       "label": "RemoveRelationTool",
@@ -36329,7 +36377,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L31",
       "id": "remove_relation_tool_removerelationtool",
-      "community": 570
+      "community": 571
     },
     {
       "label": ".constructor()",
@@ -36337,7 +36385,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L32",
       "id": "remove_relation_tool_removerelationtool_constructor",
-      "community": 570
+      "community": 571
     },
     {
       "label": ".handle()",
@@ -36345,7 +36393,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/remove-relation-tool.ts",
       "source_location": "L66",
       "id": "remove_relation_tool_removerelationtool_handle",
-      "community": 570
+      "community": 571
     },
     {
       "label": "extract-relations-tool.ts",
@@ -36353,7 +36401,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_extract_relations_tool_ts",
-      "community": 571
+      "community": 572
     },
     {
       "label": "ExtractRelationsTool",
@@ -36361,7 +36409,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_extractrelationstool",
-      "community": 571
+      "community": 572
     },
     {
       "label": ".constructor()",
@@ -36369,7 +36417,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L20",
       "id": "extract_relations_tool_extractrelationstool_constructor",
-      "community": 571
+      "community": 572
     },
     {
       "label": ".handle()",
@@ -36377,7 +36425,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/extract-relations-tool.ts",
       "source_location": "L47",
       "id": "extract_relations_tool_extractrelationstool_handle",
-      "community": 571
+      "community": 572
     },
     {
       "label": "add-relation-tool.ts",
@@ -36385,7 +36433,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_add_relation_tool_ts",
-      "community": 468
+      "community": 469
     },
     {
       "label": "memoryItemHasOwnerIdColumn()",
@@ -36393,7 +36441,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L16",
       "id": "add_relation_tool_memoryitemhasowneridcolumn",
-      "community": 468
+      "community": 469
     },
     {
       "label": "AddRelationTool",
@@ -36401,7 +36449,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L28",
       "id": "add_relation_tool_addrelationtool",
-      "community": 468
+      "community": 469
     },
     {
       "label": ".constructor()",
@@ -36409,7 +36457,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L29",
       "id": "add_relation_tool_addrelationtool_constructor",
-      "community": 468
+      "community": 469
     },
     {
       "label": ".handle()",
@@ -36417,7 +36465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/add-relation-tool.ts",
       "source_location": "L67",
       "id": "add_relation_tool_addrelationtool_handle",
-      "community": 468
+      "community": 469
     },
     {
       "label": "extract-triples-tool.ts",
@@ -36481,7 +36529,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_get_relations_tool_spec_ts",
-      "community": 700
+      "community": 702
     },
     {
       "label": "createBaseSchema()",
@@ -36489,7 +36537,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L17",
       "id": "get_relations_tool_spec_createbaseschema",
-      "community": 700
+      "community": 702
     },
     {
       "label": "createTestMemory()",
@@ -36497,7 +36545,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/get-relations-tool.spec.ts",
       "source_location": "L53",
       "id": "get_relations_tool_spec_createtestmemory",
-      "community": 700
+      "community": 702
     },
     {
       "label": "extract-relations-tool.spec.ts",
@@ -36505,7 +36553,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_extract_relations_tool_spec_ts",
-      "community": 701
+      "community": 703
     },
     {
       "label": "createBaseSchema()",
@@ -36513,7 +36561,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L19",
       "id": "extract_relations_tool_spec_createbaseschema",
-      "community": 701
+      "community": 703
     },
     {
       "label": "createTestMemory()",
@@ -36521,7 +36569,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/extract-relations-tool.spec.ts",
       "source_location": "L54",
       "id": "extract_relations_tool_spec_createtestmemory",
-      "community": 701
+      "community": 703
     },
     {
       "label": "visualize-relations-tool.spec.ts",
@@ -36529,7 +36577,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_visualize_relations_tool_spec_ts",
-      "community": 702
+      "community": 704
     },
     {
       "label": "createBaseSchema()",
@@ -36537,7 +36585,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L14",
       "id": "visualize_relations_tool_spec_createbaseschema",
-      "community": 702
+      "community": 704
     },
     {
       "label": "createTestMemory()",
@@ -36545,7 +36593,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/visualize-relations-tool.spec.ts",
       "source_location": "L44",
       "id": "visualize_relations_tool_spec_createtestmemory",
-      "community": 702
+      "community": 704
     },
     {
       "label": "remove-relation-tool.spec.ts",
@@ -36553,7 +36601,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/remove-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_remove_relation_tool_spec_ts",
-      "community": 1306
+      "community": 1307
     },
     {
       "label": "relation-tools-registry.spec.ts",
@@ -36561,7 +36609,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/relation-tools-registry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_relation_tools_registry_spec_ts",
-      "community": 1307
+      "community": 1308
     },
     {
       "label": "add-relation-tool.spec.ts",
@@ -36569,7 +36617,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_tools_tests_add_relation_tool_spec_ts",
-      "community": 703
+      "community": 705
     },
     {
       "label": "createBaseSchema()",
@@ -36577,7 +36625,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L17",
       "id": "add_relation_tool_spec_createbaseschema",
-      "community": 703
+      "community": 705
     },
     {
       "label": "createTestMemory()",
@@ -36585,7 +36633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/tools/__tests__/add-relation-tool.spec.ts",
       "source_location": "L53",
       "id": "add_relation_tool_spec_createtestmemory",
-      "community": 703
+      "community": 705
     },
     {
       "label": "relation-retry-manager.ts",
@@ -36593,7 +36641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_retry_manager_ts",
-      "community": 572
+      "community": 573
     },
     {
       "label": "RelationRetryManager",
@@ -36601,7 +36649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L8",
       "id": "relation_retry_manager_relationretrymanager",
-      "community": 572
+      "community": 573
     },
     {
       "label": ".constructor()",
@@ -36609,7 +36657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L9",
       "id": "relation_retry_manager_relationretrymanager_constructor",
-      "community": 572
+      "community": 573
     },
     {
       "label": ".retry()",
@@ -36617,7 +36665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-retry-manager.ts",
       "source_location": "L11",
       "id": "relation_retry_manager_relationretrymanager_retry",
-      "community": 572
+      "community": 573
     },
     {
       "label": "relation-errors.ts",
@@ -36825,7 +36873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_query_ts",
-      "community": 469
+      "community": 470
     },
     {
       "label": "RelationGraphQuery",
@@ -36833,7 +36881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L16",
       "id": "relation_graph_query_relationgraphquery",
-      "community": 469
+      "community": 470
     },
     {
       "label": ".constructor()",
@@ -36841,7 +36889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L17",
       "id": "relation_graph_query_relationgraphquery_constructor",
-      "community": 469
+      "community": 470
     },
     {
       "label": ".getRelations()",
@@ -36849,7 +36897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L25",
       "id": "relation_graph_query_relationgraphquery_getrelations",
-      "community": 469
+      "community": 470
     },
     {
       "label": ".getRelationsBatch()",
@@ -36857,7 +36905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-query.ts",
       "source_location": "L99",
       "id": "relation_graph_query_relationgraphquery_getrelationsbatch",
-      "community": 469
+      "community": 470
     },
     {
       "label": "relation-graph-row-utils.ts",
@@ -36865,7 +36913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_row_utils_ts",
-      "community": 573
+      "community": 574
     },
     {
       "label": "mapRelationRowToMemoryRelation()",
@@ -36873,7 +36921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L13",
       "id": "relation_graph_row_utils_maprelationrowtomemoryrelation",
-      "community": 573
+      "community": 574
     },
     {
       "label": "filterRelationRows()",
@@ -36881,7 +36929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L29",
       "id": "relation_graph_row_utils_filterrelationrows",
-      "community": 573
+      "community": 574
     },
     {
       "label": "filterRelationRowsWithWarning()",
@@ -36889,7 +36937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-row-utils.ts",
       "source_location": "L36",
       "id": "relation_graph_row_utils_filterrelationrowswithwarning",
-      "community": 573
+      "community": 574
     },
     {
       "label": "relation-graph-cycle-detector.ts",
@@ -36897,7 +36945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_cycle_detector_ts",
-      "community": 470
+      "community": 471
     },
     {
       "label": "RelationGraphCycleDetector",
@@ -36905,7 +36953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L11",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".constructor()",
@@ -36913,7 +36961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L12",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_constructor",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".detectCycleInternal()",
@@ -36921,7 +36969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L17",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycleinternal",
-      "community": 470
+      "community": 471
     },
     {
       "label": ".detectCycle()",
@@ -36929,7 +36977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-cycle-detector.ts",
       "source_location": "L89",
       "id": "relation_graph_cycle_detector_relationgraphcycledetector_detectcycle",
-      "community": 470
+      "community": 471
     },
     {
       "label": "relation-graph.ts",
@@ -37201,7 +37249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_graph_traversal_ts",
-      "community": 574
+      "community": 575
     },
     {
       "label": "RelationGraphTraversal",
@@ -37209,7 +37257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L24",
       "id": "relation_graph_traversal_relationgraphtraversal",
-      "community": 574
+      "community": 575
     },
     {
       "label": ".constructor()",
@@ -37217,7 +37265,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L25",
       "id": "relation_graph_traversal_relationgraphtraversal_constructor",
-      "community": 574
+      "community": 575
     },
     {
       "label": ".getRelatedMemories()",
@@ -37225,7 +37273,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-graph-traversal.ts",
       "source_location": "L30",
       "id": "relation_graph_traversal_relationgraphtraversal_getrelatedmemories",
-      "community": 574
+      "community": 575
     },
     {
       "label": "llm-based-relation-extractor.ts",
@@ -37601,7 +37649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extraction_quality_integration_spec_ts",
-      "community": 575
+      "community": 576
     },
     {
       "label": "loadTestDataset()",
@@ -37609,7 +37657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L25",
       "id": "relation_extraction_quality_integration_spec_loadtestdataset",
-      "community": 575
+      "community": 576
     },
     {
       "label": "createBaseSchema()",
@@ -37617,7 +37665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L50",
       "id": "relation_extraction_quality_integration_spec_createbaseschema",
-      "community": 575
+      "community": 576
     },
     {
       "label": "createTestMemory()",
@@ -37625,7 +37673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extraction-quality.integration.spec.ts",
       "source_location": "L85",
       "id": "relation_extraction_quality_integration_spec_createtestmemory",
-      "community": 575
+      "community": 576
     },
     {
       "label": "relation-quality-validator.spec.ts",
@@ -37633,7 +37681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-quality-validator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_quality_validator_spec_ts",
-      "community": 1308
+      "community": 1309
     },
     {
       "label": "relation-graph.spec.ts",
@@ -37641,7 +37689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_spec_ts",
-      "community": 704
+      "community": 706
     },
     {
       "label": "createBaseSchema()",
@@ -37649,7 +37697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L25",
       "id": "relation_graph_spec_createbaseschema",
-      "community": 704
+      "community": 706
     },
     {
       "label": "createTestMemory()",
@@ -37657,7 +37705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.spec.ts",
       "source_location": "L60",
       "id": "relation_graph_spec_createtestmemory",
-      "community": 704
+      "community": 706
     },
     {
       "label": "relation-extractor.spec.ts",
@@ -37665,7 +37713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_extractor_spec_ts",
-      "community": 927
+      "community": 928
     },
     {
       "label": "createTestMemory()",
@@ -37673,7 +37721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-extractor.spec.ts",
       "source_location": "L65",
       "id": "relation_extractor_spec_createtestmemory",
-      "community": 927
+      "community": 928
     },
     {
       "label": "relation-graph.integration.spec.ts",
@@ -37681,7 +37729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_relation_graph_integration_spec_ts",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createBaseSchema()",
@@ -37689,7 +37737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L23",
       "id": "relation_graph_integration_spec_createbaseschema",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createTestMemory()",
@@ -37697,7 +37745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L58",
       "id": "relation_graph_integration_spec_createtestmemory",
-      "community": 576
+      "community": 577
     },
     {
       "label": "createBulkMemories()",
@@ -37705,7 +37753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/relation-graph.integration.spec.ts",
       "source_location": "L71",
       "id": "relation_graph_integration_spec_createbulkmemories",
-      "community": 576
+      "community": 577
     },
     {
       "label": "rule-based-relation-extractor.spec.ts",
@@ -37713,7 +37761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_rule_based_relation_extractor_spec_ts",
-      "community": 928
+      "community": 929
     },
     {
       "label": "createTestMemory()",
@@ -37721,7 +37769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/rule-based-relation-extractor.spec.ts",
       "source_location": "L13",
       "id": "rule_based_relation_extractor_spec_createtestmemory",
-      "community": 928
+      "community": 929
     },
     {
       "label": "llm-based-relation-extractor.spec.ts",
@@ -37785,7 +37833,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-auto.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_auto_spec_ts",
-      "community": 1309
+      "community": 1310
     },
     {
       "label": "provider-no-api-keys.spec.ts",
@@ -37793,7 +37841,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-no-api-keys.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_no_api_keys_spec_ts",
-      "community": 1310
+      "community": 1311
     },
     {
       "label": "llm-provider-integration.test-setup.ts",
@@ -37801,7 +37849,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_llm_provider_integration_test_setup_ts",
-      "community": 705
+      "community": 707
     },
     {
       "label": "getMockMementoConfig()",
@@ -37809,7 +37857,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L21",
       "id": "llm_provider_integration_test_setup_getmockmementoconfig",
-      "community": 705
+      "community": 707
     },
     {
       "label": "resetLlmProviderIntegrationTestEnv()",
@@ -37817,7 +37865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/llm-provider-integration.test-setup.ts",
       "source_location": "L56",
       "id": "llm_provider_integration_test_setup_resetllmproviderintegrationtestenv",
-      "community": 705
+      "community": 707
     },
     {
       "label": "provider-ollama.spec.ts",
@@ -37825,7 +37873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-ollama.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_ollama_spec_ts",
-      "community": 1311
+      "community": 1312
     },
     {
       "label": "provider-openai.spec.ts",
@@ -37833,7 +37881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-openai.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_openai_spec_ts",
-      "community": 1312
+      "community": 1313
     },
     {
       "label": "provider-init-failure.spec.ts",
@@ -37841,7 +37889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-init-failure.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_init_failure_spec_ts",
-      "community": 1313
+      "community": 1314
     },
     {
       "label": "provider-gemini.spec.ts",
@@ -37849,7 +37897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/__tests__/llm-provider-integration/provider-gemini.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_tests_llm_provider_integration_provider_gemini_spec_ts",
-      "community": 1314
+      "community": 1315
     },
     {
       "label": "triple-extraction-rate-limiter.ts",
@@ -37857,7 +37905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_rate_limiter_ts",
-      "community": 471
+      "community": 472
     },
     {
       "label": "TokenBucketRateLimiter",
@@ -37865,7 +37913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L5",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".constructor()",
@@ -37873,7 +37921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L12",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_constructor",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".consume()",
@@ -37881,7 +37929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L19",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_consume",
-      "community": 471
+      "community": 472
     },
     {
       "label": ".refill()",
@@ -37889,7 +37937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-rate-limiter.ts",
       "source_location": "L45",
       "id": "triple_extraction_rate_limiter_tokenbucketratelimiter_refill",
-      "community": 471
+      "community": 472
     },
     {
       "label": "triple-extraction-result-helpers.ts",
@@ -37897,7 +37945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_result_helpers_ts",
-      "community": 577
+      "community": 578
     },
     {
       "label": "trackTripleExtractionSteps()",
@@ -37905,7 +37953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L15",
       "id": "triple_extraction_result_helpers_tracktripleextractionsteps",
-      "community": 577
+      "community": 578
     },
     {
       "label": "normalizeTripleExtractionResult()",
@@ -37913,7 +37961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L51",
       "id": "triple_extraction_result_helpers_normalizetripleextractionresult",
-      "community": 577
+      "community": 578
     },
     {
       "label": "createTripleExtractionFailureResult()",
@@ -37921,7 +37969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-result-helpers.ts",
       "source_location": "L92",
       "id": "triple_extraction_result_helpers_createtripleextractionfailureresult",
-      "community": 577
+      "community": 578
     },
     {
       "label": "triple-pipeline-orchestrator.ts",
@@ -38169,7 +38217,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_pipeline_orchestrator_spec_ts",
-      "community": 929
+      "community": 930
     },
     {
       "label": "extract()",
@@ -38177,7 +38225,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-pipeline-orchestrator.spec.ts",
       "source_location": "L15",
       "id": "triple_pipeline_orchestrator_spec_extract",
-      "community": 929
+      "community": 930
     },
     {
       "label": "triple-chunk-merge.ts",
@@ -38185,7 +38233,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_ts",
-      "community": 706
+      "community": 708
     },
     {
       "label": "tripleDedupeKey()",
@@ -38193,7 +38241,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L3",
       "id": "triple_chunk_merge_triplededupekey",
-      "community": 706
+      "community": 708
     },
     {
       "label": "mergeTripleLists()",
@@ -38201,7 +38249,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.ts",
       "source_location": "L14",
       "id": "triple_chunk_merge_mergetriplelists",
-      "community": 706
+      "community": 708
     },
     {
       "label": "triple-extraction-service.spec.ts",
@@ -38209,7 +38257,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_service_spec_ts",
-      "community": 1315
+      "community": 1316
     },
     {
       "label": "triple-extraction-llm-pipeline.ts",
@@ -38417,7 +38465,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/interfaces.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_interfaces_ts",
-      "community": 1316
+      "community": 1317
     },
     {
       "label": "triple-extraction-llm-pipeline.spec.ts",
@@ -38425,7 +38473,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-llm-pipeline.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_llm_pipeline_spec_ts",
-      "community": 1317
+      "community": 1318
     },
     {
       "label": "triple-chunk-merge.spec.ts",
@@ -38433,7 +38481,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-chunk-merge.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_chunk_merge_spec_ts",
-      "community": 1318
+      "community": 1319
     },
     {
       "label": "triple-text-chunker.spec.ts",
@@ -38441,7 +38489,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_spec_ts",
-      "community": 1319
+      "community": 1320
     },
     {
       "label": "triple-extractor.ts",
@@ -38585,7 +38633,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_normalizer_ts",
-      "community": 578
+      "community": 579
     },
     {
       "label": "TripleNormalizer",
@@ -38593,7 +38641,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L19",
       "id": "triple_normalizer_triplenormalizer",
-      "community": 578
+      "community": 579
     },
     {
       "label": ".constructor()",
@@ -38601,7 +38649,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L23",
       "id": "triple_normalizer_triplenormalizer_constructor",
-      "community": 578
+      "community": 579
     },
     {
       "label": ".normalize()",
@@ -38609,7 +38657,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-normalizer.ts",
       "source_location": "L39",
       "id": "triple_normalizer_triplenormalizer_normalize",
-      "community": 578
+      "community": 579
     },
     {
       "label": "predicate-canonicalizer.spec.ts",
@@ -38617,7 +38665,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/predicate-canonicalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_predicate_canonicalizer_spec_ts",
-      "community": 1320
+      "community": 1321
     },
     {
       "label": "triple-extraction-errors.ts",
@@ -38625,7 +38673,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_extraction_errors_ts",
-      "community": 579
+      "community": 580
     },
     {
       "label": "classifyTripleFailureReason()",
@@ -38633,7 +38681,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L7",
       "id": "triple_extraction_errors_classifytriplefailurereason",
-      "community": 579
+      "community": 580
     },
     {
       "label": "shouldRetryTripleLlmError()",
@@ -38641,7 +38689,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L56",
       "id": "triple_extraction_errors_shouldretrytriplellmerror",
-      "community": 579
+      "community": 580
     },
     {
       "label": "classifyTripleExtractionErrorType()",
@@ -38649,7 +38697,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-extraction-errors.ts",
       "source_location": "L71",
       "id": "triple_extraction_errors_classifytripleextractionerrortype",
-      "community": 579
+      "community": 580
     },
     {
       "label": "triple-input-normalizer.spec.ts",
@@ -38657,7 +38705,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_spec_ts",
-      "community": 1321
+      "community": 1322
     },
     {
       "label": "triple-parser.ts",
@@ -38665,7 +38713,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_parser_ts",
-      "community": 472
+      "community": 473
     },
     {
       "label": "TripleParser",
@@ -38673,7 +38721,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L17",
       "id": "triple_parser_tripleparser",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".parse()",
@@ -38681,7 +38729,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L26",
       "id": "triple_parser_tripleparser_parse",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".extractJSON()",
@@ -38689,7 +38737,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L110",
       "id": "triple_parser_tripleparser_extractjson",
-      "community": 472
+      "community": 473
     },
     {
       "label": ".isValidTriple()",
@@ -38697,7 +38745,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-parser.ts",
       "source_location": "L143",
       "id": "triple_parser_tripleparser_isvalidtriple",
-      "community": 472
+      "community": 473
     },
     {
       "label": "triple-text-chunker.ts",
@@ -38705,7 +38753,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_text_chunker_ts",
-      "community": 930
+      "community": 931
     },
     {
       "label": "splitTextIntoChunks()",
@@ -38713,7 +38761,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-text-chunker.ts",
       "source_location": "L9",
       "id": "triple_text_chunker_splittextintochunks",
-      "community": 930
+      "community": 931
     },
     {
       "label": "triple-input-normalizer.ts",
@@ -38721,7 +38769,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_triple_input_normalizer_ts",
-      "community": 931
+      "community": 932
     },
     {
       "label": "normalizeChatMessagesToText()",
@@ -38729,7 +38777,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/triple-input-normalizer.ts",
       "source_location": "L13",
       "id": "triple_input_normalizer_normalizechatmessagestotext",
-      "community": 931
+      "community": 932
     },
     {
       "label": "predicate-canonicalizer.ts",
@@ -38817,7 +38865,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/entity-linker.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_entity_linker_spec_ts",
-      "community": 1322
+      "community": 1323
     },
     {
       "label": "triple-normalizer.spec.ts",
@@ -38825,7 +38873,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-normalizer.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_normalizer_spec_ts",
-      "community": 1323
+      "community": 1324
     },
     {
       "label": "interfaces.spec.ts",
@@ -38833,7 +38881,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/interfaces.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_interfaces_spec_ts",
-      "community": 1324
+      "community": 1325
     },
     {
       "label": "triple-extractor.spec.ts",
@@ -38841,7 +38889,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-extractor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_extractor_spec_ts",
-      "community": 1325
+      "community": 1326
     },
     {
       "label": "triple-parser.spec.ts",
@@ -38849,7 +38897,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/triple-extraction/__tests__/triple-parser.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_triple_extraction_tests_triple_parser_spec_ts",
-      "community": 1326
+      "community": 1327
     },
     {
       "label": "extract-relations-gemini.ts",
@@ -38857,7 +38905,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_gemini_ts",
-      "community": 932
+      "community": 933
     },
     {
       "label": "extractRelationsWithGemini()",
@@ -38865,7 +38913,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-gemini.ts",
       "source_location": "L21",
       "id": "extract_relations_gemini_extractrelationswithgemini",
-      "community": 932
+      "community": 933
     },
     {
       "label": "extract-relations-openai.ts",
@@ -38873,7 +38921,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_openai_ts",
-      "community": 933
+      "community": 934
     },
     {
       "label": "extractRelationsWithOpenAI()",
@@ -38881,7 +38929,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-openai.ts",
       "source_location": "L21",
       "id": "extract_relations_openai_extractrelationswithopenai",
-      "community": 933
+      "community": 934
     },
     {
       "label": "types.ts",
@@ -38889,7 +38937,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_types_ts",
-      "community": 1327
+      "community": 1328
     },
     {
       "label": "ollama-chat-support.ts",
@@ -38897,7 +38945,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_ollama_chat_support_ts",
-      "community": 580
+      "community": 581
     },
     {
       "label": "checkOllamaModel()",
@@ -38905,7 +38953,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L5",
       "id": "ollama_chat_support_checkollamamodel",
-      "community": 580
+      "community": 581
     },
     {
       "label": "buildOllamaErrorLogContext()",
@@ -38913,7 +38961,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L50",
       "id": "ollama_chat_support_buildollamaerrorlogcontext",
-      "community": 580
+      "community": 581
     },
     {
       "label": "parseOllamaChatResponsePayload()",
@@ -38921,7 +38969,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/ollama-chat-support.ts",
       "source_location": "L79",
       "id": "ollama_chat_support_parseollamachatresponsepayload",
-      "community": 580
+      "community": 581
     },
     {
       "label": "embedding-candidate-filter.ts",
@@ -38929,7 +38977,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_embedding_candidate_filter_ts",
-      "community": 934
+      "community": 935
     },
     {
       "label": "filterRelationCandidatesByEmbedding()",
@@ -38937,7 +38985,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/embedding-candidate-filter.ts",
       "source_location": "L7",
       "id": "embedding_candidate_filter_filterrelationcandidatesbyembedding",
-      "community": 934
+      "community": 935
     },
     {
       "label": "provider-selection.ts",
@@ -38945,7 +38993,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_provider_selection_ts",
-      "community": 707
+      "community": 709
     },
     {
       "label": "isOllamaPreferredSlotAvailable()",
@@ -38953,7 +39001,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L15",
       "id": "provider_selection_isollamapreferredslotavailable",
-      "community": 707
+      "community": 709
     },
     {
       "label": "determineRelationLlmProvider()",
@@ -38961,7 +39009,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/provider-selection.ts",
       "source_location": "L19",
       "id": "provider_selection_determinerelationllmprovider",
-      "community": 707
+      "community": 709
     },
     {
       "label": "extract-relations-ollama.ts",
@@ -38969,7 +39017,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_extract_relations_ollama_ts",
-      "community": 935
+      "community": 936
     },
     {
       "label": "extractRelationsWithOllama()",
@@ -38977,7 +39025,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/extract-relations-ollama.ts",
       "source_location": "L26",
       "id": "extract_relations_ollama_extractrelationswithollama",
-      "community": 935
+      "community": 936
     },
     {
       "label": "llm-response-parse.ts",
@@ -38985,7 +39033,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_llm_relation_extractor_llm_response_parse_ts",
-      "community": 473
+      "community": 474
     },
     {
       "label": "extractJsonObjectFromLlmText()",
@@ -38993,7 +39041,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L5",
       "id": "llm_response_parse_extractjsonobjectfromllmtext",
-      "community": 473
+      "community": 474
     },
     {
       "label": "trimToValidJsonObject()",
@@ -39001,7 +39049,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L139",
       "id": "llm_response_parse_trimtovalidjsonobject",
-      "community": 473
+      "community": 474
     },
     {
       "label": "prepareOllamaRelationJsonContent()",
@@ -39009,7 +39057,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L163",
       "id": "llm_response_parse_prepareollamarelationjsoncontent",
-      "community": 473
+      "community": 474
     },
     {
       "label": "parseLlmRelationsResponse()",
@@ -39017,7 +39065,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/llm-relation-extractor/llm-response-parse.ts",
       "source_location": "L178",
       "id": "llm_response_parse_parsellmrelationsresponse",
-      "community": 473
+      "community": 474
     },
     {
       "label": "types.ts",
@@ -39025,7 +39073,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_types_ts",
-      "community": 1328
+      "community": 1329
     },
     {
       "label": "analysis-rules.ts",
@@ -39033,7 +39081,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_analysis_rules_ts",
-      "community": 581
+      "community": 582
     },
     {
       "label": "calculateConfusionMatrix()",
@@ -39041,7 +39089,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L12",
       "id": "analysis_rules_calculateconfusionmatrix",
-      "community": 581
+      "community": 582
     },
     {
       "label": "analyzeRelationType()",
@@ -39049,7 +39097,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L56",
       "id": "analysis_rules_analyzerelationtype",
-      "community": 581
+      "community": 582
     },
     {
       "label": "analyzeAllRelationTypes()",
@@ -39057,7 +39105,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/analysis-rules.ts",
       "source_location": "L127",
       "id": "analysis_rules_analyzeallrelationtypes",
-      "community": 581
+      "community": 582
     },
     {
       "label": "metric-rules.ts",
@@ -39113,7 +39161,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_quality_metrics_rules_ts",
-      "community": 474
+      "community": 475
     },
     {
       "label": "emptyTypeMetric()",
@@ -39121,7 +39169,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L20",
       "id": "quality_metrics_rules_emptytypemetric",
-      "community": 474
+      "community": 475
     },
     {
       "label": "calculateQualityMetrics()",
@@ -39129,7 +39177,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L31",
       "id": "quality_metrics_rules_calculatequalitymetrics",
-      "community": 474
+      "community": 475
     },
     {
       "label": "validateThresholds()",
@@ -39137,7 +39185,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L79",
       "id": "quality_metrics_rules_validatethresholds",
-      "community": 474
+      "community": 475
     },
     {
       "label": "calculateQualityMetricsWithAnalysis()",
@@ -39145,7 +39193,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/quality-metrics-rules.ts",
       "source_location": "L122",
       "id": "quality_metrics_rules_calculatequalitymetricswithanalysis",
-      "community": 474
+      "community": 475
     },
     {
       "label": "matching-rules.ts",
@@ -39153,7 +39201,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_relation_services_relation_quality_validator_matching_rules_ts",
-      "community": 936
+      "community": 937
     },
     {
       "label": "matchRelations()",
@@ -39161,7 +39209,7 @@
       "source_file": "packages/memento-core/src/domains/relation/services/relation-quality-validator/matching-rules.ts",
       "source_location": "L7",
       "id": "matching_rules_matchrelations",
-      "community": 936
+      "community": 937
     },
     {
       "label": "types.ts",
@@ -39169,7 +39217,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_types_ts",
-      "community": 1329
+      "community": 1330
     },
     {
       "label": "agent-integration-repository.ts",
@@ -39177,7 +39225,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/repositories/agent-integration-repository.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_repositories_agent_integration_repository_ts",
-      "community": 1330
+      "community": 1331
     },
     {
       "label": "agent-context-recall-service.spec.ts",
@@ -39185,7 +39233,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_recall_service_spec_ts",
-      "community": 708
+      "community": 710
     },
     {
       "label": "candidate()",
@@ -39193,7 +39241,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L10",
       "id": "agent_context_recall_service_spec_candidate",
-      "community": 708
+      "community": 710
     },
     {
       "label": "source()",
@@ -39201,7 +39249,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-recall-service.spec.ts",
       "source_location": "L33",
       "id": "agent_context_recall_service_spec_source",
-      "community": 708
+      "community": 710
     },
     {
       "label": "sqlite-hybrid-agent-context-source.spec.ts",
@@ -39209,7 +39257,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/sqlite-hybrid-agent-context-source.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_sqlite_hybrid_agent_context_source_spec_ts",
-      "community": 1331
+      "community": 1332
     },
     {
       "label": "agent-integration-error.ts",
@@ -39217,7 +39265,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_integration_error_ts",
-      "community": 709
+      "community": 711
     },
     {
       "label": "AgentIntegrationError",
@@ -39225,7 +39273,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L22",
       "id": "agent_integration_error_agentintegrationerror",
-      "community": 709
+      "community": 711
     },
     {
       "label": ".constructor()",
@@ -39233,7 +39281,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-integration-error.ts",
       "source_location": "L23",
       "id": "agent_integration_error_agentintegrationerror_constructor",
-      "community": 709
+      "community": 711
     },
     {
       "label": "agent-lifecycle-service.spec.ts",
@@ -39241,7 +39289,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-lifecycle-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_lifecycle_service_spec_ts",
-      "community": 1332
+      "community": 1333
     },
     {
       "label": "agent-session-summary-service.spec.ts",
@@ -39249,7 +39297,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_session_summary_service_spec_ts",
-      "community": 710
+      "community": 712
     },
     {
       "label": "createSession()",
@@ -39257,7 +39305,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L67",
       "id": "agent_session_summary_service_spec_createsession",
-      "community": 710
+      "community": 712
     },
     {
       "label": "addObservation()",
@@ -39265,7 +39313,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-session-summary-service.spec.ts",
       "source_location": "L78",
       "id": "agent_session_summary_service_spec_addobservation",
-      "community": 710
+      "community": 712
     },
     {
       "label": "agent-memory-promotion-service.ts",
@@ -39729,7 +39777,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_provenance_graph_ts",
-      "community": 937
+      "community": 938
     },
     {
       "label": "buildProvenanceTrace()",
@@ -39737,7 +39785,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-provenance-graph.ts",
       "source_location": "L10",
       "id": "agent_provenance_graph_buildprovenancetrace",
-      "community": 937
+      "community": 938
     },
     {
       "label": "agent-context-injection-service.spec.ts",
@@ -39745,7 +39793,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-context-injection-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_context_injection_service_spec_ts",
-      "community": 1333
+      "community": 1334
     },
     {
       "label": "sqlite-hybrid-agent-context-source.ts",
@@ -39833,7 +39881,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_memory_promotion_service_spec_ts",
-      "community": 711
+      "community": 713
     },
     {
       "label": "addObservation()",
@@ -39841,7 +39889,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L87",
       "id": "agent_memory_promotion_service_spec_addobservation",
-      "community": 711
+      "community": 713
     },
     {
       "label": "finishAndSummarize()",
@@ -39849,7 +39897,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-memory-promotion-service.spec.ts",
       "source_location": "L108",
       "id": "agent_memory_promotion_service_spec_finishandsummarize",
-      "community": 711
+      "community": 713
     },
     {
       "label": "agent-capture-transaction.ts",
@@ -39857,7 +39905,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_agent_integration_services_agent_capture_transaction_ts",
-      "community": 938
+      "community": 939
     },
     {
       "label": "executeAgentCaptureTransaction()",
@@ -39865,7 +39913,7 @@
       "source_file": "packages/memento-core/src/domains/agent-integration/services/agent-capture-transaction.ts",
       "source_location": "L21",
       "id": "agent_capture_transaction_executeagentcapturetransaction",
-      "community": 938
+      "community": 939
     },
     {
       "label": "agent-lifecycle-service.ts",
@@ -40241,7 +40289,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_model_availability_service_spec_ts",
-      "community": 582
+      "community": 583
     },
     {
       "label": "createMockService()",
@@ -40249,7 +40297,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L11",
       "id": "model_availability_service_spec_createmockservice",
-      "community": 582
+      "community": 583
     },
     {
       "label": "resolver()",
@@ -40257,7 +40305,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L24",
       "id": "model_availability_service_spec_resolver",
-      "community": 582
+      "community": 583
     },
     {
       "label": "priority()",
@@ -40265,7 +40313,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/model-availability-service.spec.ts",
       "source_location": "L25",
       "id": "model_availability_service_spec_priority",
-      "community": 582
+      "community": 583
     },
     {
       "label": "embedding-provider-factory.spec.ts",
@@ -40273,7 +40321,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/providers/__tests__/embedding-provider-factory.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_providers_tests_embedding_provider_factory_spec_ts",
-      "community": 1334
+      "community": 1335
     },
     {
       "label": "minilm-embedding-service.ts",
@@ -41289,7 +41337,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/retry-manager-usage.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_retry_manager_usage_spec_ts",
-      "community": 1335
+      "community": 1336
     },
     {
       "label": "vector-compatibility-service.spec.ts",
@@ -41297,7 +41345,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/vector-compatibility-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_vector_compatibility_service_spec_ts",
-      "community": 1336
+      "community": 1337
     },
     {
       "label": "embedding-migration-service.spec.ts",
@@ -41305,7 +41353,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_migration_service_spec_ts",
-      "community": 712
+      "community": 714
     },
     {
       "label": "createSchema()",
@@ -41313,7 +41361,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L7",
       "id": "embedding_migration_service_spec_createschema",
-      "community": 712
+      "community": 714
     },
     {
       "label": "seedMemoryItem()",
@@ -41321,7 +41369,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-migration-service.spec.ts",
       "source_location": "L65",
       "id": "embedding_migration_service_spec_seedmemoryitem",
-      "community": 712
+      "community": 714
     },
     {
       "label": "unified-embedding-service.spec.ts",
@@ -41329,7 +41377,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/unified-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_unified_embedding_service_spec_ts",
-      "community": 1337
+      "community": 1338
     },
     {
       "label": "minilm-embedding-service.spec.ts",
@@ -41337,7 +41385,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/minilm-embedding-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_minilm_embedding_service_spec_ts",
-      "community": 1338
+      "community": 1339
     },
     {
       "label": "embedding-reindex-service.spec.ts",
@@ -41345,7 +41393,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/__tests__/embedding-reindex-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_tests_embedding_reindex_service_spec_ts",
-      "community": 1339
+      "community": 1340
     },
     {
       "label": "types.ts",
@@ -41353,7 +41401,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_types_ts",
-      "community": 1340
+      "community": 1341
     },
     {
       "label": "migration-execution.ts",
@@ -41361,7 +41409,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_execution_ts",
-      "community": 475
+      "community": 476
     },
     {
       "label": "safeParseEmbedding()",
@@ -41369,7 +41417,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L24",
       "id": "migration_execution_safeparseembedding",
-      "community": 475
+      "community": 476
     },
     {
       "label": "processMigrationRow()",
@@ -41377,7 +41425,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L38",
       "id": "migration_execution_processmigrationrow",
-      "community": 475
+      "community": 476
     },
     {
       "label": "runMigrationBatchLoop()",
@@ -41385,7 +41433,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L143",
       "id": "migration_execution_runmigrationbatchloop",
-      "community": 475
+      "community": 476
     },
     {
       "label": "finalizeMigrationExecution()",
@@ -41393,7 +41441,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-execution.ts",
       "source_location": "L169",
       "id": "migration_execution_finalizemigrationexecution",
-      "community": 475
+      "community": 476
     },
     {
       "label": "migration-progress.ts",
@@ -41465,7 +41513,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_embedding_services_embedding_migration_service_migration_rollback_ts",
-      "community": 583
+      "community": 584
     },
     {
       "label": "rollback()",
@@ -41473,7 +41521,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L6",
       "id": "migration_rollback_rollback",
-      "community": 583
+      "community": 584
     },
     {
       "label": "applyRollbackDelete()",
@@ -41481,7 +41529,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L53",
       "id": "migration_rollback_applyrollbackdelete",
-      "community": 583
+      "community": 584
     },
     {
       "label": "applyRollbackRestore()",
@@ -41489,7 +41537,7 @@
       "source_file": "packages/memento-core/src/domains/embedding/services/embedding-migration-service/migration-rollback.ts",
       "source_location": "L57",
       "id": "migration_rollback_applyrollbackrestore",
-      "community": 583
+      "community": 584
     },
     {
       "label": "get-meta-memory-stats-tool.ts",
@@ -41497,7 +41545,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_get_meta_memory_stats_tool_ts",
-      "community": 584
+      "community": 585
     },
     {
       "label": "GetMetaMemoryStatsTool",
@@ -41505,7 +41553,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L61",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool",
-      "community": 584
+      "community": 585
     },
     {
       "label": ".constructor()",
@@ -41513,7 +41561,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L62",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_constructor",
-      "community": 584
+      "community": 585
     },
     {
       "label": ".handle()",
@@ -41521,7 +41569,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/get-meta-memory-stats-tool.ts",
       "source_location": "L116",
       "id": "get_meta_memory_stats_tool_getmetamemorystatstool_handle",
-      "community": 584
+      "community": 585
     },
     {
       "label": "performance-alerts.ts",
@@ -41577,7 +41625,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_performance_stats_tool_ts",
-      "community": 585
+      "community": 586
     },
     {
       "label": "PerformanceStatsTool",
@@ -41585,7 +41633,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L11",
       "id": "performance_stats_tool_performancestatstool",
-      "community": 585
+      "community": 586
     },
     {
       "label": ".constructor()",
@@ -41593,7 +41641,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L12",
       "id": "performance_stats_tool_performancestatstool_constructor",
-      "community": 585
+      "community": 586
     },
     {
       "label": ".handle()",
@@ -41601,7 +41649,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/performance-stats-tool.ts",
       "source_location": "L23",
       "id": "performance_stats_tool_performancestatstool_handle",
-      "community": 585
+      "community": 586
     },
     {
       "label": "resolve-error.ts",
@@ -41609,7 +41657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_resolve_error_ts",
-      "community": 939
+      "community": 940
     },
     {
       "label": "executeResolveError()",
@@ -41617,7 +41665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/resolve-error.ts",
       "source_location": "L32",
       "id": "resolve_error_executeresolveerror",
-      "community": 939
+      "community": 940
     },
     {
       "label": "error-stats.ts",
@@ -41625,7 +41673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_error_stats_ts",
-      "community": 940
+      "community": 941
     },
     {
       "label": "executeErrorStats()",
@@ -41633,7 +41681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/error-stats.ts",
       "source_location": "L48",
       "id": "error_stats_executeerrorstats",
-      "community": 940
+      "community": 941
     },
     {
       "label": "performance-stats-tool.spec.ts",
@@ -41641,7 +41689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/performance-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_performance_stats_tool_spec_ts",
-      "community": 1341
+      "community": 1342
     },
     {
       "label": "resolve-error.spec.ts",
@@ -41649,7 +41697,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/resolve-error.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_resolve_error_spec_ts",
-      "community": 1342
+      "community": 1343
     },
     {
       "label": "get-meta-memory-stats-tool.spec.ts",
@@ -41657,7 +41705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_get_meta_memory_stats_tool_spec_ts",
-      "community": 941
+      "community": 942
     },
     {
       "label": "createBaseSchema()",
@@ -41665,7 +41713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/get-meta-memory-stats-tool.spec.ts",
       "source_location": "L15",
       "id": "get_meta_memory_stats_tool_spec_createbaseschema",
-      "community": 941
+      "community": 942
     },
     {
       "label": "error-stats.spec.ts",
@@ -41673,7 +41721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/tools/__tests__/error-stats.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_tools_tests_error_stats_spec_ts",
-      "community": 1343
+      "community": 1344
     },
     {
       "label": "performance-monitor-types.ts",
@@ -41681,7 +41729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-monitor-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_monitor_types_ts",
-      "community": 1344
+      "community": 1345
     },
     {
       "label": "performance-monitor.ts",
@@ -42161,7 +42209,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_database_metrics_reader_ts",
-      "community": 476
+      "community": 477
     },
     {
       "label": "DatabaseMetricsReader",
@@ -42169,7 +42217,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L15",
       "id": "database_metrics_reader_databasemetricsreader",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".setDatabase()",
@@ -42177,7 +42225,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L18",
       "id": "database_metrics_reader_databasemetricsreader_setdatabase",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".getDatabaseMetrics()",
@@ -42185,7 +42233,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L22",
       "id": "database_metrics_reader_databasemetricsreader_getdatabasemetrics",
-      "community": 476
+      "community": 477
     },
     {
       "label": ".optimizeDatabase()",
@@ -42193,7 +42241,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/database-metrics-reader.ts",
       "source_location": "L70",
       "id": "database_metrics_reader_databasemetricsreader_optimizedatabase",
-      "community": 476
+      "community": 477
     },
     {
       "label": "performance-alert-service.ts",
@@ -42609,7 +42657,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_cpu_usage_tracker_ts",
-      "community": 477
+      "community": 478
     },
     {
       "label": "CpuUsageTracker",
@@ -42617,7 +42665,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L14",
       "id": "cpu_usage_tracker_cpuusagetracker",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".seed()",
@@ -42625,7 +42673,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L18",
       "id": "cpu_usage_tracker_cpuusagetracker_seed",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".getLatestSnapshot()",
@@ -42633,7 +42681,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L28",
       "id": "cpu_usage_tracker_cpuusagetracker_getlatestsnapshot",
-      "community": 477
+      "community": 478
     },
     {
       "label": ".calculateUsage()",
@@ -42641,7 +42689,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/cpu-usage-tracker.ts",
       "source_location": "L40",
       "id": "cpu_usage_tracker_cpuusagetracker_calculateusage",
-      "community": 477
+      "community": 478
     },
     {
       "label": "runtime-diagnostics-logger.ts",
@@ -42817,7 +42865,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_memory_pressure_utils_ts",
-      "community": 586
+      "community": 587
     },
     {
       "label": "getMemoryPressureDenominatorBytes()",
@@ -42825,7 +42873,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L12",
       "id": "memory_pressure_utils_getmemorypressuredenominatorbytes",
-      "community": 586
+      "community": 587
     },
     {
       "label": "memoryRatioToPercent()",
@@ -42833,7 +42881,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L27",
       "id": "memory_pressure_utils_memoryratiotopercent",
-      "community": 586
+      "community": 587
     },
     {
       "label": "formatBytes()",
@@ -42841,7 +42889,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/memory-pressure-utils.ts",
       "source_location": "L38",
       "id": "memory_pressure_utils_formatbytes",
-      "community": 586
+      "community": 587
     },
     {
       "label": "performance-analytics.ts",
@@ -42849,7 +42897,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_performance_analytics_ts",
-      "community": 478
+      "community": 479
     },
     {
       "label": "analyzeTrend()",
@@ -42857,7 +42905,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L54",
       "id": "performance_analytics_analyzetrend",
-      "community": 478
+      "community": 479
     },
     {
       "label": "generateRecommendations()",
@@ -42865,7 +42913,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L72",
       "id": "performance_analytics_generaterecommendations",
-      "community": 478
+      "community": 479
     },
     {
       "label": "getPerformanceSummary()",
@@ -42873,7 +42921,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L101",
       "id": "performance_analytics_getperformancesummary",
-      "community": 478
+      "community": 479
     },
     {
       "label": "getMetricsAnalytics()",
@@ -42881,7 +42929,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/performance-analytics.ts",
       "source_location": "L130",
       "id": "performance_analytics_getmetricsanalytics",
-      "community": 478
+      "community": 479
     },
     {
       "label": "failure-detector.spec.ts",
@@ -42889,7 +42937,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/failure-detector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_failure_detector_spec_ts",
-      "community": 1345
+      "community": 1346
     },
     {
       "label": "error-logging-service.spec.ts",
@@ -42897,7 +42945,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/error-logging-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_error_logging_service_spec_ts",
-      "community": 1346
+      "community": 1347
     },
     {
       "label": "alert-notification-service.spec.ts",
@@ -42905,7 +42953,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/alert-notification-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_alert_notification_service_spec_ts",
-      "community": 1347
+      "community": 1348
     },
     {
       "label": "performance-alert-service.spec.ts",
@@ -42913,7 +42961,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-alert-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_alert_service_spec_ts",
-      "community": 1348
+      "community": 1349
     },
     {
       "label": "performance-monitor.spec.ts",
@@ -42921,7 +42969,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_performance_monitor_spec_ts",
-      "community": 479
+      "community": 480
     },
     {
       "label": "toBytes()",
@@ -42929,7 +42977,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L8",
       "id": "performance_monitor_spec_tobytes",
-      "community": 479
+      "community": 480
     },
     {
       "label": "createMetrics()",
@@ -42937,7 +42985,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L10",
       "id": "performance_monitor_spec_createmetrics",
-      "community": 479
+      "community": 480
     },
     {
       "label": "mockNoConstrainedMemory()",
@@ -42945,7 +42993,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L261",
       "id": "performance_monitor_spec_mocknoconstrainedmemory",
-      "community": 479
+      "community": 480
     },
     {
       "label": "makeMonitor()",
@@ -42953,7 +43001,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/performance-monitor.spec.ts",
       "source_location": "L268",
       "id": "performance_monitor_spec_makemonitor",
-      "community": 479
+      "community": 480
     },
     {
       "label": "runtime-diagnostics-logger.spec.ts",
@@ -42961,7 +43009,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_tests_runtime_diagnostics_logger_spec_ts",
-      "community": 942
+      "community": 943
     },
     {
       "label": "restoreEnvValue()",
@@ -42969,7 +43017,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/__tests__/runtime-diagnostics-logger.spec.ts",
       "source_location": "L18",
       "id": "runtime_diagnostics_logger_spec_restoreenvvalue",
-      "community": 942
+      "community": 943
     },
     {
       "label": "quality-assurance-service.spec.ts",
@@ -42977,7 +43025,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_assurance_service_spec_ts",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -42985,7 +43033,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L13",
       "id": "quality_assurance_service_spec_createqualitymeasurementhistorytable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityMetricsTable()",
@@ -42993,7 +43041,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L37",
       "id": "quality_assurance_service_spec_createqualitymetricstable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43001,7 +43049,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-assurance-service.spec.ts",
       "source_location": "L63",
       "id": "quality_assurance_service_spec_createqualitythresholdstable",
-      "community": 587
+      "community": 588
     },
     {
       "label": "relation-metrics-collector.ts",
@@ -43009,7 +43057,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_relation_metrics_collector_ts",
-      "community": 480
+      "community": 481
     },
     {
       "label": "isRelationType()",
@@ -43017,7 +43065,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L9",
       "id": "relation_metrics_collector_isrelationtype",
-      "community": 480
+      "community": 481
     },
     {
       "label": "RelationMetricsCollector",
@@ -43025,7 +43073,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L13",
       "id": "relation_metrics_collector_relationmetricscollector",
-      "community": 480
+      "community": 481
     },
     {
       "label": ".constructor()",
@@ -43033,7 +43081,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L14",
       "id": "relation_metrics_collector_relationmetricscollector_constructor",
-      "community": 480
+      "community": 481
     },
     {
       "label": ".collect()",
@@ -43041,7 +43089,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/relation-metrics-collector.ts",
       "source_location": "L16",
       "id": "relation_metrics_collector_relationmetricscollector_collect",
-      "community": 480
+      "community": 481
     },
     {
       "label": "quality-recorder.ts",
@@ -43113,7 +43161,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_evaluator_spec_ts",
-      "community": 943
+      "community": 944
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43121,7 +43169,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-evaluator.spec.ts",
       "source_location": "L11",
       "id": "quality_evaluator_spec_createqualitythresholdstable",
-      "community": 943
+      "community": 944
     },
     {
       "label": "quality-threshold-manager.ts",
@@ -43201,7 +43249,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_threshold_manager_spec_ts",
-      "community": 944
+      "community": 945
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43209,7 +43257,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-threshold-manager.spec.ts",
       "source_location": "L10",
       "id": "quality_threshold_manager_spec_createqualitythresholdstable",
-      "community": 944
+      "community": 945
     },
     {
       "label": "category-quality-aggregator.ts",
@@ -43217,7 +43265,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_category_quality_aggregator_ts",
-      "community": 588
+      "community": 589
     },
     {
       "label": "CategoryQualityAggregator",
@@ -43225,7 +43273,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L23",
       "id": "category_quality_aggregator_categoryqualityaggregator",
-      "community": 588
+      "community": 589
     },
     {
       "label": ".constructor()",
@@ -43233,7 +43281,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L24",
       "id": "category_quality_aggregator_categoryqualityaggregator_constructor",
-      "community": 588
+      "community": 589
     },
     {
       "label": ".collect()",
@@ -43241,7 +43289,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/category-quality-aggregator.ts",
       "source_location": "L26",
       "id": "category_quality_aggregator_categoryqualityaggregator_collect",
-      "community": 588
+      "community": 589
     },
     {
       "label": "consolidation-metrics-collector.ts",
@@ -43249,7 +43297,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_consolidation_metrics_collector_ts",
-      "community": 589
+      "community": 590
     },
     {
       "label": "ConsolidationMetricsCollector",
@@ -43257,7 +43305,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L14",
       "id": "consolidation_metrics_collector_consolidationmetricscollector",
-      "community": 589
+      "community": 590
     },
     {
       "label": ".constructor()",
@@ -43265,7 +43313,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L15",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_constructor",
-      "community": 589
+      "community": 590
     },
     {
       "label": ".collect()",
@@ -43273,7 +43321,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/consolidation-metrics-collector.ts",
       "source_location": "L17",
       "id": "consolidation_metrics_collector_consolidationmetricscollector_collect",
-      "community": 589
+      "community": 590
     },
     {
       "label": "quality-report-renderers.ts",
@@ -43393,7 +43441,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_reporter_spec_ts",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -43401,7 +43449,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L14",
       "id": "quality_reporter_spec_createqualitymeasurementhistorytable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createQualityMetricsTable()",
@@ -43409,7 +43457,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L38",
       "id": "quality_reporter_spec_createqualitymetricstable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43417,7 +43465,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-reporter.spec.ts",
       "source_location": "L64",
       "id": "quality_reporter_spec_createqualitythresholdstable",
-      "community": 590
+      "community": 591
     },
     {
       "label": "storage-metrics-collector.ts",
@@ -43425,7 +43473,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_storage_metrics_collector_ts",
-      "community": 591
+      "community": 592
     },
     {
       "label": "StorageMetricsCollector",
@@ -43433,7 +43481,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L5",
       "id": "storage_metrics_collector_storagemetricscollector",
-      "community": 591
+      "community": 592
     },
     {
       "label": ".constructor()",
@@ -43441,7 +43489,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L6",
       "id": "storage_metrics_collector_storagemetricscollector_constructor",
-      "community": 591
+      "community": 592
     },
     {
       "label": ".collect()",
@@ -43449,7 +43497,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/storage-metrics-collector.ts",
       "source_location": "L8",
       "id": "storage_metrics_collector_storagemetricscollector_collect",
-      "community": 591
+      "community": 592
     },
     {
       "label": "quality-metrics-collector.spec.ts",
@@ -43457,7 +43505,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-collector.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_collector_spec_ts",
-      "community": 1349
+      "community": 1350
     },
     {
       "label": "quality-assurance-service.ts",
@@ -43657,7 +43705,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_search_metrics_collector_ts",
-      "community": 481
+      "community": 482
     },
     {
       "label": "calculateMRR()",
@@ -43665,7 +43713,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L31",
       "id": "search_metrics_collector_calculatemrr",
-      "community": 481
+      "community": 482
     },
     {
       "label": "SearchMetricsCollector",
@@ -43673,7 +43721,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L64",
       "id": "search_metrics_collector_searchmetricscollector",
-      "community": 481
+      "community": 482
     },
     {
       "label": ".constructor()",
@@ -43681,7 +43729,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L65",
       "id": "search_metrics_collector_searchmetricscollector_constructor",
-      "community": 481
+      "community": 482
     },
     {
       "label": ".collect()",
@@ -43689,7 +43737,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/search-metrics-collector.ts",
       "source_location": "L67",
       "id": "search_metrics_collector_searchmetricscollector_collect",
-      "community": 481
+      "community": 482
     },
     {
       "label": "quality-evaluator.ts",
@@ -43769,7 +43817,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-metrics-types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_metrics_types_ts",
-      "community": 1350
+      "community": 1351
     },
     {
       "label": "quality-recorder.spec.ts",
@@ -43777,7 +43825,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_domains_monitoring_services_quality_assurance_quality_recorder_spec_ts",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createQualityMeasurementHistoryTable()",
@@ -43785,7 +43833,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L14",
       "id": "quality_recorder_spec_createqualitymeasurementhistorytable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createQualityMetricsTable()",
@@ -43793,7 +43841,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L38",
       "id": "quality_recorder_spec_createqualitymetricstable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "createQualityThresholdsTable()",
@@ -43801,7 +43849,7 @@
       "source_file": "packages/memento-core/src/domains/monitoring/services/quality-assurance/quality-recorder.spec.ts",
       "source_location": "L64",
       "id": "quality_recorder_spec_createqualitythresholdstable",
-      "community": 592
+      "community": 593
     },
     {
       "label": "migrate-embeddings-tool.ts",
@@ -43993,7 +44041,7 @@
       "source_file": "packages/memento-core/src/tools/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_tools_types_ts",
-      "community": 1351
+      "community": 1352
     },
     {
       "label": "base-tool.ts",
@@ -44289,7 +44337,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_bootstrap_ts",
-      "community": 945
+      "community": 946
     },
     {
       "label": "testBootstrapIntegration()",
@@ -44297,7 +44345,7 @@
       "source_file": "packages/memento-core/src/test/test-bootstrap.ts",
       "source_location": "L12",
       "id": "test_bootstrap_testbootstrapintegration",
-      "community": 945
+      "community": 946
     },
     {
       "label": "test-sleep-consolidation-isolation.spec.ts",
@@ -44305,7 +44353,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_isolation_spec_ts",
-      "community": 946
+      "community": 947
     },
     {
       "label": "measureRecall()",
@@ -44313,7 +44361,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation-isolation.spec.ts",
       "source_location": "L70",
       "id": "test_sleep_consolidation_isolation_spec_measurerecall",
-      "community": 946
+      "community": 947
     },
     {
       "label": "test-embedding.ts",
@@ -44321,7 +44369,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_embedding_ts",
-      "community": 947
+      "community": 948
     },
     {
       "label": "testEmbeddingFunctionality()",
@@ -44329,7 +44377,7 @@
       "source_file": "packages/memento-core/src/test/test-embedding.ts",
       "source_location": "L10",
       "id": "test_embedding_testembeddingfunctionality",
-      "community": 947
+      "community": 948
     },
     {
       "label": "test-tool-consistency.ts",
@@ -44337,7 +44385,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_tool_consistency_ts",
-      "community": 713
+      "community": 715
     },
     {
       "label": "compareToolResults()",
@@ -44345,7 +44393,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L16",
       "id": "test_tool_consistency_comparetoolresults",
-      "community": 713
+      "community": 715
     },
     {
       "label": "testToolConsistency()",
@@ -44353,7 +44401,7 @@
       "source_file": "packages/memento-core/src/test/test-tool-consistency.ts",
       "source_location": "L73",
       "id": "test_tool_consistency_testtoolconsistency",
-      "community": 713
+      "community": 715
     },
     {
       "label": "test-quality-assurance.ts",
@@ -44361,7 +44409,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_quality_assurance_ts",
-      "community": 714
+      "community": 716
     },
     {
       "label": "createQualityTables()",
@@ -44369,7 +44417,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L18",
       "id": "test_quality_assurance_createqualitytables",
-      "community": 714
+      "community": 716
     },
     {
       "label": "testQualityAssuranceE2E()",
@@ -44377,7 +44425,7 @@
       "source_file": "packages/memento-core/src/test/test-quality-assurance.ts",
       "source_location": "L69",
       "id": "test_quality_assurance_testqualityassurancee2e",
-      "community": 714
+      "community": 716
     },
     {
       "label": "embedding-performance-benchmark.ts",
@@ -44385,7 +44433,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_performance_benchmark_ts",
-      "community": 482
+      "community": 483
     },
     {
       "label": "PerformanceBenchmark",
@@ -44393,7 +44441,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L42",
       "id": "embedding_performance_benchmark_performancebenchmark",
-      "community": 482
+      "community": 483
     },
     {
       "label": ".measureOperation()",
@@ -44401,7 +44449,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L45",
       "id": "embedding_performance_benchmark_performancebenchmark_measureoperation",
-      "community": 482
+      "community": 483
     },
     {
       "label": ".getResults()",
@@ -44409,7 +44457,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L82",
       "id": "embedding_performance_benchmark_performancebenchmark_getresults",
-      "community": 482
+      "community": 483
     },
     {
       "label": ".getSummary()",
@@ -44417,7 +44465,7 @@
       "source_file": "packages/memento-core/src/test/embedding-performance-benchmark.ts",
       "source_location": "L86",
       "id": "embedding_performance_benchmark_performancebenchmark_getsummary",
-      "community": 482
+      "community": 483
     },
     {
       "label": "test-search.ts",
@@ -44425,7 +44473,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_search_ts",
-      "community": 948
+      "community": 949
     },
     {
       "label": "testSearchFunctionality()",
@@ -44433,7 +44481,7 @@
       "source_file": "packages/memento-core/src/test/test-search.ts",
       "source_location": "L8",
       "id": "test_search_testsearchfunctionality",
-      "community": 948
+      "community": 949
     },
     {
       "label": "test-forgetting.ts",
@@ -44441,7 +44489,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_forgetting_ts",
-      "community": 949
+      "community": 950
     },
     {
       "label": "testForgettingFunctionality()",
@@ -44449,7 +44497,7 @@
       "source_file": "packages/memento-core/src/test/test-forgetting.ts",
       "source_location": "L9",
       "id": "test_forgetting_testforgettingfunctionality",
-      "community": 949
+      "community": 950
     },
     {
       "label": "mock-database.spec.ts",
@@ -44457,7 +44505,7 @@
       "source_file": "packages/memento-core/src/test/mock-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_mock_database_spec_ts",
-      "community": 1352
+      "community": 1353
     },
     {
       "label": "test-m1-completion.ts",
@@ -44465,7 +44513,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_m1_completion_ts",
-      "community": 950
+      "community": 951
     },
     {
       "label": "testM1Completion()",
@@ -44473,7 +44521,7 @@
       "source_file": "packages/memento-core/src/test/test-m1-completion.ts",
       "source_location": "L9",
       "id": "test_m1_completion_testm1completion",
-      "community": 950
+      "community": 951
     },
     {
       "label": "test-gemini-embedding.ts",
@@ -44481,7 +44529,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_gemini_embedding_ts",
-      "community": 951
+      "community": 952
     },
     {
       "label": "testGeminiEmbeddingService()",
@@ -44489,7 +44537,7 @@
       "source_file": "packages/memento-core/src/test/test-gemini-embedding.ts",
       "source_location": "L13",
       "id": "test_gemini_embedding_testgeminiembeddingservice",
-      "community": 951
+      "community": 952
     },
     {
       "label": "vitest.setup.ts",
@@ -44497,7 +44545,7 @@
       "source_file": "packages/memento-core/src/test/vitest.setup.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_vitest_setup_ts",
-      "community": 1353
+      "community": 1354
     },
     {
       "label": "test-feedback-ranking.spec.ts",
@@ -44505,7 +44553,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_feedback_ranking_spec_ts",
-      "community": 952
+      "community": 953
     },
     {
       "label": "parseItems()",
@@ -44513,7 +44561,7 @@
       "source_file": "packages/memento-core/src/test/test-feedback-ranking.spec.ts",
       "source_location": "L82",
       "id": "test_feedback_ranking_spec_parseitems",
-      "community": 952
+      "community": 953
     },
     {
       "label": "test-memory-resource.ts",
@@ -44521,7 +44569,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_resource_ts",
-      "community": 715
+      "community": 717
     },
     {
       "label": "setupResourceHandlers()",
@@ -44529,7 +44577,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L296",
       "id": "test_memory_resource_setupresourcehandlers",
-      "community": 715
+      "community": 717
     },
     {
       "label": "createTestMemories()",
@@ -44537,7 +44585,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-resource.ts",
       "source_location": "L393",
       "id": "test_memory_resource_createtestmemories",
-      "community": 715
+      "community": 717
     },
     {
       "label": "test-regression.ts",
@@ -44545,7 +44593,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_regression_ts",
-      "community": 953
+      "community": 954
     },
     {
       "label": "testRegression()",
@@ -44553,7 +44601,7 @@
       "source_file": "packages/memento-core/src/test/test-regression.ts",
       "source_location": "L14",
       "id": "test_regression_testregression",
-      "community": 953
+      "community": 954
     },
     {
       "label": "test-anchor-system.ts",
@@ -44617,7 +44665,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_quality_with_consolidation_spec_ts",
-      "community": 1354
+      "community": 1355
     },
     {
       "label": "multi-provider-search-performance-benchmark.ts",
@@ -44689,7 +44737,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_single_provider_regression_ts",
-      "community": 954
+      "community": 955
     },
     {
       "label": "testSingleProviderRegression()",
@@ -44697,7 +44745,7 @@
       "source_file": "packages/memento-core/src/test/test-single-provider-regression.ts",
       "source_location": "L30",
       "id": "test_single_provider_regression_testsingleproviderregression",
-      "community": 954
+      "community": 955
     },
     {
       "label": "visualize-recency.ts",
@@ -44761,7 +44809,7 @@
       "source_file": "packages/memento-core/src/test/embedding-integration-test.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_embedding_integration_test_ts",
-      "community": 1355
+      "community": 1356
     },
     {
       "label": "test-consolidation-search-quality.ts",
@@ -44825,7 +44873,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_vector_search_engine_ts",
-      "community": 955
+      "community": 956
     },
     {
       "label": "constructor()",
@@ -44833,7 +44881,7 @@
       "source_file": "packages/memento-core/src/test/test-vector-search-engine.ts",
       "source_location": "L18",
       "id": "test_vector_search_engine_constructor",
-      "community": 955
+      "community": 956
     },
     {
       "label": "mock-database.ts",
@@ -45065,7 +45113,7 @@
       "source_file": "packages/memento-core/src/test/test-batch-scheduler.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_batch_scheduler_ts",
-      "community": 1356
+      "community": 1357
     },
     {
       "label": "test-telemetry.spec.ts",
@@ -45073,7 +45121,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_telemetry_spec_ts",
-      "community": 593
+      "community": 594
     },
     {
       "label": "telemetryDb()",
@@ -45081,7 +45129,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L14",
       "id": "test_telemetry_spec_telemetrydb",
-      "community": 593
+      "community": 594
     },
     {
       "label": "percentile95()",
@@ -45089,7 +45137,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L21",
       "id": "test_telemetry_spec_percentile95",
-      "community": 593
+      "community": 594
     },
     {
       "label": "run()",
@@ -45097,7 +45145,7 @@
       "source_file": "packages/memento-core/src/test/test-telemetry.spec.ts",
       "source_location": "L68",
       "id": "test_telemetry_spec_run",
-      "community": 593
+      "community": 594
     },
     {
       "label": "test-memory-neighbors.ts",
@@ -45105,7 +45153,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_neighbors_ts",
-      "community": 956
+      "community": 957
     },
     {
       "label": "createTestMemories()",
@@ -45113,7 +45161,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-neighbors.ts",
       "source_location": "L289",
       "id": "test_memory_neighbors_createtestmemories",
-      "community": 956
+      "community": 957
     },
     {
       "label": "test-lightweight-embedding.ts",
@@ -45121,7 +45169,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_lightweight_embedding_ts",
-      "community": 957
+      "community": 958
     },
     {
       "label": "testLightweightEmbeddingFunctionality()",
@@ -45129,7 +45177,7 @@
       "source_file": "packages/memento-core/src/test/test-lightweight-embedding.ts",
       "source_location": "L9",
       "id": "test_lightweight_embedding_testlightweightembeddingfunctionality",
-      "community": 957
+      "community": 958
     },
     {
       "label": "test-memory-injection-prompt.ts",
@@ -45137,7 +45185,7 @@
       "source_file": "packages/memento-core/src/test/test-memory-injection-prompt.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_memory_injection_prompt_ts",
-      "community": 1357
+      "community": 1358
     },
     {
       "label": "test-sleep-consolidation.spec.ts",
@@ -45145,7 +45193,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_test_sleep_consolidation_spec_ts",
-      "community": 958
+      "community": 959
     },
     {
       "label": "seedCluster()",
@@ -45153,7 +45201,7 @@
       "source_file": "packages/memento-core/src/test/test-sleep-consolidation.spec.ts",
       "source_location": "L36",
       "id": "test_sleep_consolidation_spec_seedcluster",
-      "community": 958
+      "community": 959
     },
     {
       "label": "dependency-boundaries.spec.ts",
@@ -45161,7 +45209,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_architecture_dependency_boundaries_spec_ts",
-      "community": 716
+      "community": 718
     },
     {
       "label": "readSource()",
@@ -45169,7 +45217,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L15",
       "id": "dependency_boundaries_spec_readsource",
-      "community": 716
+      "community": 718
     },
     {
       "label": "collectDomainProductionFiles()",
@@ -45177,7 +45225,7 @@
       "source_file": "packages/memento-core/src/test/architecture/dependency-boundaries.spec.ts",
       "source_location": "L19",
       "id": "dependency_boundaries_spec_collectdomainproductionfiles",
-      "community": 716
+      "community": 718
     },
     {
       "label": "search-quality-benchmark-builder.ts",
@@ -45185,7 +45233,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_ts",
-      "community": 594
+      "community": 595
     },
     {
       "label": "extractBenchmarkSequence()",
@@ -45193,7 +45241,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L18",
       "id": "search_quality_benchmark_builder_extractbenchmarksequence",
-      "community": 594
+      "community": 595
     },
     {
       "label": "normalizeTags()",
@@ -45201,7 +45249,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L23",
       "id": "search_quality_benchmark_builder_normalizetags",
-      "community": 594
+      "community": 595
     },
     {
       "label": "buildBenchmarkCorpus()",
@@ -45209,7 +45257,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.ts",
       "source_location": "L44",
       "id": "search_quality_benchmark_builder_buildbenchmarkcorpus",
-      "community": 594
+      "community": 595
     },
     {
       "label": "search-quality-review-verifier.spec.ts",
@@ -45217,7 +45265,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_spec_ts",
-      "community": 959
+      "community": 960
     },
     {
       "label": "writeFixtureDir()",
@@ -45225,7 +45273,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.spec.ts",
       "source_location": "L7",
       "id": "search_quality_review_verifier_spec_writefixturedir",
-      "community": 959
+      "community": 960
     },
     {
       "label": "search-quality-metrics.ts",
@@ -45321,7 +45369,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-checklist.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_checklist_spec_ts",
-      "community": 1358
+      "community": 1359
     },
     {
       "label": "search-quality-review-checklist.ts",
@@ -45385,7 +45433,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_ts",
-      "community": 483
+      "community": 484
     },
     {
       "label": "mulberry32()",
@@ -45393,7 +45441,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L22",
       "id": "benchmark_search_database_mulberry32",
-      "community": 483
+      "community": 484
     },
     {
       "label": "normalizeMemoryType()",
@@ -45401,7 +45449,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L33",
       "id": "benchmark_search_database_normalizememorytype",
-      "community": 483
+      "community": 484
     },
     {
       "label": "createSeededBenchmarkDatabase()",
@@ -45409,7 +45457,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L50",
       "id": "benchmark_search_database_createseededbenchmarkdatabase",
-      "community": 483
+      "community": 484
     },
     {
       "label": "seedOneCorpusRow()",
@@ -45417,7 +45465,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.ts",
       "source_location": "L134",
       "id": "benchmark_search_database_seedonecorpusrow",
-      "community": 483
+      "community": 484
     },
     {
       "label": "vector-search-quality-metrics.spec.ts",
@@ -45425,7 +45473,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spec_ts",
-      "community": 1359
+      "community": 1360
     },
     {
       "label": "search-quality-candidate-builder.spec.ts",
@@ -45433,7 +45481,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_spec_ts",
-      "community": 1360
+      "community": 1361
     },
     {
       "label": "test-database.ts",
@@ -45465,7 +45513,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_candidate_builder_ts",
-      "community": 960
+      "community": 961
     },
     {
       "label": "mergeCandidateIds()",
@@ -45473,7 +45521,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-candidate-builder.ts",
       "source_location": "L9",
       "id": "search_quality_candidate_builder_mergecandidateids",
-      "community": 960
+      "community": 961
     },
     {
       "label": "search-quality-review-verifier.ts",
@@ -45481,7 +45529,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_review_verifier_ts",
-      "community": 717
+      "community": 719
     },
     {
       "label": "normalizeBenchmarkGroundTruths()",
@@ -45489,7 +45537,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L25",
       "id": "search_quality_review_verifier_normalizebenchmarkgroundtruths",
-      "community": 717
+      "community": 719
     },
     {
       "label": "verifyReviewableBenchmark()",
@@ -45497,7 +45545,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-review-verifier.ts",
       "source_location": "L45",
       "id": "search_quality_review_verifier_verifyreviewablebenchmark",
-      "community": 717
+      "community": 719
     },
     {
       "label": "search-quality-benchmark-builder.spec.ts",
@@ -45505,7 +45553,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-builder.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_builder_spec_ts",
-      "community": 1361
+      "community": 1362
     },
     {
       "label": "search-quality-benchmark-fixtures.spec.ts",
@@ -45513,7 +45561,7 @@
       "source_file": "packages/memento-core/src/test/helpers/search-quality-benchmark-fixtures.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_search_quality_benchmark_fixtures_spec_ts",
-      "community": 1362
+      "community": 1363
     },
     {
       "label": "search-quality-benchmark-fixtures.ts",
@@ -45713,7 +45761,7 @@
       "source_file": "packages/memento-core/src/test/helpers/benchmark-search-database.spec.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_benchmark_search_database_spec_ts",
-      "community": 1363
+      "community": 1364
     },
     {
       "label": "query-counter.ts",
@@ -45721,7 +45769,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_query_counter_ts",
-      "community": 595
+      "community": 596
     },
     {
       "label": "extractQueryType()",
@@ -45729,7 +45777,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L54",
       "id": "query_counter_extractquerytype",
-      "community": 595
+      "community": 596
     },
     {
       "label": "isExcluded()",
@@ -45737,7 +45785,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L73",
       "id": "query_counter_isexcluded",
-      "community": 595
+      "community": 596
     },
     {
       "label": "createQueryCounter()",
@@ -45745,7 +45793,7 @@
       "source_file": "packages/memento-core/src/test/helpers/query-counter.ts",
       "source_location": "L85",
       "id": "query_counter_createquerycounter",
-      "community": 595
+      "community": 596
     },
     {
       "label": "vector-search-quality-metrics.ts",
@@ -45753,7 +45801,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_ts",
-      "community": 1364
+      "community": 1365
     },
     {
       "label": "top-k-retention.ts",
@@ -45761,7 +45809,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_top_k_retention_ts",
-      "community": 961
+      "community": 962
     },
     {
       "label": "calculateTopKRetention()",
@@ -45769,7 +45817,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/top-k-retention.ts",
       "source_location": "L29",
       "id": "top_k_retention_calculatetopkretention",
-      "community": 961
+      "community": 962
     },
     {
       "label": "types.ts",
@@ -45777,7 +45825,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/types.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_types_ts",
-      "community": 1365
+      "community": 1366
     },
     {
       "label": "kendall-tau.ts",
@@ -45833,7 +45881,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L1",
       "id": "packages_memento_core_src_test_helpers_vector_search_quality_metrics_spearman_ts",
-      "community": 718
+      "community": 720
     },
     {
       "label": "calculateSpearmanRho()",
@@ -45841,7 +45889,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L27",
       "id": "spearman_calculatespearmanrho",
-      "community": 718
+      "community": 720
     },
     {
       "label": "calculateRanks()",
@@ -45849,7 +45897,7 @@
       "source_file": "packages/memento-core/src/test/helpers/vector-search-quality-metrics/spearman.ts",
       "source_location": "L81",
       "id": "spearman_calculateranks",
-      "community": 718
+      "community": 720
     },
     {
       "label": "report-comparison.ts",
@@ -46153,7 +46201,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L1",
       "id": "packages_memento_core_scripts_copy_assets_js",
-      "community": 962
+      "community": 963
     },
     {
       "label": "copyDir()",
@@ -46161,7 +46209,7 @@
       "source_file": "packages/memento-core/scripts/copy-assets.js",
       "source_location": "L31",
       "id": "copy_assets_copydir",
-      "community": 962
+      "community": 963
     },
     {
       "label": "npm-publish-bin.spec.ts",
@@ -46169,7 +46217,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L1",
       "id": "tests_npm_publish_bin_spec_ts",
-      "community": 963
+      "community": 964
     },
     {
       "label": "readRootPackageJson()",
@@ -46177,7 +46225,7 @@
       "source_file": "tests/npm-publish-bin.spec.ts",
       "source_location": "L9",
       "id": "npm_publish_bin_spec_readrootpackagejson",
-      "community": 963
+      "community": 964
     },
     {
       "label": "memory-export-import.spec.ts",
@@ -46185,7 +46233,7 @@
       "source_file": "tests/memory-export-import.spec.ts",
       "source_location": "L1",
       "id": "tests_memory_export_import_spec_ts",
-      "community": 1366
+      "community": 1367
     },
     {
       "label": "workspace-client-paths.spec.ts",
@@ -46193,7 +46241,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L1",
       "id": "tests_workspace_client_paths_spec_ts",
-      "community": 964
+      "community": 965
     },
     {
       "label": "readJson()",
@@ -46201,7 +46249,7 @@
       "source_file": "tests/workspace-client-paths.spec.ts",
       "source_location": "L11",
       "id": "workspace_client_paths_spec_readjson",
-      "community": 964
+      "community": 965
     },
     {
       "label": "security-check-workflow.spec.ts",
@@ -46209,7 +46257,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L1",
       "id": "tests_security_check_workflow_spec_ts",
-      "community": 965
+      "community": 966
     },
     {
       "label": "readWorkflow()",
@@ -46217,7 +46265,7 @@
       "source_file": "tests/security-check-workflow.spec.ts",
       "source_location": "L5",
       "id": "security_check_workflow_spec_readworkflow",
-      "community": 965
+      "community": 966
     },
     {
       "label": "root-quality-gates.spec.ts",
@@ -46289,7 +46337,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L1",
       "id": "tests_static_design_contracts_spec_ts",
-      "community": 719
+      "community": 721
     },
     {
       "label": "readStaticFile()",
@@ -46297,7 +46345,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L5",
       "id": "static_design_contracts_spec_readstaticfile",
-      "community": 719
+      "community": 721
     },
     {
       "label": "getFunctionMetrics()",
@@ -46305,7 +46353,7 @@
       "source_file": "tests/static-design-contracts.spec.ts",
       "source_location": "L9",
       "id": "static_design_contracts_spec_getfunctionmetrics",
-      "community": 719
+      "community": 721
     },
     {
       "label": "anchor-map.e2e.ts",
@@ -46313,7 +46361,7 @@
       "source_file": "tests/e2e/dashboard/anchor-map.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_anchor_map_e2e_ts",
-      "community": 1367
+      "community": 1368
     },
     {
       "label": "agent-sessions.e2e.ts",
@@ -46321,7 +46369,7 @@
       "source_file": "tests/e2e/dashboard/agent-sessions.e2e.ts",
       "source_location": "L1",
       "id": "tests_e2e_dashboard_agent_sessions_e2e_ts",
-      "community": 1368
+      "community": 1369
     },
     {
       "label": "agent-sessions.fixtures.ts",
@@ -46385,7 +46433,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L1",
       "id": "tests_integrations_smoke_spec_ts",
-      "community": 966
+      "community": 967
     },
     {
       "label": "extractFencedBlocks()",
@@ -46393,7 +46441,7 @@
       "source_file": "tests/integrations/smoke.spec.ts",
       "source_location": "L9",
       "id": "smoke_spec_extractfencedblocks",
-      "community": 966
+      "community": 967
     },
     {
       "label": "check-legacy-script-usage.ts",
@@ -46465,7 +46513,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_report_ts",
-      "community": 596
+      "community": 597
     },
     {
       "label": "parseArgs()",
@@ -46473,7 +46521,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L44",
       "id": "quality_report_parseargs",
-      "community": 596
+      "community": 597
     },
     {
       "label": "printHelp()",
@@ -46481,7 +46529,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L85",
       "id": "quality_report_printhelp",
-      "community": 596
+      "community": 597
     },
     {
       "label": "main()",
@@ -46489,7 +46537,7 @@
       "source_file": "scripts/quality-report.ts",
       "source_location": "L114",
       "id": "quality_report_main",
-      "community": 596
+      "community": 597
     },
     {
       "label": "check-magic-numbers.ts",
@@ -46577,7 +46625,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L1",
       "id": "scripts_prepack_bundle_core_js",
-      "community": 967
+      "community": 968
     },
     {
       "label": "shouldInclude()",
@@ -46585,7 +46633,7 @@
       "source_file": "scripts/prepack-bundle-core.js",
       "source_location": "L51",
       "id": "prepack_bundle_core_shouldinclude",
-      "community": 967
+      "community": 968
     },
     {
       "label": "verify-npm-pack-bundle.js",
@@ -46593,7 +46641,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L1",
       "id": "scripts_verify_npm_pack_bundle_js",
-      "community": 720
+      "community": 722
     },
     {
       "label": "listUstarGzipEntryPaths()",
@@ -46601,7 +46649,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L31",
       "id": "verify_npm_pack_bundle_listustargzipentrypaths",
-      "community": 720
+      "community": 722
     },
     {
       "label": "readTarString()",
@@ -46609,7 +46657,7 @@
       "source_file": "scripts/verify-npm-pack-bundle.js",
       "source_location": "L54",
       "id": "verify_npm_pack_bundle_readtarstring",
-      "community": 720
+      "community": 722
     },
     {
       "label": "generate-search-quality-candidates.ts",
@@ -46673,7 +46721,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L1",
       "id": "scripts_fix_migration_js",
-      "community": 968
+      "community": 969
     },
     {
       "label": "fixMigration()",
@@ -46681,7 +46729,7 @@
       "source_file": "scripts/fix-migration.js",
       "source_location": "L21",
       "id": "fix_migration_fixmigration",
-      "community": 968
+      "community": 969
     },
     {
       "label": "sync-root-server-dist.js",
@@ -46689,7 +46737,7 @@
       "source_file": "scripts/sync-root-server-dist.js",
       "source_location": "L1",
       "id": "scripts_sync_root_server_dist_js",
-      "community": 1369
+      "community": 1370
     },
     {
       "label": "compare-weight-profiles.ts",
@@ -46905,7 +46953,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L1",
       "id": "scripts_verify_search_quality_benchmark_review_ts",
-      "community": 597
+      "community": 598
     },
     {
       "label": "parseArgs()",
@@ -46913,7 +46961,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L12",
       "id": "verify_search_quality_benchmark_review_parseargs",
-      "community": 597
+      "community": 598
     },
     {
       "label": "printHelp()",
@@ -46921,7 +46969,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L44",
       "id": "verify_search_quality_benchmark_review_printhelp",
-      "community": 597
+      "community": 598
     },
     {
       "label": "main()",
@@ -46929,7 +46977,7 @@
       "source_file": "scripts/verify-search-quality-benchmark-review.ts",
       "source_location": "L55",
       "id": "verify_search_quality_benchmark_review_main",
-      "community": 597
+      "community": 598
     },
     {
       "label": "check-path-traversal.ts",
@@ -47129,7 +47177,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_ts",
-      "community": 598
+      "community": 599
     },
     {
       "label": "buildLongMemEvalDatasetUrl()",
@@ -47137,7 +47185,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L19",
       "id": "acquire_longmemeval_buildlongmemevaldataseturl",
-      "community": 598
+      "community": 599
     },
     {
       "label": "acquireLongMemEval()",
@@ -47145,7 +47193,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L29",
       "id": "acquire_longmemeval_acquirelongmemeval",
-      "community": 598
+      "community": 599
     },
     {
       "label": "main()",
@@ -47153,7 +47201,7 @@
       "source_file": "scripts/acquire-longmemeval.ts",
       "source_location": "L65",
       "id": "acquire_longmemeval_main",
-      "community": 598
+      "community": 599
     },
     {
       "label": "agent-memory-benchmark.ts",
@@ -47441,7 +47489,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L1",
       "id": "scripts_quality_thresholds_ts",
-      "community": 484
+      "community": 485
     },
     {
       "label": "parseArgs()",
@@ -47449,7 +47497,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L43",
       "id": "quality_thresholds_parseargs",
-      "community": 484
+      "community": 485
     },
     {
       "label": "printHelp()",
@@ -47457,7 +47505,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L87",
       "id": "quality_thresholds_printhelp",
-      "community": 484
+      "community": 485
     },
     {
       "label": "printThresholds()",
@@ -47465,7 +47513,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L125",
       "id": "quality_thresholds_printthresholds",
-      "community": 484
+      "community": 485
     },
     {
       "label": "main()",
@@ -47473,7 +47521,7 @@
       "source_file": "scripts/quality-thresholds.ts",
       "source_location": "L151",
       "id": "quality_thresholds_main",
-      "community": 484
+      "community": 485
     },
     {
       "label": "simple-update.js",
@@ -47481,7 +47529,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L1",
       "id": "scripts_simple_update_js",
-      "community": 969
+      "community": 970
     },
     {
       "label": "updateEmbeddings()",
@@ -47489,7 +47537,7 @@
       "source_file": "scripts/simple-update.js",
       "source_location": "L23",
       "id": "simple_update_updateembeddings",
-      "community": 969
+      "community": 970
     },
     {
       "label": "memory-export.ts",
@@ -47497,7 +47545,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L1",
       "id": "scripts_memory_export_ts",
-      "community": 599
+      "community": 600
     },
     {
       "label": "parseArgs()",
@@ -47505,7 +47553,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L20",
       "id": "memory_export_parseargs",
-      "community": 599
+      "community": 600
     },
     {
       "label": "printHelp()",
@@ -47513,7 +47561,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L47",
       "id": "memory_export_printhelp",
-      "community": 599
+      "community": 600
     },
     {
       "label": "main()",
@@ -47521,7 +47569,7 @@
       "source_file": "scripts/memory-export.ts",
       "source_location": "L65",
       "id": "memory_export_main",
-      "community": 599
+      "community": 600
     },
     {
       "label": "agent-smoke-matrix.spec.ts",
@@ -47529,7 +47577,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_smoke_matrix_spec_ts",
-      "community": 721
+      "community": 723
     },
     {
       "label": "temporaryRoot()",
@@ -47537,7 +47585,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L14",
       "id": "agent_smoke_matrix_spec_temporaryroot",
-      "community": 721
+      "community": 723
     },
     {
       "label": "dependencies()",
@@ -47545,7 +47593,7 @@
       "source_file": "scripts/agent-smoke-matrix.spec.ts",
       "source_location": "L24",
       "id": "agent_smoke_matrix_spec_dependencies",
-      "community": 721
+      "community": 723
     },
     {
       "label": "export-search-quality-benchmark.ts",
@@ -47641,7 +47689,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L1",
       "id": "scripts_reindex_embeddings_ts",
-      "community": 722
+      "community": 724
     },
     {
       "label": "option()",
@@ -47649,7 +47697,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L3",
       "id": "reindex_embeddings_option",
-      "community": 722
+      "community": 724
     },
     {
       "label": "main()",
@@ -47657,7 +47705,7 @@
       "source_file": "scripts/reindex-embeddings.ts",
       "source_location": "L8",
       "id": "reindex_embeddings_main",
-      "community": 722
+      "community": 724
     },
     {
       "label": "check-pii-masking.ts",
@@ -47737,7 +47785,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_migrate_wrapper_ts",
-      "community": 970
+      "community": 971
     },
     {
       "label": "analyzeEmbeddings()",
@@ -47745,7 +47793,7 @@
       "source_file": "scripts/simple-migrate-wrapper.ts",
       "source_location": "L26",
       "id": "simple_migrate_wrapper_analyzeembeddings",
-      "community": 970
+      "community": 971
     },
     {
       "label": "test-docker.js",
@@ -47753,7 +47801,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L1",
       "id": "scripts_test_docker_js",
-      "community": 723
+      "community": 725
     },
     {
       "label": "fetchJson()",
@@ -47761,7 +47809,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L7",
       "id": "test_docker_fetchjson",
-      "community": 723
+      "community": 725
     },
     {
       "label": "testDockerServer()",
@@ -47769,7 +47817,7 @@
       "source_file": "scripts/test-docker.js",
       "source_location": "L23",
       "id": "test_docker_testdockerserver",
-      "community": 723
+      "community": 725
     },
     {
       "label": "pack-with-restore.js",
@@ -47777,7 +47825,7 @@
       "source_file": "scripts/pack-with-restore.js",
       "source_location": "L1",
       "id": "scripts_pack_with_restore_js",
-      "community": 1370
+      "community": 1371
     },
     {
       "label": "run-migration.js",
@@ -47785,7 +47833,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L1",
       "id": "scripts_run_migration_js",
-      "community": 971
+      "community": 972
     },
     {
       "label": "runMigration()",
@@ -47793,7 +47841,7 @@
       "source_file": "scripts/run-migration.js",
       "source_location": "L20",
       "id": "run_migration_runmigration",
-      "community": 971
+      "community": 972
     },
     {
       "label": "safe-migration.js",
@@ -47801,7 +47849,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L1",
       "id": "scripts_safe_migration_js",
-      "community": 972
+      "community": 973
     },
     {
       "label": "safeMigration()",
@@ -47809,7 +47857,7 @@
       "source_file": "scripts/safe-migration.js",
       "source_location": "L21",
       "id": "safe_migration_safemigration",
-      "community": 972
+      "community": 973
     },
     {
       "label": "generate-ground-truth.ts",
@@ -47873,7 +47921,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L1",
       "id": "scripts_save_work_memory_ts",
-      "community": 973
+      "community": 974
     },
     {
       "label": "saveWorkMemory()",
@@ -47881,7 +47929,7 @@
       "source_file": "scripts/save-work-memory.ts",
       "source_location": "L12",
       "id": "save_work_memory_saveworkmemory",
-      "community": 973
+      "community": 974
     },
     {
       "label": "check-file-sizes.ts",
@@ -48121,7 +48169,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_spec_ts",
-      "community": 1371
+      "community": 1372
     },
     {
       "label": "quality-benchmark-verify-categories.ts",
@@ -48129,7 +48177,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_verify_categories_ts",
-      "community": 974
+      "community": 975
     },
     {
       "label": "main()",
@@ -48137,7 +48185,7 @@
       "source_file": "scripts/quality-benchmark-verify-categories.ts",
       "source_location": "L26",
       "id": "quality_benchmark_verify_categories_main",
-      "community": 974
+      "community": 975
     },
     {
       "label": "agent-integration-release-gate.spec.ts",
@@ -48145,7 +48193,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_integration_release_gate_spec_ts",
-      "community": 600
+      "community": 601
     },
     {
       "label": "createDatabase()",
@@ -48153,7 +48201,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L8",
       "id": "agent_integration_release_gate_spec_createdatabase",
-      "community": 600
+      "community": 601
     },
     {
       "label": "passingEvidence()",
@@ -48161,7 +48209,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L49",
       "id": "agent_integration_release_gate_spec_passingevidence",
-      "community": 600
+      "community": 601
     },
     {
       "label": "seedPassingDatabase()",
@@ -48169,7 +48217,7 @@
       "source_file": "scripts/agent-integration-release-gate.spec.ts",
       "source_location": "L64",
       "id": "agent_integration_release_gate_spec_seedpassingdatabase",
-      "community": 600
+      "community": 601
     },
     {
       "label": "generate-search-quality-review-checklist.ts",
@@ -48177,7 +48225,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L1",
       "id": "scripts_generate_search_quality_review_checklist_ts",
-      "community": 601
+      "community": 602
     },
     {
       "label": "parseArgs()",
@@ -48185,7 +48233,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L13",
       "id": "generate_search_quality_review_checklist_parseargs",
-      "community": 601
+      "community": 602
     },
     {
       "label": "printHelp()",
@@ -48193,7 +48241,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L47",
       "id": "generate_search_quality_review_checklist_printhelp",
-      "community": 601
+      "community": 602
     },
     {
       "label": "main()",
@@ -48201,7 +48249,7 @@
       "source_file": "scripts/generate-search-quality-review-checklist.ts",
       "source_location": "L58",
       "id": "generate_search_quality_review_checklist_main",
-      "community": 601
+      "community": 602
     },
     {
       "label": "check-debt-markers.ts",
@@ -48257,7 +48305,7 @@
       "source_file": "scripts/verify-bin.js",
       "source_location": "L1",
       "id": "scripts_verify_bin_js",
-      "community": 1372
+      "community": 1373
     },
     {
       "label": "forgetting-events-query.ts",
@@ -48265,7 +48313,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L1",
       "id": "scripts_forgetting_events_query_ts",
-      "community": 602
+      "community": 603
     },
     {
       "label": "parseArgs()",
@@ -48273,7 +48321,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L20",
       "id": "forgetting_events_query_parseargs",
-      "community": 602
+      "community": 603
     },
     {
       "label": "printHelp()",
@@ -48281,7 +48329,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L49",
       "id": "forgetting_events_query_printhelp",
-      "community": 602
+      "community": 603
     },
     {
       "label": "main()",
@@ -48289,7 +48337,7 @@
       "source_file": "scripts/forgetting-events-query.ts",
       "source_location": "L65",
       "id": "forgetting_events_query_main",
-      "community": 602
+      "community": 603
     },
     {
       "label": "agent-memory-benchmark.spec.ts",
@@ -48297,7 +48345,7 @@
       "source_file": "scripts/agent-memory-benchmark.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_spec_ts",
-      "community": 1373
+      "community": 1374
     },
     {
       "label": "check-and-fix-trigger.ts",
@@ -48305,7 +48353,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L1",
       "id": "scripts_check_and_fix_trigger_ts",
-      "community": 485
+      "community": 486
     },
     {
       "label": "getTriggerInfo()",
@@ -48313,7 +48361,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L25",
       "id": "check_and_fix_trigger_gettriggerinfo",
-      "community": 485
+      "community": 486
     },
     {
       "label": "fixTriggers()",
@@ -48321,7 +48369,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L52",
       "id": "check_and_fix_trigger_fixtriggers",
-      "community": 485
+      "community": 486
     },
     {
       "label": "checkMigrationVersion()",
@@ -48329,7 +48377,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L121",
       "id": "check_and_fix_trigger_checkmigrationversion",
-      "community": 485
+      "community": 486
     },
     {
       "label": "main()",
@@ -48337,7 +48385,7 @@
       "source_file": "scripts/check-and-fix-trigger.ts",
       "source_location": "L168",
       "id": "check_and_fix_trigger_main",
-      "community": 485
+      "community": 486
     },
     {
       "label": "simple-migrate.js",
@@ -48345,7 +48393,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L1",
       "id": "scripts_simple_migrate_js",
-      "community": 975
+      "community": 976
     },
     {
       "label": "analyzeEmbeddings()",
@@ -48353,7 +48401,7 @@
       "source_file": "scripts/simple-migrate.js",
       "source_location": "L20",
       "id": "simple_migrate_analyzeembeddings",
-      "community": 975
+      "community": 976
     },
     {
       "label": "memory-import.ts",
@@ -48361,7 +48409,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L1",
       "id": "scripts_memory_import_ts",
-      "community": 603
+      "community": 604
     },
     {
       "label": "parseArgs()",
@@ -48369,7 +48417,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L27",
       "id": "memory_import_parseargs",
-      "community": 603
+      "community": 604
     },
     {
       "label": "printHelp()",
@@ -48377,7 +48425,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L60",
       "id": "memory_import_printhelp",
-      "community": 603
+      "community": 604
     },
     {
       "label": "main()",
@@ -48385,7 +48433,7 @@
       "source_file": "scripts/memory-import.ts",
       "source_location": "L79",
       "id": "memory_import_main",
-      "community": 603
+      "community": 604
     },
     {
       "label": "fix-vector-dimensions.js",
@@ -48393,7 +48441,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L1",
       "id": "scripts_fix_vector_dimensions_js",
-      "community": 976
+      "community": 977
     },
     {
       "label": "fixVectorDimensions()",
@@ -48401,7 +48449,7 @@
       "source_file": "scripts/fix-vector-dimensions.js",
       "source_location": "L19",
       "id": "fix_vector_dimensions_fixvectordimensions",
-      "community": 976
+      "community": 977
     },
     {
       "label": "quality-benchmark-category-report.ts",
@@ -48409,7 +48457,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_ts",
-      "community": 604
+      "community": 605
     },
     {
       "label": "formatCategoryReportLine()",
@@ -48417,7 +48465,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L27",
       "id": "quality_benchmark_category_report_formatcategoryreportline",
-      "community": 604
+      "community": 605
     },
     {
       "label": "anyCategoryFailsMrrGate()",
@@ -48425,7 +48473,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L32",
       "id": "quality_benchmark_category_report_anycategoryfailsmrrgate",
-      "community": 604
+      "community": 605
     },
     {
       "label": "main()",
@@ -48433,7 +48481,7 @@
       "source_file": "scripts/quality-benchmark-category-report.ts",
       "source_location": "L36",
       "id": "quality_benchmark_category_report_main",
-      "community": 604
+      "community": 605
     },
     {
       "label": "fix-tfidf-dimensions.ts",
@@ -48441,7 +48489,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_fix_tfidf_dimensions_ts",
-      "community": 724
+      "community": 726
     },
     {
       "label": "loadVecExtension()",
@@ -48449,7 +48497,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L21",
       "id": "fix_tfidf_dimensions_loadvecextension",
-      "community": 724
+      "community": 726
     },
     {
       "label": "fixTfidfDimensions()",
@@ -48457,7 +48505,7 @@
       "source_file": "scripts/fix-tfidf-dimensions.ts",
       "source_location": "L31",
       "id": "fix_tfidf_dimensions_fixtfidfdimensions",
-      "community": 724
+      "community": 726
     },
     {
       "label": "longmemeval-validation.spec.ts",
@@ -48465,7 +48513,7 @@
       "source_file": "scripts/longmemeval-validation.spec.ts",
       "source_location": "L1",
       "id": "scripts_longmemeval_validation_spec_ts",
-      "community": 1374
+      "community": 1375
     },
     {
       "label": "simple-update-wrapper.ts",
@@ -48473,7 +48521,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L1",
       "id": "scripts_simple_update_wrapper_ts",
-      "community": 977
+      "community": 978
     },
     {
       "label": "runUpdateMigration()",
@@ -48481,7 +48529,7 @@
       "source_file": "scripts/simple-update-wrapper.ts",
       "source_location": "L28",
       "id": "simple_update_wrapper_runupdatemigration",
-      "community": 977
+      "community": 978
     },
     {
       "label": "quality-feedback-reappearance-report.ts",
@@ -48489,7 +48537,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L1",
       "id": "scripts_quality_feedback_reappearance_report_ts",
-      "community": 725
+      "community": 727
     },
     {
       "label": "reappearanceRate()",
@@ -48497,7 +48545,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L18",
       "id": "quality_feedback_reappearance_report_reappearancerate",
-      "community": 725
+      "community": 727
     },
     {
       "label": "main()",
@@ -48505,7 +48553,7 @@
       "source_file": "scripts/quality-feedback-reappearance-report.ts",
       "source_location": "L34",
       "id": "quality_feedback_reappearance_report_main",
-      "community": 725
+      "community": 727
     },
     {
       "label": "acquire-longmemeval.spec.ts",
@@ -48513,7 +48561,7 @@
       "source_file": "scripts/acquire-longmemeval.spec.ts",
       "source_location": "L1",
       "id": "scripts_acquire_longmemeval_spec_ts",
-      "community": 1375
+      "community": 1376
     },
     {
       "label": "regenerate-embeddings.js",
@@ -48521,7 +48569,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L1",
       "id": "scripts_regenerate_embeddings_js",
-      "community": 978
+      "community": 979
     },
     {
       "label": "regenerateEmbeddings()",
@@ -48529,7 +48577,7 @@
       "source_file": "scripts/regenerate-embeddings.js",
       "source_location": "L19",
       "id": "regenerate_embeddings_regenerateembeddings",
-      "community": 978
+      "community": 979
     },
     {
       "label": "generate-relation-report.ts",
@@ -48681,7 +48729,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L1",
       "id": "scripts_quality_benchmark_category_report_spec_ts",
-      "community": 979
+      "community": 980
     },
     {
       "label": "sampleReport()",
@@ -48689,7 +48737,7 @@
       "source_file": "scripts/quality-benchmark-category-report.spec.ts",
       "source_location": "L9",
       "id": "quality_benchmark_category_report_spec_samplereport",
-      "community": 979
+      "community": 980
     },
     {
       "label": "postpack-restore-workspace.js",
@@ -48697,7 +48745,7 @@
       "source_file": "scripts/postpack-restore-workspace.js",
       "source_location": "L1",
       "id": "scripts_postpack_restore_workspace_js",
-      "community": 1376
+      "community": 1377
     },
     {
       "label": "debug-embeddings.js",
@@ -48705,7 +48753,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L1",
       "id": "scripts_debug_embeddings_js",
-      "community": 980
+      "community": 981
     },
     {
       "label": "debugEmbeddings()",
@@ -48713,7 +48761,7 @@
       "source_file": "scripts/debug-embeddings.js",
       "source_location": "L18",
       "id": "debug_embeddings_debugembeddings",
-      "community": 980
+      "community": 981
     },
     {
       "label": "agent-memory-benchmark-adapter.spec.ts",
@@ -48721,7 +48769,7 @@
       "source_file": "scripts/agent-memory-benchmark-adapter.spec.ts",
       "source_location": "L1",
       "id": "scripts_agent_memory_benchmark_adapter_spec_ts",
-      "community": 1377
+      "community": 1378
     },
     {
       "label": "longmemeval-validation.ts",
@@ -48881,7 +48929,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L1",
       "id": "scripts_check_db_integrity_js",
-      "community": 605
+      "community": 606
     },
     {
       "label": "log()",
@@ -48889,7 +48937,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L28",
       "id": "check_db_integrity_log",
-      "community": 605
+      "community": 606
     },
     {
       "label": "checkDatabaseIntegrity()",
@@ -48897,7 +48945,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L40",
       "id": "check_db_integrity_checkdatabaseintegrity",
-      "community": 605
+      "community": 606
     },
     {
       "label": "main()",
@@ -48905,7 +48953,7 @@
       "source_file": "scripts/check-db-integrity.js",
       "source_location": "L97",
       "id": "check_db_integrity_main",
-      "community": 605
+      "community": 606
     },
     {
       "label": "agent-smoke-matrix.ts",
@@ -49089,7 +49137,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L1",
       "id": "scripts_tune_report_ts",
-      "community": 606
+      "community": 607
     },
     {
       "label": "parseReportArgs()",
@@ -49097,7 +49145,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L10",
       "id": "tune_report_parsereportargs",
-      "community": 606
+      "community": 607
     },
     {
       "label": "findLatestRunDir()",
@@ -49105,7 +49153,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L20",
       "id": "tune_report_findlatestrundir",
-      "community": 606
+      "community": 607
     },
     {
       "label": "main()",
@@ -49113,7 +49161,7 @@
       "source_file": "scripts/tune-report.ts",
       "source_location": "L61",
       "id": "tune_report_main",
-      "community": 606
+      "community": 607
     },
     {
       "label": "mcp-http-client.js",
@@ -49353,7 +49401,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L1",
       "id": "scripts_backup_embeddings_js",
-      "community": 981
+      "community": 982
     },
     {
       "label": "backupEmbeddings()",
@@ -49361,7 +49409,7 @@
       "source_file": "scripts/backup-embeddings.js",
       "source_location": "L40",
       "id": "backup_embeddings_backupembeddings",
-      "community": 981
+      "community": 982
     },
     {
       "label": "count-any-types.ts",
@@ -49577,7 +49625,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L1",
       "id": "scripts_compare_weight_profiles_spec_ts",
-      "community": 982
+      "community": 983
     },
     {
       "label": "makeRng()",
@@ -49585,7 +49633,7 @@
       "source_file": "scripts/compare-weight-profiles.spec.ts",
       "source_location": "L49",
       "id": "compare_weight_profiles_spec_makerng",
-      "community": 982
+      "community": 983
     },
     {
       "label": "count-console-logs.spec.ts",
@@ -49593,7 +49641,7 @@
       "source_file": "scripts/__tests__/count-console-logs.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_count_console_logs_spec_ts",
-      "community": 1378
+      "community": 1379
     },
     {
       "label": "simple-update-wrapper.spec.ts",
@@ -49601,7 +49649,7 @@
       "source_file": "scripts/__tests__/simple-update-wrapper.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_simple_update_wrapper_spec_ts",
-      "community": 1379
+      "community": 1380
     },
     {
       "label": "legacy-script-removal.spec.ts",
@@ -49609,7 +49657,7 @@
       "source_file": "scripts/__tests__/legacy-script-removal.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_removal_spec_ts",
-      "community": 1380
+      "community": 1381
     },
     {
       "label": "migrate-embedding-data.integration.spec.ts",
@@ -49617,7 +49665,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_migrate_embedding_data_integration_spec_ts",
-      "community": 983
+      "community": 984
     },
     {
       "label": "jsonEmbedding()",
@@ -49625,7 +49673,7 @@
       "source_file": "scripts/__tests__/migrate-embedding-data.integration.spec.ts",
       "source_location": "L13",
       "id": "migrate_embedding_data_integration_spec_jsonembedding",
-      "community": 983
+      "community": 984
     },
     {
       "label": "legacy-script-verification.spec.ts",
@@ -49633,7 +49681,7 @@
       "source_file": "scripts/__tests__/legacy-script-verification.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_legacy_script_verification_spec_ts",
-      "community": 1381
+      "community": 1382
     },
     {
       "label": "check-magic-numbers.spec.ts",
@@ -49641,7 +49689,7 @@
       "source_file": "scripts/__tests__/check-magic-numbers.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_magic_numbers_spec_ts",
-      "community": 1382
+      "community": 1383
     },
     {
       "label": "check-db-integrity.integration.spec.ts",
@@ -49649,7 +49697,7 @@
       "source_file": "scripts/__tests__/check-db-integrity.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_check_db_integrity_integration_spec_ts",
-      "community": 1383
+      "community": 1384
     },
     {
       "label": "supports-tsx-subprocess.ts",
@@ -49657,7 +49705,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L1",
       "id": "scripts_tests_supports_tsx_subprocess_ts",
-      "community": 984
+      "community": 985
     },
     {
       "label": "supportsTsxSubprocess()",
@@ -49665,7 +49713,7 @@
       "source_file": "scripts/__tests__/supports-tsx-subprocess.ts",
       "source_location": "L5",
       "id": "supports_tsx_subprocess_supportstsxsubprocess",
-      "community": 984
+      "community": 985
     },
     {
       "label": "regenerate-embeddings.integration.spec.ts",
@@ -49673,7 +49721,7 @@
       "source_file": "scripts/__tests__/regenerate-embeddings.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_regenerate_embeddings_integration_spec_ts",
-      "community": 1384
+      "community": 1385
     },
     {
       "label": "fix-migration.integration.spec.ts",
@@ -49681,7 +49729,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L1",
       "id": "scripts_tests_fix_migration_integration_spec_ts",
-      "community": 985
+      "community": 986
     },
     {
       "label": "jsonEmbedding()",
@@ -49689,7 +49737,7 @@
       "source_file": "scripts/__tests__/fix-migration.integration.spec.ts",
       "source_location": "L16",
       "id": "fix_migration_integration_spec_jsonembedding",
-      "community": 985
+      "community": 986
     },
     {
       "label": "check-embedding-dimensions.ts",
@@ -49697,7 +49745,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_embedding_dimensions_ts",
-      "community": 986
+      "community": 987
     },
     {
       "label": "main()",
@@ -49705,7 +49753,7 @@
       "source_file": "scripts/archive/check-embedding-dimensions.ts",
       "source_location": "L12",
       "id": "check_embedding_dimensions_main",
-      "community": 986
+      "community": 987
     },
     {
       "label": "check-convertible-episodic-memories.ts",
@@ -49713,7 +49761,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L1",
       "id": "scripts_archive_check_convertible_episodic_memories_ts",
-      "community": 987
+      "community": 988
     },
     {
       "label": "checkConvertibleEpisodicMemories()",
@@ -49721,7 +49769,7 @@
       "source_file": "scripts/archive/check-convertible-episodic-memories.ts",
       "source_location": "L40",
       "id": "check_convertible_episodic_memories_checkconvertibleepisodicmemories",
-      "community": 987
+      "community": 988
     },
     {
       "label": "remove-benchmark-test-data.ts",
@@ -49729,7 +49777,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_remove_benchmark_test_data_ts",
-      "community": 726
+      "community": 728
     },
     {
       "label": "createBackup()",
@@ -49737,7 +49785,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L33",
       "id": "remove_benchmark_test_data_createbackup",
-      "community": 726
+      "community": 728
     },
     {
       "label": "removeBenchmarkTestData()",
@@ -49745,7 +49793,7 @@
       "source_file": "scripts/archive/remove-benchmark-test-data.ts",
       "source_location": "L64",
       "id": "remove_benchmark_test_data_removebenchmarktestdata",
-      "community": 726
+      "community": 728
     },
     {
       "label": "restore-legacy.ps1",
@@ -49753,7 +49801,7 @@
       "source_file": "scripts/archive/restore-legacy.ps1",
       "source_location": "L1",
       "id": "scripts_archive_restore_legacy_ps1",
-      "community": 1385
+      "community": 1386
     },
     {
       "label": "check-retry-usage.ts",
@@ -49873,7 +49921,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L1",
       "id": "scripts_archive_analyze_benchmark_test_data_ts",
-      "community": 988
+      "community": 989
     },
     {
       "label": "analyzeBenchmarkTestData()",
@@ -49881,7 +49929,7 @@
       "source_file": "scripts/archive/analyze-benchmark-test-data.ts",
       "source_location": "L31",
       "id": "analyze_benchmark_test_data_analyzebenchmarktestdata",
-      "community": 988
+      "community": 989
     },
     {
       "label": "check-no-console-violations.ts",
@@ -49977,7 +50025,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L1",
       "id": "scripts_archive_fix_vec_table_dimensions_ts",
-      "community": 989
+      "community": 990
     },
     {
       "label": "fixVecTableDimensions()",
@@ -49985,7 +50033,7 @@
       "source_file": "scripts/archive/fix-vec-table-dimensions.ts",
       "source_location": "L15",
       "id": "fix_vec_table_dimensions_fixvectabledimensions",
-      "community": 989
+      "community": 990
     },
     {
       "label": "sources.ts",
@@ -50073,7 +50121,7 @@
       "source_file": "scripts/log-issue-monitor/types.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_types_ts",
-      "community": 1386
+      "community": 1387
     },
     {
       "label": "issue-body.ts",
@@ -50081,7 +50129,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_issue_body_ts",
-      "community": 607
+      "community": 608
     },
     {
       "label": "startMarker()",
@@ -50089,7 +50137,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L5",
       "id": "issue_body_startmarker",
-      "community": 607
+      "community": 608
     },
     {
       "label": "renderManagedIssueBody()",
@@ -50097,7 +50145,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L9",
       "id": "issue_body_rendermanagedissuebody",
-      "community": 607
+      "community": 608
     },
     {
       "label": "upsertManagedIssueBody()",
@@ -50105,7 +50153,7 @@
       "source_file": "scripts/log-issue-monitor/issue-body.ts",
       "source_location": "L38",
       "id": "issue_body_upsertmanagedissuebody",
-      "community": 607
+      "community": 608
     },
     {
       "label": "fingerprint.ts",
@@ -50113,7 +50161,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_fingerprint_ts",
-      "community": 727
+      "community": 729
     },
     {
       "label": "normalizeMessage()",
@@ -50121,7 +50169,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L4",
       "id": "fingerprint_normalizemessage",
-      "community": 727
+      "community": 729
     },
     {
       "label": "createFingerprint()",
@@ -50129,7 +50177,7 @@
       "source_file": "scripts/log-issue-monitor/fingerprint.ts",
       "source_location": "L17",
       "id": "fingerprint_createfingerprint",
-      "community": 727
+      "community": 729
     },
     {
       "label": "sanitizer.ts",
@@ -50137,7 +50185,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_sanitizer_ts",
-      "community": 728
+      "community": 730
     },
     {
       "label": "limitUtf8Bytes()",
@@ -50145,7 +50193,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L5",
       "id": "sanitizer_limitutf8bytes",
-      "community": 728
+      "community": 730
     },
     {
       "label": "sanitizeExcerpt()",
@@ -50153,7 +50201,7 @@
       "source_file": "scripts/log-issue-monitor/sanitizer.ts",
       "source_location": "L19",
       "id": "sanitizer_sanitizeexcerpt",
-      "community": 728
+      "community": 730
     },
     {
       "label": "parsers.ts",
@@ -50161,7 +50209,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_parsers_ts",
-      "community": 608
+      "community": 609
     },
     {
       "label": "inferLevel()",
@@ -50169,7 +50217,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L15",
       "id": "parsers_inferlevel",
-      "community": 608
+      "community": 609
     },
     {
       "label": "parseAppLogLine()",
@@ -50177,7 +50225,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L30",
       "id": "parsers_parseapplogline",
-      "community": 608
+      "community": 609
     },
     {
       "label": "parseJsonlRecord()",
@@ -50185,7 +50233,7 @@
       "source_file": "scripts/log-issue-monitor/parsers.ts",
       "source_location": "L61",
       "id": "parsers_parsejsonlrecord",
-      "community": 608
+      "community": 609
     },
     {
       "label": "index.ts",
@@ -50193,7 +50241,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_index_ts",
-      "community": 609
+      "community": 610
     },
     {
       "label": "isExecutedAsMainCli()",
@@ -50201,7 +50249,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L9",
       "id": "index_isexecutedasmaincli",
-      "community": 609
+      "community": 610
     },
     {
       "label": "createMonitorRuntime()",
@@ -50209,7 +50257,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L19",
       "id": "index_createmonitorruntime",
-      "community": 609
+      "community": 610
     },
     {
       "label": "runForever()",
@@ -50217,7 +50265,7 @@
       "source_file": "scripts/log-issue-monitor/index.ts",
       "source_location": "L32",
       "id": "index_runforever",
-      "community": 609
+      "community": 610
     },
     {
       "label": "promotion.ts",
@@ -50225,7 +50273,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_promotion_ts",
-      "community": 990
+      "community": 991
     },
     {
       "label": "shouldSyncToGitHub()",
@@ -50233,7 +50281,7 @@
       "source_file": "scripts/log-issue-monitor/promotion.ts",
       "source_location": "L5",
       "id": "promotion_shouldsynctogithub",
-      "community": 990
+      "community": 991
     },
     {
       "label": "state-store.ts",
@@ -50513,7 +50561,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/promotion.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_promotion_spec_ts",
-      "community": 1387
+      "community": 1388
     },
     {
       "label": "issue-body.spec.ts",
@@ -50521,7 +50569,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/issue-body.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_issue_body_spec_ts",
-      "community": 1388
+      "community": 1389
     },
     {
       "label": "github-client.spec.ts",
@@ -50529,7 +50577,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/github-client.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_github_client_spec_ts",
-      "community": 1389
+      "community": 1390
     },
     {
       "label": "config.spec.ts",
@@ -50537,7 +50585,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/config.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_config_spec_ts",
-      "community": 1390
+      "community": 1391
     },
     {
       "label": "detectors.spec.ts",
@@ -50545,7 +50593,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/detectors.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_detectors_spec_ts",
-      "community": 1391
+      "community": 1392
     },
     {
       "label": "sources.spec.ts",
@@ -50553,7 +50601,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sources.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sources_spec_ts",
-      "community": 1392
+      "community": 1393
     },
     {
       "label": "parsers.spec.ts",
@@ -50561,7 +50609,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/parsers.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_parsers_spec_ts",
-      "community": 1393
+      "community": 1394
     },
     {
       "label": "monitor.spec.ts",
@@ -50569,7 +50617,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_monitor_spec_ts",
-      "community": 991
+      "community": 992
     },
     {
       "label": "config()",
@@ -50577,7 +50625,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/monitor.spec.ts",
       "source_location": "L18",
       "id": "monitor_spec_config",
-      "community": 991
+      "community": 992
     },
     {
       "label": "fingerprint.spec.ts",
@@ -50585,7 +50633,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/fingerprint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_fingerprint_spec_ts",
-      "community": 1394
+      "community": 1395
     },
     {
       "label": "state-store.spec.ts",
@@ -50593,7 +50641,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/state-store.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_state_store_spec_ts",
-      "community": 1395
+      "community": 1396
     },
     {
       "label": "sanitizer.spec.ts",
@@ -50601,7 +50649,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/sanitizer.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_sanitizer_spec_ts",
-      "community": 1396
+      "community": 1397
     },
     {
       "label": "entrypoint.spec.ts",
@@ -50609,7 +50657,7 @@
       "source_file": "scripts/log-issue-monitor/__tests__/entrypoint.spec.ts",
       "source_location": "L1",
       "id": "scripts_log_issue_monitor_tests_entrypoint_spec_ts",
-      "community": 1397
+      "community": 1398
     },
     {
       "label": "index.ts",
@@ -50617,7 +50665,7 @@
       "source_file": "apps/experimental-assistant-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_assistant_example_src_index_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "main()",
@@ -50625,7 +50673,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L49",
       "id": "index_main",
-      "community": 610
+      "community": 611
     },
     {
       "label": "index.ts",
@@ -50633,7 +50681,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_ts",
-      "community": 610
+      "community": 611
     },
     {
       "label": "runExample()",
@@ -50641,7 +50689,7 @@
       "source_file": "apps/experimental-example/src/index.ts",
       "source_location": "L20",
       "id": "index_runexample",
-      "community": 610
+      "community": 611
     },
     {
       "label": "index.spec.ts",
@@ -50649,7 +50697,7 @@
       "source_file": "apps/experimental-example/src/index.spec.ts",
       "source_location": "L1",
       "id": "apps_experimental_example_src_index_spec_ts",
-      "community": 1398
+      "community": 1399
     },
     {
       "label": "review-candidates-panel-poll-fetch.js",
@@ -50657,7 +50705,7 @@
       "source_file": "static/js/review-candidates-panel-poll-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_fetch_js",
-      "community": 1399
+      "community": 1400
     },
     {
       "label": "memento-admin-fetch.js",
@@ -50721,7 +50769,7 @@
       "source_file": "static/js/embedding-map-state.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_state_js",
-      "community": 1400
+      "community": 1401
     },
     {
       "label": "memory-evolution-demo-shell-render.js",
@@ -50729,7 +50777,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_js",
-      "community": 1401
+      "community": 1402
     },
     {
       "label": "dashboard-auth.js",
@@ -50737,7 +50785,7 @@
       "source_file": "static/js/dashboard-auth.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_js",
-      "community": 1402
+      "community": 1403
     },
     {
       "label": "anchor-map.js",
@@ -50745,7 +50793,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_js",
-      "community": 611
+      "community": 612
     },
     {
       "label": "initializeMap()",
@@ -50753,7 +50801,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L14",
       "id": "anchor_map_initializemap",
-      "community": 611
+      "community": 612
     },
     {
       "label": "onSearchResultClick()",
@@ -50761,7 +50809,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L52",
       "id": "anchor_map_onsearchresultclick",
-      "community": 611
+      "community": 612
     },
     {
       "label": "setupEventListeners()",
@@ -50769,7 +50817,7 @@
       "source_file": "static/js/anchor-map.js",
       "source_location": "L68",
       "id": "anchor_map_setupeventlisteners",
-      "community": 611
+      "community": 612
     },
     {
       "label": "dashboard-auth-error.js",
@@ -50777,7 +50825,7 @@
       "source_file": "static/js/dashboard-auth-error.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_error_js",
-      "community": 1403
+      "community": 1404
     },
     {
       "label": "embedding-map-fetch.js",
@@ -50785,7 +50833,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_js",
-      "community": 729
+      "community": 731
     },
     {
       "label": "buildEmbeddingMapQuery()",
@@ -50793,7 +50841,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L12",
       "id": "embedding_map_fetch_buildembeddingmapquery",
-      "community": 729
+      "community": 731
     },
     {
       "label": "handleEmbeddingMapResponse()",
@@ -50801,7 +50849,7 @@
       "source_file": "static/js/embedding-map-fetch.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_handleembeddingmapresponse",
-      "community": 729
+      "community": 731
     },
     {
       "label": "review-candidates-panel-poll.js",
@@ -50809,7 +50857,7 @@
       "source_file": "static/js/review-candidates-panel-poll.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_js",
-      "community": 1404
+      "community": 1405
     },
     {
       "label": "review-candidates-panel-poll-notify-os.js",
@@ -50817,7 +50865,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_notify_os_js",
-      "community": 992
+      "community": 993
     },
     {
       "label": "tryOsNotifyReviewQueueGrowth()",
@@ -50825,7 +50873,7 @@
       "source_file": "static/js/review-candidates-panel-poll-notify-os.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_notify_os_tryosnotifyreviewqueuegrowth",
-      "community": 992
+      "community": 993
     },
     {
       "label": "graph-detail.js",
@@ -50833,7 +50881,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L1",
       "id": "static_js_graph_detail_js",
-      "community": 612
+      "community": 613
     },
     {
       "label": "getTypeBadgeClass()",
@@ -50841,7 +50889,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L12",
       "id": "graph_detail_gettypebadgeclass",
-      "community": 612
+      "community": 613
     },
     {
       "label": "buildTagsHtml()",
@@ -50849,7 +50897,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L19",
       "id": "graph_detail_buildtagshtml",
-      "community": 612
+      "community": 613
     },
     {
       "label": "buildDetailRows()",
@@ -50857,7 +50905,7 @@
       "source_file": "static/js/graph-detail.js",
       "source_location": "L26",
       "id": "graph_detail_builddetailrows",
-      "community": 612
+      "community": 613
     },
     {
       "label": "review-candidates-panel-render-actions.js",
@@ -50865,7 +50913,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_actions_js",
-      "community": 613
+      "community": 614
     },
     {
       "label": "showActionToast()",
@@ -50873,7 +50921,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L16",
       "id": "review_candidates_panel_render_actions_showactiontoast",
-      "community": 613
+      "community": 614
     },
     {
       "label": "showError()",
@@ -50881,7 +50929,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L33",
       "id": "review_candidates_panel_render_actions_showerror",
-      "community": 613
+      "community": 614
     },
     {
       "label": "postCandidateAction()",
@@ -50889,7 +50937,7 @@
       "source_file": "static/js/review-candidates-panel-render-actions.js",
       "source_location": "L41",
       "id": "review_candidates_panel_render_actions_postcandidateaction",
-      "community": 613
+      "community": 614
     },
     {
       "label": "dashboard-auth-render-message.js",
@@ -50897,7 +50945,7 @@
       "source_file": "static/js/dashboard-auth-render-message.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_message_js",
-      "community": 1405
+      "community": 1406
     },
     {
       "label": "review-candidates-panel.js",
@@ -50905,7 +50953,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_js",
-      "community": 993
+      "community": 994
     },
     {
       "label": "initReviewCandidatesPanel()",
@@ -50913,7 +50961,7 @@
       "source_file": "static/js/review-candidates-panel.js",
       "source_location": "L16",
       "id": "review_candidates_panel_initreviewcandidatespanel",
-      "community": 993
+      "community": 994
     },
     {
       "label": "review-candidates-panel-health-fetch.js",
@@ -50921,7 +50969,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_fetch_js",
-      "community": 730
+      "community": 732
     },
     {
       "label": "loadBatchRunHistory()",
@@ -50929,7 +50977,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L15",
       "id": "review_candidates_panel_health_fetch_loadbatchrunhistory",
-      "community": 730
+      "community": 732
     },
     {
       "label": "loadHealthMetrics()",
@@ -50937,7 +50985,7 @@
       "source_file": "static/js/review-candidates-panel-health-fetch.js",
       "source_location": "L61",
       "id": "review_candidates_panel_health_fetch_loadhealthmetrics",
-      "community": 730
+      "community": 732
     },
     {
       "label": "graph.js",
@@ -50945,7 +50993,7 @@
       "source_file": "static/js/graph.js",
       "source_location": "L1",
       "id": "static_js_graph_js",
-      "community": 1406
+      "community": 1407
     },
     {
       "label": "dashboard-tabs-init.js",
@@ -51025,7 +51073,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_state_js",
-      "community": 486
+      "community": 487
     },
     {
       "label": "createSessionGate()",
@@ -51033,7 +51081,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L16",
       "id": "dashboard_auth_state_createsessiongate",
-      "community": 486
+      "community": 487
     },
     {
       "label": "ensureSessionGate()",
@@ -51041,7 +51089,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L22",
       "id": "dashboard_auth_state_ensuresessiongate",
-      "community": 486
+      "community": 487
     },
     {
       "label": "unlockSessionGate()",
@@ -51049,7 +51097,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L25",
       "id": "dashboard_auth_state_unlocksessiongate",
-      "community": 486
+      "community": 487
     },
     {
       "label": "resetSessionGate()",
@@ -51057,7 +51105,7 @@
       "source_file": "static/js/dashboard-auth-state.js",
       "source_location": "L31",
       "id": "dashboard_auth_state_resetsessiongate",
-      "community": 486
+      "community": 487
     },
     {
       "label": "embedding-map-chart-setup.js",
@@ -51065,7 +51113,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_setup_js",
-      "community": 614
+      "community": 615
     },
     {
       "label": "readContainerSize()",
@@ -51073,7 +51121,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L12",
       "id": "embedding_map_chart_setup_readcontainersize",
-      "community": 614
+      "community": 615
     },
     {
       "label": "appendPlotLayers()",
@@ -51081,7 +51129,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L24",
       "id": "embedding_map_chart_setup_appendplotlayers",
-      "community": 614
+      "community": 615
     },
     {
       "label": "appendBackgroundClickHandler()",
@@ -51089,7 +51137,7 @@
       "source_file": "static/js/embedding-map-chart-setup.js",
       "source_location": "L32",
       "id": "embedding_map_chart_setup_appendbackgroundclickhandler",
-      "community": 614
+      "community": 615
     },
     {
       "label": "memory-evolution-demo-shell-render-timeline.js",
@@ -51097,7 +51145,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_timeline_js",
-      "community": 487
+      "community": 488
     },
     {
       "label": "buildComparisonHintMarkup()",
@@ -51105,7 +51153,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_timeline_buildcomparisonhintmarkup",
-      "community": 487
+      "community": 488
     },
     {
       "label": "updateComparisonHint()",
@@ -51113,7 +51161,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L36",
       "id": "memory_evolution_demo_shell_render_timeline_updatecomparisonhint",
-      "community": 487
+      "community": 488
     },
     {
       "label": "syncSegmentSelection()",
@@ -51121,7 +51169,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L51",
       "id": "memory_evolution_demo_shell_render_timeline_syncsegmentselection",
-      "community": 487
+      "community": 488
     },
     {
       "label": "renderPointSegment()",
@@ -51129,7 +51177,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-timeline.js",
       "source_location": "L66",
       "id": "memory_evolution_demo_shell_render_timeline_renderpointsegment",
-      "community": 487
+      "community": 488
     },
     {
       "label": "embedding-map-fetch-status.js",
@@ -51137,7 +51185,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_fetch_status_js",
-      "community": 615
+      "community": 616
     },
     {
       "label": "setLoading()",
@@ -51145,7 +51193,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L23",
       "id": "embedding_map_fetch_status_setloading",
-      "community": 615
+      "community": 616
     },
     {
       "label": "setError()",
@@ -51153,7 +51201,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L30",
       "id": "embedding_map_fetch_status_seterror",
-      "community": 615
+      "community": 616
     },
     {
       "label": "updateCacheInfo()",
@@ -51161,7 +51209,7 @@
       "source_file": "static/js/embedding-map-fetch-status.js",
       "source_location": "L58",
       "id": "embedding_map_fetch_status_updatecacheinfo",
-      "community": 615
+      "community": 616
     },
     {
       "label": "agent-sessions-panel-data.js",
@@ -51217,7 +51265,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_category_js",
-      "community": 994
+      "community": 995
     },
     {
       "label": "eventCategory()",
@@ -51225,7 +51273,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline-category.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_render_timeline_category_eventcategory",
-      "community": 994
+      "community": 995
     },
     {
       "label": "graph-shared.js",
@@ -51233,7 +51281,7 @@
       "source_file": "static/js/graph-shared.js",
       "source_location": "L1",
       "id": "static_js_graph_shared_js",
-      "community": 1407
+      "community": 1408
     },
     {
       "label": "dashboard-auth-render-form.js",
@@ -51241,7 +51289,7 @@
       "source_file": "static/js/dashboard-auth-render-form.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_form_js",
-      "community": 1408
+      "community": 1409
     },
     {
       "label": "memory-evolution-demo-shell-shared.js",
@@ -51529,7 +51577,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_config_js",
-      "community": 488
+      "community": 489
     },
     {
       "label": "getReviewQueueBoot()",
@@ -51537,7 +51585,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L12",
       "id": "review_candidates_panel_poll_config_getreviewqueueboot",
-      "community": 488
+      "community": 489
     },
     {
       "label": "clearPollTimer()",
@@ -51545,7 +51593,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L23",
       "id": "review_candidates_panel_poll_config_clearpolltimer",
-      "community": 488
+      "community": 489
     },
     {
       "label": "schedulePollAfterMs()",
@@ -51553,7 +51601,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L30",
       "id": "review_candidates_panel_poll_config_schedulepollafterms",
-      "community": 488
+      "community": 489
     },
     {
       "label": "schedulePollAfterMsUnlessSse()",
@@ -51561,7 +51609,7 @@
       "source_file": "static/js/review-candidates-panel-poll-config.js",
       "source_location": "L41",
       "id": "review_candidates_panel_poll_config_schedulepollaftermsunlesssse",
-      "community": 488
+      "community": 489
     },
     {
       "label": "agent-sessions-panel-shared.js",
@@ -51569,7 +51617,7 @@
       "source_file": "static/js/agent-sessions-panel-shared.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_shared_js",
-      "community": 1409
+      "community": 1410
     },
     {
       "label": "agent-sessions-panel-render.js",
@@ -51577,7 +51625,7 @@
       "source_file": "static/js/agent-sessions-panel-render.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_js",
-      "community": 1410
+      "community": 1411
     },
     {
       "label": "embedding-map-tooltip.js",
@@ -51585,7 +51633,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_tooltip_js",
-      "community": 616
+      "community": 617
     },
     {
       "label": "ensureTooltip()",
@@ -51593,7 +51641,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L12",
       "id": "embedding_map_tooltip_ensuretooltip",
-      "community": 616
+      "community": 617
     },
     {
       "label": "showTooltip()",
@@ -51601,7 +51649,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L23",
       "id": "embedding_map_tooltip_showtooltip",
-      "community": 616
+      "community": 617
     },
     {
       "label": "hideTooltip()",
@@ -51609,7 +51657,7 @@
       "source_file": "static/js/embedding-map-tooltip.js",
       "source_location": "L40",
       "id": "embedding_map_tooltip_hidetooltip",
-      "community": 616
+      "community": 617
     },
     {
       "label": "review-candidates-panel-render-preview.js",
@@ -51689,7 +51737,7 @@
       "source_file": "static/js/anchor-map-shared.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_shared_js",
-      "community": 1411
+      "community": 1412
     },
     {
       "label": "dashboard-auth-render-status.js",
@@ -51697,7 +51745,7 @@
       "source_file": "static/js/dashboard-auth-render-status.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_status_js",
-      "community": 1412
+      "community": 1413
     },
     {
       "label": "review-candidates-panel-poll-toast.js",
@@ -51705,7 +51753,7 @@
       "source_file": "static/js/review-candidates-panel-poll-toast.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_toast_js",
-      "community": 1413
+      "community": 1414
     },
     {
       "label": "embedding-map-chart-scatter.js",
@@ -51817,7 +51865,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_js",
-      "community": 617
+      "community": 618
     },
     {
       "label": "on()",
@@ -51825,7 +51873,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L12",
       "id": "agent_sessions_panel_on",
-      "community": 617
+      "community": 618
     },
     {
       "label": "wirePanel()",
@@ -51833,7 +51881,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L19",
       "id": "agent_sessions_panel_wirepanel",
-      "community": 617
+      "community": 618
     },
     {
       "label": "initAgentSessionsPanel()",
@@ -51841,7 +51889,7 @@
       "source_file": "static/js/agent-sessions-panel.js",
       "source_location": "L71",
       "id": "agent_sessions_panel_initagentsessionspanel",
-      "community": 617
+      "community": 618
     },
     {
       "label": "agent-sessions-panel-render-injections.js",
@@ -51849,7 +51897,7 @@
       "source_file": "static/js/agent-sessions-panel-render-injections.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_injections_js",
-      "community": 1414
+      "community": 1415
     },
     {
       "label": "anchor-map-render.js",
@@ -51993,7 +52041,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_consolidation_js",
-      "community": 489
+      "community": 490
     },
     {
       "label": "renderEpisodicSources()",
@@ -52001,7 +52049,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_consolidation_renderepisodicsources",
-      "community": 489
+      "community": 490
     },
     {
       "label": "renderSemanticResult()",
@@ -52009,7 +52057,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersemanticresult",
-      "community": 489
+      "community": 490
     },
     {
       "label": "renderSearchComparison()",
@@ -52017,7 +52065,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L110",
       "id": "memory_evolution_demo_shell_render_consolidation_rendersearchcomparison",
-      "community": 489
+      "community": 490
     },
     {
       "label": "renderConsolidationPanel()",
@@ -52025,7 +52073,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-consolidation.js",
       "source_location": "L128",
       "id": "memory_evolution_demo_shell_render_consolidation_renderconsolidationpanel",
-      "community": 489
+      "community": 490
     },
     {
       "label": "memory-evolution-demo-shell.js",
@@ -52033,7 +52081,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_js",
-      "community": 995
+      "community": 996
     },
     {
       "label": "init()",
@@ -52041,7 +52089,7 @@
       "source_file": "static/js/memory-evolution-demo-shell.js",
       "source_location": "L15",
       "id": "memory_evolution_demo_shell_init",
-      "community": 995
+      "community": 996
     },
     {
       "label": "review-candidates-panel-bulk.js",
@@ -52105,7 +52153,7 @@
       "source_file": "static/js/review-candidates-panel-poll-snapshot.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_snapshot_js",
-      "community": 1415
+      "community": 1416
     },
     {
       "label": "review-candidates-panel-health.js",
@@ -52113,7 +52161,7 @@
       "source_file": "static/js/review-candidates-panel-health.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_health_js",
-      "community": 1416
+      "community": 1417
     },
     {
       "label": "review-candidates-panel-poll-prompt.js",
@@ -52121,7 +52169,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_prompt_js",
-      "community": 731
+      "community": 733
     },
     {
       "label": "isReviewNotifyPromptDismissed()",
@@ -52129,7 +52177,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L10",
       "id": "review_candidates_panel_poll_prompt_isreviewnotifypromptdismissed",
-      "community": 731
+      "community": 733
     },
     {
       "label": "dismissReviewNotifyPrompt()",
@@ -52137,7 +52185,7 @@
       "source_file": "static/js/review-candidates-panel-poll-prompt.js",
       "source_location": "L18",
       "id": "review_candidates_panel_poll_prompt_dismissreviewnotifyprompt",
-      "community": 731
+      "community": 733
     },
     {
       "label": "dashboard-auth-dom.js",
@@ -52145,7 +52193,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_dom_js",
-      "community": 732
+      "community": 734
     },
     {
       "label": "selectFirst()",
@@ -52153,7 +52201,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L12",
       "id": "dashboard_auth_dom_selectfirst",
-      "community": 732
+      "community": 734
     },
     {
       "label": "getElementByIdFallback()",
@@ -52161,7 +52209,7 @@
       "source_file": "static/js/dashboard-auth-dom.js",
       "source_location": "L20",
       "id": "dashboard_auth_dom_getelementbyidfallback",
-      "community": 732
+      "community": 734
     },
     {
       "label": "graph-search.js",
@@ -52233,7 +52281,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_js",
-      "community": 733
+      "community": 735
     },
     {
       "label": "refreshChartIfActive()",
@@ -52241,7 +52289,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L13",
       "id": "embedding_map_refreshchartifactive",
-      "community": 733
+      "community": 735
     },
     {
       "label": "initEmbeddingMap()",
@@ -52249,7 +52297,7 @@
       "source_file": "static/js/embedding-map.js",
       "source_location": "L24",
       "id": "embedding_map_initembeddingmap",
-      "community": 733
+      "community": 735
     },
     {
       "label": "anchor-map-search.js",
@@ -52313,7 +52361,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L1",
       "id": "static_js_anchor_map_data_js",
-      "community": 618
+      "community": 619
     },
     {
       "label": "getSelectedAgentId()",
@@ -52321,7 +52369,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L12",
       "id": "anchor_map_data_getselectedagentid",
-      "community": 618
+      "community": 619
     },
     {
       "label": "loadAgentIdOptions()",
@@ -52329,7 +52377,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L17",
       "id": "anchor_map_data_loadagentidoptions",
-      "community": 618
+      "community": 619
     },
     {
       "label": "loadMapData()",
@@ -52337,7 +52385,7 @@
       "source_file": "static/js/anchor-map-data.js",
       "source_location": "L66",
       "id": "anchor_map_data_loadmapdata",
-      "community": 618
+      "community": 619
     },
     {
       "label": "agent-sessions-panel-render-timeline.js",
@@ -52345,7 +52393,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_timeline_js",
-      "community": 996
+      "community": 997
     },
     {
       "label": "eventCategory()",
@@ -52353,7 +52401,7 @@
       "source_file": "static/js/agent-sessions-panel-render-timeline.js",
       "source_location": "L13",
       "id": "agent_sessions_panel_render_timeline_eventcategory",
-      "community": 996
+      "community": 997
     },
     {
       "label": "agent-sessions-panel-render-provenance.js",
@@ -52361,7 +52409,7 @@
       "source_file": "static/js/agent-sessions-panel-render-provenance.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_provenance_js",
-      "community": 1417
+      "community": 1418
     },
     {
       "label": "graph-render.js",
@@ -52457,7 +52505,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_sign_in_js",
-      "community": 997
+      "community": 998
     },
     {
       "label": "handleSignInResponse()",
@@ -52465,7 +52513,7 @@
       "source_file": "static/js/dashboard-auth-sign-in.js",
       "source_location": "L10",
       "id": "dashboard_auth_sign_in_handlesigninresponse",
-      "community": 997
+      "community": 998
     },
     {
       "label": "embedding-map-chart-colors.js",
@@ -52473,7 +52521,7 @@
       "source_file": "static/js/embedding-map-chart-colors.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_chart_colors_js",
-      "community": 1418
+      "community": 1419
     },
     {
       "label": "review-candidates-panel-poll-cycle.js",
@@ -52481,7 +52529,7 @@
       "source_file": "static/js/review-candidates-panel-poll-cycle.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_cycle_js",
-      "community": 1419
+      "community": 1420
     },
     {
       "label": "dashboard-auth-session-check.js",
@@ -52489,7 +52537,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_session_check_js",
-      "community": 998
+      "community": 999
     },
     {
       "label": "handleSessionCheckResponse()",
@@ -52497,7 +52545,7 @@
       "source_file": "static/js/dashboard-auth-session-check.js",
       "source_location": "L10",
       "id": "dashboard_auth_session_check_handlesessioncheckresponse",
-      "community": 998
+      "community": 999
     },
     {
       "label": "agent-sessions-panel-render-sessions.js",
@@ -52505,7 +52553,7 @@
       "source_file": "static/js/agent-sessions-panel-render-sessions.js",
       "source_location": "L1",
       "id": "static_js_agent_sessions_panel_render_sessions_js",
-      "community": 1420
+      "community": 1421
     },
     {
       "label": "review-candidates-panel-render-list.js",
@@ -52721,7 +52769,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L1",
       "id": "static_js_memory_evolution_demo_shell_render_snapshot_js",
-      "community": 619
+      "community": 620
     },
     {
       "label": "renderMemoryGroups()",
@@ -52729,7 +52777,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L13",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorygroups",
-      "community": 619
+      "community": 620
     },
     {
       "label": "renderMemoryStats()",
@@ -52737,7 +52785,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L69",
       "id": "memory_evolution_demo_shell_render_snapshot_rendermemorystats",
-      "community": 619
+      "community": 620
     },
     {
       "label": "renderSnapshot()",
@@ -52745,7 +52793,7 @@
       "source_file": "static/js/memory-evolution-demo-shell-render-snapshot.js",
       "source_location": "L92",
       "id": "memory_evolution_demo_shell_render_snapshot_rendersnapshot",
-      "community": 619
+      "community": 620
     },
     {
       "label": "dashboard-auth-requests.js",
@@ -52753,7 +52801,7 @@
       "source_file": "static/js/dashboard-auth-requests.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_requests_js",
-      "community": 1421
+      "community": 1422
     },
     {
       "label": "dashboard-tabs.js",
@@ -52761,7 +52809,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_js",
-      "community": 490
+      "community": 491
     },
     {
       "label": "getTabButtons()",
@@ -52769,7 +52817,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L18",
       "id": "dashboard_tabs_gettabbuttons",
-      "community": 490
+      "community": 491
     },
     {
       "label": "setRovingTabindex()",
@@ -52777,7 +52825,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L22",
       "id": "dashboard_tabs_setrovingtabindex",
-      "community": 490
+      "community": 491
     },
     {
       "label": "focusActiveTabButton()",
@@ -52785,7 +52833,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L28",
       "id": "dashboard_tabs_focusactivetabbutton",
-      "community": 490
+      "community": 491
     },
     {
       "label": "activateTab()",
@@ -52793,7 +52841,7 @@
       "source_file": "static/js/dashboard-tabs.js",
       "source_location": "L37",
       "id": "dashboard_tabs_activatetab",
-      "community": 490
+      "community": 491
     },
     {
       "label": "review-candidates-panel-health-render.js",
@@ -52857,7 +52905,7 @@
       "source_file": "static/js/review-candidates-panel-render.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_render_js",
-      "community": 1422
+      "community": 1423
     },
     {
       "label": "dashboard-tabs-panels.js",
@@ -52865,7 +52913,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L1",
       "id": "static_js_dashboard_tabs_panels_js",
-      "community": 620
+      "community": 621
     },
     {
       "label": "getPanel()",
@@ -52873,7 +52921,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L16",
       "id": "dashboard_tabs_panels_getpanel",
-      "community": 620
+      "community": 621
     },
     {
       "label": "setTabButtonsActive()",
@@ -52881,7 +52929,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L23",
       "id": "dashboard_tabs_panels_settabbuttonsactive",
-      "community": 620
+      "community": 621
     },
     {
       "label": "setPanelVisibility()",
@@ -52889,7 +52937,7 @@
       "source_file": "static/js/dashboard-tabs-panels.js",
       "source_location": "L31",
       "id": "dashboard_tabs_panels_setpanelvisibility",
-      "community": 620
+      "community": 621
     },
     {
       "label": "dashboard-auth-ui.js",
@@ -52897,7 +52945,7 @@
       "source_file": "static/js/dashboard-auth-ui.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_ui_js",
-      "community": 1423
+      "community": 1424
     },
     {
       "label": "dashboard-auth-render-tabs.js",
@@ -52905,7 +52953,7 @@
       "source_file": "static/js/dashboard-auth-render-tabs.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_tabs_js",
-      "community": 1424
+      "community": 1425
     },
     {
       "label": "review-candidates-panel-shared.js",
@@ -53001,7 +53049,7 @@
       "source_file": "static/js/review-candidates-panel-poll-badge.js",
       "source_location": "L1",
       "id": "static_js_review_candidates_panel_poll_badge_js",
-      "community": 1425
+      "community": 1426
     },
     {
       "label": "graph-embed-init.js",
@@ -53009,7 +53057,7 @@
       "source_file": "static/js/graph-embed-init.js",
       "source_location": "L1",
       "id": "static_js_graph_embed_init_js",
-      "community": 1426
+      "community": 1427
     },
     {
       "label": "dashboard-auth-render.js",
@@ -53017,7 +53065,7 @@
       "source_file": "static/js/dashboard-auth-render.js",
       "source_location": "L1",
       "id": "static_js_dashboard_auth_render_js",
-      "community": 1427
+      "community": 1428
     },
     {
       "label": "graph-fetch.js",
@@ -53025,7 +53073,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L1",
       "id": "static_js_graph_fetch_js",
-      "community": 734
+      "community": 736
     },
     {
       "label": "resetGraphState()",
@@ -53033,7 +53081,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L48",
       "id": "graph_fetch_resetgraphstate",
-      "community": 734
+      "community": 736
     },
     {
       "label": "handleGraphPayload()",
@@ -53041,7 +53089,7 @@
       "source_file": "static/js/graph-fetch.js",
       "source_location": "L62",
       "id": "graph_fetch_handlegraphpayload",
-      "community": 734
+      "community": 736
     },
     {
       "label": "embedding-map-panel.js",
@@ -53049,7 +53097,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L1",
       "id": "static_js_embedding_map_panel_js",
-      "community": 621
+      "community": 622
     },
     {
       "label": "appendLabeledLine()",
@@ -53057,7 +53105,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L12",
       "id": "embedding_map_panel_appendlabeledline",
-      "community": 621
+      "community": 622
     },
     {
       "label": "closeSidePanel()",
@@ -53065,7 +53113,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L21",
       "id": "embedding_map_panel_closesidepanel",
-      "community": 621
+      "community": 622
     },
     {
       "label": "openSidePanel()",
@@ -53073,7 +53121,7 @@
       "source_file": "static/js/embedding-map-panel.js",
       "source_location": "L29",
       "id": "embedding_map_panel_opensidepanel",
-      "community": 621
+      "community": 622
     }
   ],
   "links": [
@@ -86945,11 +86993,35 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
-      "source_location": "L29",
+      "source_location": "L26",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
+      "_tgt": "batch_scheduler_anchor_handlers_isisolatedcandidate",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
+      "target": "batch_scheduler_anchor_handlers_isisolatedcandidate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
+      "source_location": "L50",
       "weight": 1.0,
       "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
       "_tgt": "batch_scheduler_anchor_handlers_runanchorautorefresh",
       "source": "packages_memento_core_src_infrastructure_scheduler_handlers_batch_scheduler_anchor_handlers_ts",
+      "target": "batch_scheduler_anchor_handlers_runanchorautorefresh",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts",
+      "source_location": "L117",
+      "weight": 1.0,
+      "_src": "batch_scheduler_anchor_handlers_runanchorautorefresh",
+      "_tgt": "batch_scheduler_anchor_handlers_isisolatedcandidate",
+      "source": "batch_scheduler_anchor_handlers_isisolatedcandidate",
       "target": "batch_scheduler_anchor_handlers_runanchorautorefresh",
       "confidence_score": 1.0
     },
@@ -87155,6 +87227,54 @@
       "_tgt": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
       "source": "batch_scheduler_maintenance_handlers_countmonitoringalertbuckets",
       "target": "batch_scheduler_maintenance_handlers_runmonitoring",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "_tgt": "batch_scheduler_anchor_handlers_spec_addrelation",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "target": "batch_scheduler_anchor_handlers_spec_addrelation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "_tgt": "batch_scheduler_anchor_handlers_spec_addembedding",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "target": "batch_scheduler_anchor_handlers_spec_addembedding",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "_tgt": "batch_scheduler_anchor_handlers_spec_seedstaleanchor",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "target": "batch_scheduler_anchor_handlers_spec_seedstaleanchor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts",
+      "source_location": "L43",
+      "weight": 1.0,
+      "_src": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "_tgt": "batch_scheduler_anchor_handlers_spec_createcontext",
+      "source": "packages_memento_core_src_infrastructure_scheduler_handlers_tests_batch_scheduler_anchor_handlers_spec_ts",
+      "target": "batch_scheduler_anchor_handlers_spec_createcontext",
       "confidence_score": 1.0
     },
     {

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts
@@ -176,6 +176,30 @@ describe('runAnchorAutoRefresh candidate scoring', () => {
     expect((result.details as { isolatedPicks: number } | undefined)?.isolatedPicks ?? 0).toBe(0);
   });
 
+  it('LIMIT 윈도우 밖에 있는 연결 후보도 고립 후보보다 우선 선택되어야 한다 (PR #721 리뷰)', async () => {
+    // Given: slot A(slotIndex 0, 이전 LIMIT=3)의 상위 importance를 모두 차지하는 고립 후보 4개
+    // + LIMIT 윈도우 밖(importance 낮음)에 있는 연결 후보 1개.
+    // 이전 구현은 SQL LIMIT으로 먼저 잘라낸 뒤 JS에서 연결-우선 정렬을 했기 때문에,
+    // 연결 후보가 애초에 조회되지 않아 고립 후보가 선택되는 버그가 있었다.
+    const isolated1 = createTestMemory(db, { id: 'mem_win_isolated_1', content: 'iso1', importance: 0.95 });
+    createTestMemory(db, { id: 'mem_win_isolated_2', content: 'iso2', importance: 0.94 });
+    createTestMemory(db, { id: 'mem_win_isolated_3', content: 'iso3', importance: 0.93 });
+    createTestMemory(db, { id: 'mem_win_isolated_4', content: 'iso4', importance: 0.92 });
+    const connected = createTestMemory(db, { id: 'mem_win_connected', content: 'connected', importance: 0.5 });
+    addEmbedding(db, connected);
+    seedStaleAnchor(db, agentId, isolated1);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then: slot A는 importance가 가장 낮아도 연결된 candidate를 선택해야 한다
+    expect(result.success).toBe(true);
+    const anchorA = (await anchorManager.getAnchor(agentId, 'A')) as { memory_id: string } | null;
+    expect(anchorA?.memory_id).toBe(connected);
+  });
+
   it('수동 set-anchor는 relation/embedding 여부와 무관하게 그대로 동작해야 한다(비파괴)', async () => {
     // Given: relation도 embedding도 없는 메모리
     const memoryId = createTestMemory(db, { content: 'manual anchor target', importance: 0.1 });

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * runAnchorAutoRefresh candidate scoring (GitHub #714).
+ *
+ * FIXED policy: penalize/exclude a candidate ONLY when BOTH
+ *  - relation degree == 0, AND
+ *  - embedding missing.
+ * A candidate with a relation must never be disadvantaged solely for
+ * missing an embedding (relation-first recovery, see #708/#709).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { runAnchorAutoRefresh } from '../batch-scheduler-anchor-handlers.js';
+import type { BatchSchedulerRunContext } from '../batch-scheduler-run-context.js';
+import { AnchorManager } from '../../../../domains/anchor/services/anchor/anchor-manager.js';
+import { AnchorCacheService } from '../../../../domains/anchor/services/anchor/anchor-cache-service.js';
+import { AnchorSearchService } from '../../../../domains/anchor/services/anchor/anchor-search-service.js';
+import { setupTestDatabase, createTestMemory, cleanupTestDatabase } from '../../../../test/helpers/test-database.js';
+
+function addRelation(db: Database.Database, sourceId: string, targetId: string): void {
+  db.prepare(
+    `INSERT INTO memory_relation (source_id, target_id, relation_type) VALUES (?, ?, 'related_to')`
+  ).run(sourceId, targetId);
+}
+
+function addEmbedding(db: Database.Database, memoryId: string): void {
+  db.prepare(
+    `INSERT INTO memory_embedding (memory_id, embedding_provider, embedding, dim)
+     VALUES (?, 'tfidf', '[0.1,0.2]', 2)`
+  ).run(memoryId);
+}
+
+/**
+ * runAnchorAutoRefresh only refreshes agents that already have at least one
+ * anchor row (it is a "refresh", not a bootstrap). Seed a stale slot A anchor
+ * so all three slots (A/B/C) become eligible for re-selection in tests.
+ */
+function seedStaleAnchor(db: Database.Database, agentId: string, memoryId: string): void {
+  db.prepare(
+    `INSERT INTO anchor (agent_id, slot, memory_id, updated_at) VALUES (?, 'A', ?, '2020-01-01 00:00:00')`
+  ).run(agentId, memoryId);
+}
+
+function createContext(db: Database.Database, anchorManager: AnchorManager): BatchSchedulerRunContext {
+  return {
+    db,
+    anchorManager,
+    log: vi.fn()
+  } as unknown as BatchSchedulerRunContext;
+}
+
+describe('runAnchorAutoRefresh candidate scoring', () => {
+  let db: Database.Database;
+  let anchorManager: AnchorManager;
+  const agentId = 'test-agent';
+
+  beforeEach(async () => {
+    db = await setupTestDatabase();
+    const cacheService = new AnchorCacheService();
+    cacheService.setDatabase(db);
+    const searchService = new AnchorSearchService(cacheService);
+    searchService.setDatabase(db);
+    anchorManager = new AnchorManager(cacheService, searchService);
+    anchorManager.setDatabase(db);
+  });
+
+  afterEach(() => {
+    cleanupTestDatabase(db);
+  });
+
+  it('관계도 임베딩도 없는 고립 후보는 대체 후보가 있으면 어떤 슬롯에도 선택되지 않아야 한다', async () => {
+    // Given: 슬롯(A/B/C) 수(3)보다 많은 4개의 후보 중 1개만 relation/embedding이 전혀 없음
+    const isolated = createTestMemory(db, { id: 'mem_isolated', content: 'isolated', importance: 0.9 });
+    const connectedA = createTestMemory(db, { id: 'mem_connected_a', content: 'connected a', importance: 0.9 });
+    const connectedB = createTestMemory(db, { id: 'mem_connected_b', content: 'connected b', importance: 0.9 });
+    const connectedC = createTestMemory(db, { id: 'mem_connected_c', content: 'connected c', importance: 0.9 });
+    addRelation(db, connectedA, connectedB);
+    addEmbedding(db, connectedC);
+    seedStaleAnchor(db, agentId, isolated);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then: 고립 후보(mem_isolated)는 대체 후보가 3개(슬롯 수만큼) 있으므로 선택되지 않음
+    expect(result.success).toBe(true);
+    const anchors = (await anchorManager.getAnchor(agentId)) as Array<{ slot: string; memory_id: string }> | null;
+    expect(anchors).not.toBeNull();
+    const pickedIds = (anchors ?? []).map(a => a.memory_id);
+    expect(pickedIds).not.toContain(isolated);
+    expect(pickedIds.sort()).toEqual([connectedA, connectedB, connectedC].sort());
+  });
+
+  it('relation degree > 0인 후보는 embedding이 없어도 불이익받지 않아야 한다', async () => {
+    // Given: relation만 있는 후보, embedding만 있는 후보, 그리고 별도 relation을 가진 후보 3개 + 고립 후보 1개
+    const relationOnly = createTestMemory(db, { id: 'mem_relation_only', content: 'relation only', importance: 0.9 });
+    const embeddingOnly = createTestMemory(db, { id: 'mem_embedding_only', content: 'embedding only', importance: 0.9 });
+    const extraConnected = createTestMemory(db, { id: 'mem_extra_connected', content: 'extra connected', importance: 0.9 });
+    const isolated = createTestMemory(db, { id: 'mem_isolated_2', content: 'isolated 2', importance: 0.95 });
+    addRelation(db, relationOnly, embeddingOnly);
+    addEmbedding(db, embeddingOnly);
+    addRelation(db, extraConnected, relationOnly);
+    seedStaleAnchor(db, agentId, isolated);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then: relation만 있고 embedding이 없는 후보도 embedding만 있는 후보와 동등하게 선택되고,
+    // relation/embedding이 모두 없는 고립 후보만 배제됨 (importance가 더 높아도)
+    expect(result.success).toBe(true);
+    const anchors = (await anchorManager.getAnchor(agentId)) as Array<{ slot: string; memory_id: string }> | null;
+    const pickedIds = (anchors ?? []).map(a => a.memory_id);
+
+    expect(pickedIds).toContain(relationOnly);
+    expect(pickedIds).toContain(embeddingOnly);
+    expect(pickedIds).toContain(extraConnected);
+    expect(pickedIds).not.toContain(isolated);
+  });
+
+  it('고립 후보만 존재하면(대체 후보가 없으면) 폴백으로 여전히 앵커를 채워야 한다', async () => {
+    // Given: 모든 후보가 relation/embedding 없음
+    const only1 = createTestMemory(db, { id: 'mem_only_1', content: 'only 1', importance: 0.9 });
+    createTestMemory(db, { id: 'mem_only_2', content: 'only 2', importance: 0.8 });
+    createTestMemory(db, { id: 'mem_only_3', content: 'only 3', importance: 0.7 });
+    seedStaleAnchor(db, agentId, only1);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then: 후보가 모두 고립이어도 앵커는 정상적으로 채워짐 (예외 없음)
+    expect(result.success).toBe(true);
+    const anchors = (await anchorManager.getAnchor(agentId)) as Array<{ slot: string; memory_id: string }> | null;
+    expect(anchors).not.toBeNull();
+    expect((anchors ?? []).length).toBeGreaterThan(0);
+  });
+
+  it('고립 후보가 어쩔 수 없이 선택된 경우 isolatedPicks 메트릭을 기록해야 한다', async () => {
+    // Given: 후보가 모두 고립되어 있어 고립 후보가 선택될 수밖에 없는 상황
+    const metric1 = createTestMemory(db, { id: 'mem_metric_1', content: 'metric 1', importance: 0.9 });
+    createTestMemory(db, { id: 'mem_metric_2', content: 'metric 2', importance: 0.8 });
+    createTestMemory(db, { id: 'mem_metric_3', content: 'metric 3', importance: 0.7 });
+    seedStaleAnchor(db, agentId, metric1);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then: details에 고립 후보 선택 횟수가 기록됨
+    expect(result.success).toBe(true);
+    expect(result.details).toBeDefined();
+    expect((result.details as { isolatedPicks: number }).isolatedPicks).toBeGreaterThan(0);
+  });
+
+  it('고립 후보를 회피할 수 있으면 isolatedPicks는 0이어야 한다', async () => {
+    // Given: 대체 후보가 충분해 고립 후보를 완전히 회피 가능한 상황
+    const okIsolated = createTestMemory(db, { id: 'mem_ok_isolated', content: 'isolated', importance: 0.9 });
+    const a = createTestMemory(db, { id: 'mem_ok_a', content: 'a', importance: 0.9 });
+    const b = createTestMemory(db, { id: 'mem_ok_b', content: 'b', importance: 0.9 });
+    const c = createTestMemory(db, { id: 'mem_ok_c', content: 'c', importance: 0.9 });
+    addRelation(db, a, b);
+    addEmbedding(db, c);
+    seedStaleAnchor(db, agentId, okIsolated);
+
+    const ctx = createContext(db, anchorManager);
+
+    // When
+    const result = await runAnchorAutoRefresh(ctx);
+
+    // Then
+    expect(result.success).toBe(true);
+    expect((result.details as { isolatedPicks: number } | undefined)?.isolatedPicks ?? 0).toBe(0);
+  });
+
+  it('수동 set-anchor는 relation/embedding 여부와 무관하게 그대로 동작해야 한다(비파괴)', async () => {
+    // Given: relation도 embedding도 없는 메모리
+    const memoryId = createTestMemory(db, { content: 'manual anchor target', importance: 0.1 });
+
+    // When: 수동으로 앵커 설정
+    await anchorManager.setAnchor(agentId, memoryId, 'A');
+
+    // Then: 자동 스코어링과 무관하게 그대로 설정됨
+    const anchor = await anchorManager.getAnchor(agentId, 'A');
+    expect((anchor as { memory_id: string }).memory_id).toBe(memoryId);
+  });
+});

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
@@ -28,14 +28,6 @@ function isIsolatedCandidate(candidate: MemoryCandidate): boolean {
 }
 
 /**
- * Reorders candidates so isolated ones sort last, without disturbing the
- * relative importance/recency order within each group (stable sort).
- */
-function prioritizeConnectedCandidates(candidates: MemoryCandidate[]): MemoryCandidate[] {
-  return [...candidates].sort((a, b) => Number(isIsolatedCandidate(a)) - Number(isIsolatedCandidate(b)));
-}
-
-/**
  * Periodically refreshes anchor slots with recent high-importance memories.
  *
  * Rationale: `autoReanchor` only discovers candidates via N-hop traversal from the
@@ -48,7 +40,12 @@ function prioritizeConnectedCandidates(candidates: MemoryCandidate[]): MemoryCan
  *
  * Candidate scoring (#714): candidates with neither a relation nor an embedding
  * ("isolated") are deprioritized behind every other candidate, so a slot is only
- * ever pinned to an isolated memory when no connected alternative exists.
+ * ever pinned to an isolated memory when no connected alternative exists. The
+ * isolation flag is the *first* SQL `ORDER BY` key (PR #721 review) so a
+ * connected candidate ranked outside the old LIMIT window by
+ * importance/created_at alone is still fetched ahead of higher-importance
+ * isolated candidates, instead of being cut off before a JS-side sort ever
+ * sees it.
  */
 export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promise<BatchJobResult> {
   const result = createEmptyBatchJobResult('anchor_auto_refresh');
@@ -107,13 +104,12 @@ export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promi
              FROM memory_item m
              WHERE (m.owner_id = ? OR m.owner_id IS NULL)
                AND m.deleted_at IS NULL
-             ORDER BY m.importance DESC, m.created_at DESC
+             ORDER BY (has_relation = 0 AND has_embedding = 0) ASC, m.importance DESC, m.created_at DESC
              LIMIT ?`
           )
           .all(agentId, slotIndex + 3) as MemoryCandidate[];
 
-        const prioritized = prioritizeConnectedCandidates(candidates);
-        const candidate = prioritized[slotIndex] ?? prioritized[prioritized.length - 1];
+        const candidate = candidates[slotIndex] ?? candidates[candidates.length - 1];
         if (!candidate) {
           continue;
         }

--- a/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
+++ b/packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts
@@ -13,6 +13,26 @@ interface AnchorRow {
 
 interface MemoryCandidate {
   id: string;
+  has_relation: number;
+  has_embedding: number;
+}
+
+/**
+ * A candidate is "isolated" only when it has neither a relation edge nor an
+ * embedding (GitHub #714). A candidate with a relation must never be
+ * disadvantaged solely for missing an embedding, since relation-based n-hop
+ * recovery (#708/#709) does not require one.
+ */
+function isIsolatedCandidate(candidate: MemoryCandidate): boolean {
+  return !candidate.has_relation && !candidate.has_embedding;
+}
+
+/**
+ * Reorders candidates so isolated ones sort last, without disturbing the
+ * relative importance/recency order within each group (stable sort).
+ */
+function prioritizeConnectedCandidates(candidates: MemoryCandidate[]): MemoryCandidate[] {
+  return [...candidates].sort((a, b) => Number(isIsolatedCandidate(a)) - Number(isIsolatedCandidate(b)));
 }
 
 /**
@@ -25,6 +45,10 @@ interface MemoryCandidate {
  *
  * Staleness threshold: 1 day.  Only slots whose `updated_at` is older than that
  * are touched, so anchors updated by normal recall flow are never overwritten.
+ *
+ * Candidate scoring (#714): candidates with neither a relation nor an embedding
+ * ("isolated") are deprioritized behind every other candidate, so a slot is only
+ * ever pinned to an isolated memory when no connected alternative exists.
  */
 export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promise<BatchJobResult> {
   const result = createEmptyBatchJobResult('anchor_auto_refresh');
@@ -52,6 +76,7 @@ export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promi
     }
 
     let totalMoved = 0;
+    let isolatedPicks = 0;
     const stalenessThresholdDays = 1;
     const now = Date.now();
 
@@ -75,17 +100,27 @@ export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promi
         const slotIndex = SLOTS.indexOf(slot as Slot);
         const candidates = db
           .prepare(
-            `SELECT id FROM memory_item
-             WHERE (owner_id = ? OR owner_id IS NULL)
-               AND deleted_at IS NULL
-             ORDER BY importance DESC, created_at DESC
+            `SELECT
+               m.id AS id,
+               EXISTS(SELECT 1 FROM memory_relation r WHERE r.source_id = m.id OR r.target_id = m.id) AS has_relation,
+               EXISTS(SELECT 1 FROM memory_embedding e WHERE e.memory_id = m.id) AS has_embedding
+             FROM memory_item m
+             WHERE (m.owner_id = ? OR m.owner_id IS NULL)
+               AND m.deleted_at IS NULL
+             ORDER BY m.importance DESC, m.created_at DESC
              LIMIT ?`
           )
           .all(agentId, slotIndex + 3) as MemoryCandidate[];
 
-        const candidate = candidates[slotIndex] ?? candidates[candidates.length - 1];
+        const prioritized = prioritizeConnectedCandidates(candidates);
+        const candidate = prioritized[slotIndex] ?? prioritized[prioritized.length - 1];
         if (!candidate) {
           continue;
+        }
+
+        if (isIsolatedCandidate(candidate)) {
+          isolatedPicks++;
+          ctx.log(`anchor_auto_refresh: isolated candidate selected for ${agentId}/${slot} → ${candidate.id} (no connected alternative)`, undefined, 'warn');
         }
 
         try {
@@ -102,7 +137,8 @@ export async function runAnchorAutoRefresh(ctx: BatchSchedulerRunContext): Promi
 
     result.success = result.errors.length === 0;
     result.processed = totalMoved;
-    ctx.log('anchor_auto_refresh completed', { moved: totalMoved, agents: agentIds.length });
+    result.details = { moved: totalMoved, isolatedPicks };
+    ctx.log('anchor_auto_refresh completed', { moved: totalMoved, agents: agentIds.length, isolatedPicks });
   } catch (error) {
     result.errors.push(error instanceof Error ? error.message : String(error));
     ctx.log('anchor_auto_refresh failed', error, 'error');


### PR DESCRIPTION
## Summary

Closes #714
Parent: #707 (note: epic-optional hardening)

- `runAnchorAutoRefresh`(anchor 자동 refresh 배치 잡)의 후보 선정 로직에 relation degree(1-hop 이상 여부)와 embedding 존재 여부를 반영했다.
- **감점/제외 조건은 정책대로 "relation degree == 0 AND embedding 부재"인 경우로 한정**했다. relation만 있고 embedding이 없는 후보는 embedding 부재만으로 불이익받지 않는다 (relation-first 복구, #708/#709와 정합).
- 대체 가능한 연결 후보가 있으면 고립 후보(관계·임베딩 모두 없음)는 어떤 슬롯에도 선택되지 않는다. 대체 후보가 전혀 없을 때만 폴백으로 고립 후보를 채우고, 이 경우 `result.details.isolatedPicks` 메트릭 + warn 로그로 기록한다.
- 수동 `AnchorManager.setAnchor`는 변경하지 않음 (비파괴 유지).

## Root cause

`runAnchorAutoRefresh`가 `memory_item`을 `importance DESC, created_at DESC` 로만 정렬해 slotIndex 위치의 후보를 그대로 슬롯에 꽂았기 때문에, C slot이 relation degree 0인 메모리로 고정될 수 있었다.

## Changes

- `packages/memento-core/src/infrastructure/scheduler/handlers/batch-scheduler-anchor-handlers.ts`
  - 후보 조회 SQL에 `has_relation`(`memory_relation` source/target EXISTS), `has_embedding`(`memory_embedding` EXISTS) 추가
  - `isIsolatedCandidate` / `prioritizeConnectedCandidates`(stable sort로 고립 후보만 뒤로) 추가
  - 고립 후보가 어쩔 수 없이 선택된 경우 `isolatedPicks` 카운트 + warn 로그, `result.details`에 포함
- `packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts` (신규)
  - 고립 후보 vs 연결 후보 우선순위 회귀 테스트
  - relation-only 후보가 embedding 부재만으로 불이익받지 않음을 검증
  - 대체 후보 없을 때 폴백 및 `isolatedPicks` 메트릭 검증
  - 수동 set-anchor 비파괴 회귀 테스트
- `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json` — graphify 재빌드

## Test plan

- [x] `npx vitest run packages/memento-core/src/infrastructure/scheduler/handlers/__tests__/batch-scheduler-anchor-handlers.spec.ts` — 6/6 통과
- [x] `npx vitest run packages/memento-core/src/infrastructure/scheduler packages/memento-core/src/domains/anchor` — 41 files / 363 tests 통과 (회귀 없음)
- [x] `npm run type-check` — 전체 워크스페이스 통과
- [x] `npx eslint` (변경 파일) — 통과

Made with [Cursor](https://cursor.com)