### PR TITLE
fix(ci): lint 실패 은폐 제거 및 빠른 테스트 lane 복원 (#734)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
-      - run: npm run lint -- --max-warnings 0 || echo "Linting completed with warnings"
+      - run: npm run lint
       - run: npx tsx scripts/count-console-logs.ts --core-only --ci
         continue-on-error: false
       - run: npx tsx scripts/archive/check-retry-usage.ts --ci
@@ -145,6 +145,50 @@ jobs:
           path: test-results/
           retention-days: 7
         continue-on-error: true
+
+  test-agent-integration:
+    needs: [ lint-typecheck ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run tests (@memento/agent-integration)
+        run: npm run test:ci -w @memento/agent-integration
+
+  test-assistant:
+    needs: [ lint-typecheck ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - name: Build @memento/client (required for assistant test resolution)
+        run: npm run build -w @memento/client
+      - name: Run tests (@memento/assistant)
+        run: npm run test:ci -w @memento/assistant
+
+  test-scripts:
+    needs: [ lint-typecheck ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run scripts unit tests
+        run: npm run test:ci:scripts
 
   test-search-quality:
     needs: [ lint-typecheck ]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:ci:root": "vitest --run --reporter=basic tests/",
     "test:ci:core": "vitest --run --reporter=basic packages/memento-core/src/",
     "test:ci:server": "vitest --run --reporter=basic packages/memento-server/src/",
+    "test:ci:scripts": "vitest --run --reporter=basic scripts/acquire-longmemeval.spec.ts scripts/agent-integration-release-gate.spec.ts scripts/agent-memory-benchmark-adapter.spec.ts scripts/agent-memory-benchmark.spec.ts scripts/agent-smoke-matrix.spec.ts scripts/compare-weight-profiles.spec.ts scripts/longmemeval-validation.spec.ts scripts/quality-benchmark-category-report.spec.ts scripts/quality-feedback-reappearance-report.spec.ts scripts/__tests__/check-magic-numbers.spec.ts scripts/__tests__/count-console-logs.spec.ts scripts/__tests__/legacy-script-removal.spec.ts scripts/__tests__/legacy-script-verification.spec.ts scripts/log-issue-monitor/__tests__/",
     "test:vector-search-quality": "vitest --run packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
     "test:vector-search-quality:ci": "vitest --run --reporter=junit --reporter=json --outputFile.junit=./test-results/vector-search-quality-junit.xml --outputFile.json=./test-results/vector-search-quality-results.json packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
     "lint": "npm run lint:ts && npm run lint:js",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:ci:root": "vitest --run --reporter=basic tests/",
     "test:ci:core": "vitest --run --reporter=basic packages/memento-core/src/",
     "test:ci:server": "vitest --run --reporter=basic packages/memento-server/src/",
-    "test:ci:scripts": "vitest --run --reporter=basic scripts/acquire-longmemeval.spec.ts scripts/agent-integration-release-gate.spec.ts scripts/agent-memory-benchmark-adapter.spec.ts scripts/agent-memory-benchmark.spec.ts scripts/agent-smoke-matrix.spec.ts scripts/compare-weight-profiles.spec.ts scripts/longmemeval-validation.spec.ts scripts/quality-benchmark-category-report.spec.ts scripts/quality-feedback-reappearance-report.spec.ts scripts/__tests__/check-magic-numbers.spec.ts scripts/__tests__/count-console-logs.spec.ts scripts/__tests__/legacy-script-removal.spec.ts scripts/__tests__/legacy-script-verification.spec.ts scripts/log-issue-monitor/__tests__/",
+    "test:ci:scripts": "vitest --run --reporter=basic scripts --exclude '**/*.integration.spec.ts'",
     "test:vector-search-quality": "vitest --run packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
     "test:vector-search-quality:ci": "vitest --run --reporter=junit --reporter=json --outputFile.junit=./test-results/vector-search-quality-junit.xml --outputFile.json=./test-results/vector-search-quality-results.json packages/memento-core/src/test/test-vector-search-quality-with-consolidation.spec.ts",
     "lint": "npm run lint:ts && npm run lint:js",

--- a/packages/memento-assistant/package.json
+++ b/packages/memento-assistant/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest --run --passWithNoTests",
-    "test:ci": "vitest --run --reporter=basic --passWithNoTests"
+    "test:ci": "vitest --run src --reporter=basic --passWithNoTests"
   },
   "keywords": [
     "memento",

--- a/packages/memento-assistant/package.json
+++ b/packages/memento-assistant/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -p tsconfig.build.json",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "test": "vitest --run --passWithNoTests",
-    "test:ci": "vitest --run src --reporter=basic --passWithNoTests"
+    "test:ci": "vitest --run src --reporter=basic"
   },
   "keywords": [
     "memento",

--- a/packages/memento-core/src/test/vitest.setup.ts
+++ b/packages/memento-core/src/test/vitest.setup.ts
@@ -5,9 +5,6 @@
  */
 
 import { vi } from 'vitest';
-import { PIIMasker } from '@memento/core/shared/utils/pii-masker.js';
-
-const isPrimaryVitestWorker = !process.env.VITEST_WORKER_ID || process.env.VITEST_WORKER_ID === '1';
 
 // @huggingface/transformers 모킹 (onnxruntime-node 로딩 방지)
 // 모든 테스트에서 일관되게 모킹되도록 전역 설정
@@ -57,15 +54,4 @@ vi.mock('sharp', () => ({
     toFile: vi.fn().mockResolvedValue({})
   }))
 }));
-
-// CI/CD 통합을 위한 품질 측정 테스트 훅 (PRD FR-5.9)
-// CI 환경에서만 로드하여 테스트 성능에 영향 없도록 함
-if (process.env.CI && isPrimaryVitestWorker) {
-  // 동적 import를 사용하여 CI 환경에서만 로드
-  // vitest는 TypeScript를 직접 실행하지만, ES modules에서는 .js 확장자 사용
-  import('./quality-measurement-hook.js').catch(error => {
-    const maskedError = error instanceof Error ? PIIMasker.maskError(error) : { message: String(error), name: 'Error' };
-    console.error('CI 품질 측정 훅 로드 실패:', maskedError.message);
-  });
-}
 

--- a/tests/security-check-workflow.spec.ts
+++ b/tests/security-check-workflow.spec.ts
@@ -39,4 +39,19 @@ describe("CI workflow", () => {
     expect(workflow).toContain("test-scripts:");
     expect(workflow).toContain("npm run test:ci:scripts");
   });
+
+  it("keeps scripts fast lane pattern-based and assistant CI truthful", () => {
+    const rootPkg = JSON.parse(
+      readFileSync(join(process.cwd(), "package.json"), "utf-8")
+    ) as { scripts: Record<string, string> };
+    const assistantPkg = JSON.parse(
+      readFileSync(join(process.cwd(), "packages/memento-assistant/package.json"), "utf-8")
+    ) as { scripts: Record<string, string> };
+
+    expect(rootPkg.scripts["test:ci:scripts"]).toContain("scripts");
+    expect(rootPkg.scripts["test:ci:scripts"]).toContain("*.integration.spec.ts");
+    expect(rootPkg.scripts["test:ci:scripts"]).not.toContain("acquire-longmemeval.spec.ts");
+    expect(assistantPkg.scripts["test:ci"]).toContain("vitest --run src");
+    expect(assistantPkg.scripts["test:ci"]).not.toContain("--passWithNoTests");
+  });
 });

--- a/tests/security-check-workflow.spec.ts
+++ b/tests/security-check-workflow.spec.ts
@@ -6,6 +6,10 @@ function readWorkflow(): string {
   return readFileSync(join(process.cwd(), ".github/workflows/security-check.yml"), "utf-8");
 }
 
+function readCiWorkflow(): string {
+  return readFileSync(join(process.cwd(), ".github/workflows/ci.yml"), "utf-8");
+}
+
 describe("security-check workflow", () => {
   it("runs lint without forwarding positional args into nested npm scripts", () => {
     const workflow = readWorkflow();
@@ -13,5 +17,26 @@ describe("security-check workflow", () => {
     expect(workflow).toContain("- name: ESLint Security Check");
     expect(workflow).toContain("run: npm run lint");
     expect(workflow).not.toContain("npm run lint -- --max-warnings 500");
+  });
+});
+
+describe("CI workflow", () => {
+  it("runs lint truthfully without masking failures or forwarding arguments", () => {
+    const workflow = readCiWorkflow();
+
+    expect(workflow).toContain("- run: npm run lint");
+    expect(workflow).not.toContain("|| echo");
+    expect(workflow).not.toContain("npm run lint -- --max-warnings 0");
+  });
+
+  it("runs the restored fast package and scripts test lanes", () => {
+    const workflow = readCiWorkflow();
+
+    expect(workflow).toContain("test-agent-integration:");
+    expect(workflow).toContain("npm run test:ci -w @memento/agent-integration");
+    expect(workflow).toContain("test-assistant:");
+    expect(workflow).toContain("npm run test:ci -w @memento/assistant");
+    expect(workflow).toContain("test-scripts:");
+    expect(workflow).toContain("npm run test:ci:scripts");
   });
 });


### PR DESCRIPTION
## Summary
- CI lint 단계에서 `|| echo ...` 은폐와 잘못된 `--max-warnings` 전달을 제거해 lint 실패가 job을 실패시키도록 복구합니다.
- 존재하지 않는 `quality-measurement-hook` 동적 import(fail-open)를 core vitest setup에서 제거합니다.
- PR CI에 agent-integration·assistant·scripts 비통합 단위 테스트 빠른 lane을 추가합니다.

Closes #734  
Parent: #733  
Related: #731

## Test plan
- [x] `npm run lint` exit 0 (warnings only)
- [x] `npm test -- tests/security-check-workflow.spec.ts`
- [x] agent-integration / assistant / scripts unit lanes (로컬)
- [ ] CI green on PR

## Note
`test:quality-assurance`는 비용·제외 정책이 불명확해 이번 PR에 넣지 않았습니다. category-report 게이트는 #731에서 다룹니다.


Made with [Cursor](https://cursor.com)